### PR TITLE
(SIMP-3) Ensure GPG keys are proper

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -58,7 +58,7 @@ CLEAN.include(
 
 CLOBBER.include(
   DIST_DIR,
-  "#{BUILD_DIR}/gpgkeys/dev"
+  "#{BUILD_DIR}/build_keys/dev"
 )
 
 # This just abstracts the clean/clobber space in such a way that clobber can actally be used!

--- a/build/GPGKEYS/Rakefile
+++ b/build/GPGKEYS/Rakefile
@@ -2,18 +2,21 @@
 
 require 'simp/rake'
 
-Simp::Rake::Pkg.new( File.dirname( __FILE__ ) )
+Simp::Rake::Pkg.new(File.dirname( __FILE__ ) )
 
-# Clean up the dropped keys from this build...
-Dir.chdir(File.dirname(__FILE__)) do
+Rake::Task['pkg:tar'].enhance do
+  # Clean up the dropped keys from this build...
+  Dir.chdir(File.dirname(__FILE__)) do
 
-  if File.exist?('.dropped_keys')
-    dropped_keys = File.read('.dropped_keys')
+    if File.exist?('.dropped_keys')
+      dropped_keys = File.read('.dropped_keys')
 
-    dropped_keys.each_line do |dk|
-      rm(dk) if File.exist?(dk)
+      dropped_keys.each_line do |dk|
+        dk.strip!
+        rm(dk) if File.exist?(dk)
+      end
+
+      rm('.dropped_keys')
     end
-
-    rm('.dropped_keys')
   end
 end


### PR DESCRIPTION
This update ensures that the GPG keys are properly incorporated into the
simp-gpgkeys RPM prior to submission.

In addition, any keys that are dropped into the GPGKEYS directory are
cleaned out after packaging the RPM.

Finally, a small fix was made to the main Rakefile to ensure that any
development keys were destroyed on running `rake clobber`.

SIMP-3 #close