### PR TITLE
(SIMP-131) Fix bundler bug w/missing submodules

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,21 +9,24 @@
 # ruby=2.1
 
 
-# watch the name, or RVM will flip out
-is_ruby_old = false
-if Gem::Version.new( RUBY_VERSION ) < Gem::Version.new( '1.9' )
-  warn( "WARNING: ruby #{RUBY_VERSION} detected!" +
-        " Any ruby version below 1.9 will have issues." )
-  is_ruby_old = true
-end
-
-source 'https://rubygems.org'
-
 # Allow a comma or space-delimited list of gem servers
 if simp_gem_server =  ENV.fetch( 'SIMP_GEM_SERVERS', false )
   simp_gem_server.split( / |,/ ).each{ |gem_server|
     source gem_server
   }
+else
+  # watch the name, or RVM will flip out
+  source 'https://rubygems.org'
+end
+
+
+# In offline CI environments, the only copy of simp-rake-helpers will be in the
+# local source tree.  Unless the SIMP_NO_LOCAL_RAKE_HELPERS environment variable
+# is set, that path will be loaded if persent
+simp_rake_helpers_opts = {}
+path                   = './src/rubygems/simp-rake-helpers'
+if File.directory?( path ) && ENV.fetch( 'SIMP_NO_LOCAL_RAKE_HELPERS', false )
+  simp_rake_helpers_opts = { :path => path }
 end
 
 
@@ -34,7 +37,7 @@ gem 'coderay'
 gem 'puppet'
 gem 'puppet-lint'
 gem 'puppetlabs_spec_helper'
-gem 'simp-rake-helpers', :path => './src/rubygems/simp-rake-helpers'
+gem 'simp-rake-helpers', simp_rake_helpers_opts
 gem 'parallel'
 gem 'dotenv'
 gem 'ruby-progressbar'
@@ -43,11 +46,6 @@ gem 'ruby-progressbar'
 group :debug do
   gem 'pry'
   gem 'pry-doc'
-  if is_ruby_old #ruby_version_below_1_9
-    warn( "WARNING: skipping pry-debugger because ruby #{RUBY_VERSION}!" )
-  else
-    #gem 'pry-debugger'
-  end
 end
 
 #vim: set syntax=ruby:


### PR DESCRIPTION
Before this fix, running "bundle" after a fresh checkout would fail due
to a hardcoded local :path for simp-rake-helpers in the Gemfile.

This update fixes that bug by testing for the submodule path and
introduces the environment variable SIMP_NO_LOCAL_RAKE_HELPERS to never
use the local path.

As a convenience to offline CI environments, this patch also enables the
SIMP_GEM_SERVERS to skip 'https://rubygems.org'.

SIMP-131 #close