### PR TITLE
(SIMP-46) Ensure that snapshot_release works

### DIFF
--- a/rakefiles/pkg.rake
+++ b/rakefiles/pkg.rake
@@ -208,7 +208,6 @@ namespace :pkg do
       * :snapshot_release - Will add a define to the Mock to set snapshot_release to current date and time.
   EOM
   task :simp,[:chroot,:snapshot_release] => [:prep,:mock_prep] do |t,args|
-    args.with_defaults(:snapshot_release => 'true')
     build(args.chroot,@build_dirs[:simp],t,false,args.snapshot_release)
   end
 


### PR DESCRIPTION
The previous code had the default set to 'true' which caused the
Rakefiles to be unable to actually make a build *without* the
snapshot_release in place.

SIMP-46 #resolved

Change-Id: I449e7eee43346d57275d7287217ef3f424b4eddf