### PR TITLE
(SIMP-231) Rake updates to deal with yumdownloader

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -51,7 +51,7 @@
 	url = git://github.com/simp/pupmod-simp-logrotate
 [submodule "src/puppet/modules/logstash"]
 	path = src/puppet/modules/logstash
-	url = git://github.com/simp/pupmod-simp-logstash
+	url = git://github.com/simp/puppet-logstash
 [submodule "src/puppet/modules/mcafee"]
 	path = src/puppet/modules/mcafee
 	url = git://github.com/simp/pupmod-simp-mcafee

--- a/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/packages.yaml
+++ b/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/packages.yaml
@@ -1,0 +1,227 @@
+---
+activemq-5.9.1-2.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/activemq-5.9.1-2.el7.noarch.rpm
+activemq-info-provider-5.9.1-2.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/activemq-info-provider-5.9.1-2.el7.noarch.rpm
+cfacter-0.3.0-1.el7.x86_64:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/cfacter-0.3.0-1.el7.x86_64.rpm
+chkrootkit-0.50-4el7.x86_64:
+  :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/7/ext/x86_64/chkrootkit-0.50-4el7.x86_64.rpm
+clamav-0.98.7-1.el7.x86_64:
+  :source: http://lug.mtu.edu/epel/7/x86_64/c/clamav-0.98.7-1.el7.x86_64.rpm
+elasticsearch-1.3.2.noarch:
+  :source: https://download.elasticsearch.org/elasticsearch/elasticsearch/packages/centos/elasticsearch-1.3.2.noarch.rpm
+elasticsearch-curator-1.1.1-0el7.noarch:
+  :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/7/ext/x86_64/elasticsearch-curator-1.1.1-0el7.noarch.rpm
+es2unix-1.6.1-0el7.noarch:
+  :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/7/ext/x86_64/es2unix-1.6.1-0el7.noarch.rpm
+etcd-2.0.11-0.SIMP.x86_64:
+  :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/7/ext/x86_64/etcd-2.0.11-0.SIMP.x86_64.rpm
+facter-2.4.1-1.el7.x86_64:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/facter-2.4.1-1.el7.x86_64.rpm
+facter-2.4.4-1.el7.x86_64:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/facter-2.4.4-1.el7.x86_64.rpm
+gweb-2.1.8-1.noarch:
+  :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/7/ext/x86_64/gweb-2.1.8-1.noarch.rpm
+incron-0.5.10-8.el7.x86_64:
+  :source: http://lug.mtu.edu/epel/7/x86_64/i/incron-0.5.10-8.el7.x86_64.rpm
+kibana-3.1.0.SIMP-0.noarch:
+  :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/7/ext/x86_64/kibana-3.1.0.SIMP-0.noarch.rpm
+libconfuse-2.7-7.el7.x86_64:
+  :source: http://lug.mtu.edu/epel/7/x86_64/l/libconfuse-2.7-7.el7.x86_64.rpm
+libev-4.15-3.el7.x86_64:
+  :source: http://lug.mtu.edu/epel/7/x86_64/l/libev-4.15-3.el7.x86_64.rpm
+libselinux-2.2.2-6.el7.x86_64:
+  :source: http://mirror.metrocast.net/centos/7.1.1503/os/x86_64/Packages/libselinux-2.2.2-6.el7.x86_64.rpm
+libselinux-python-2.2.2-6.el7.x86_64:
+  :source: http://mirror.metrocast.net/centos/7.1.1503/os/x86_64/Packages/libselinux-python-2.2.2-6.el7.x86_64.rpm
+libselinux-ruby-2.2.2-6.el7.x86_64:
+  :source: http://mirror.metrocast.net/centos/7.1.1503/os/x86_64/Packages/libselinux-ruby-2.2.2-6.el7.x86_64.rpm
+libselinux-static-2.2.2-6.el7.x86_64:
+  :source: http://mirror.metrocast.net/centos/7.1.1503/os/x86_64/Packages/libselinux-static-2.2.2-6.el7.x86_64.rpm
+libselinux-utils-2.2.2-6.el7.x86_64:
+  :source: http://mirror.metrocast.net/centos/7.1.1503/os/x86_64/Packages/libselinux-utils-2.2.2-6.el7.x86_64.rpm
+libsepol-2.1.9-3.el7.x86_64:
+  :source: http://mirror.metrocast.net/centos/7.1.1503/os/x86_64/Packages/libsepol-2.1.9-3.el7.x86_64.rpm
+libsepol-static-2.1.9-3.el7.x86_64:
+  :source: http://mirror.metrocast.net/centos/7.1.1503/os/x86_64/Packages/libsepol-static-2.1.9-3.el7.x86_64.rpm
+logstash-1.4.2-1_2c0f5a1.noarch:
+  :source: https://download.elasticsearch.org/logstash/logstash/packages/centos/logstash-1.4.2-1_2c0f5a1.noarch.rpm
+logstash-contrib-1.4.2-1_efd53ef.noarch:
+  :source: https://download.elastic.co/logstash/logstash/packages/centos/logstash-contrib-1.4.2-1_efd53ef.noarch.rpm
+mcollective-2.7.0-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-2.7.0-1.el7.noarch.rpm
+mcollective-2.8.2-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-2.8.2-1.el7.noarch.rpm
+mcollective-actionpolicy-auth-2.1.0-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-actionpolicy-auth-2.1.0-1.el7.noarch.rpm
+mcollective-client-2.7.0-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-client-2.7.0-1.el7.noarch.rpm
+mcollective-client-2.8.2-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-client-2.8.2-1.el7.noarch.rpm
+mcollective-common-2.7.0-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-common-2.7.0-1.el7.noarch.rpm
+mcollective-common-2.8.2-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-common-2.8.2-1.el7.noarch.rpm
+mcollective-filemgr-agent-1.0.2-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-filemgr-agent-1.0.2-1.el7.noarch.rpm
+mcollective-filemgr-agent-1.1.0-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-filemgr-agent-1.1.0-1.el7.noarch.rpm
+mcollective-filemgr-client-1.0.2-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-filemgr-client-1.0.2-1.el7.noarch.rpm
+mcollective-filemgr-client-1.1.0-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-filemgr-client-1.1.0-1.el7.noarch.rpm
+mcollective-filemgr-common-1.0.2-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-filemgr-common-1.0.2-1.el7.noarch.rpm
+mcollective-filemgr-common-1.1.0-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-filemgr-common-1.1.0-1.el7.noarch.rpm
+mcollective-iptables-agent-3.0.2-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-iptables-agent-3.0.2-1.el7.noarch.rpm
+mcollective-iptables-client-3.0.2-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-iptables-client-3.0.2-1.el7.noarch.rpm
+mcollective-iptables-common-3.0.2-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-iptables-common-3.0.2-1.el7.noarch.rpm
+mcollective-nettest-agent-3.0.4-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-nettest-agent-3.0.4-1.el7.noarch.rpm
+mcollective-nettest-client-3.0.4-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-nettest-client-3.0.4-1.el7.noarch.rpm
+mcollective-nettest-common-3.0.4-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-nettest-common-3.0.4-1.el7.noarch.rpm
+mcollective-nrpe-agent-3.0.3-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-nrpe-agent-3.0.3-1.el7.noarch.rpm
+mcollective-nrpe-agent-3.1.0-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-nrpe-agent-3.1.0-1.el7.noarch.rpm
+mcollective-nrpe-client-3.0.3-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-nrpe-client-3.0.3-1.el7.noarch.rpm
+mcollective-nrpe-client-3.1.0-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-nrpe-client-3.1.0-1.el7.noarch.rpm
+mcollective-nrpe-common-3.0.3-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-nrpe-common-3.0.3-1.el7.noarch.rpm
+mcollective-nrpe-common-3.1.0-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-nrpe-common-3.1.0-1.el7.noarch.rpm
+mcollective-package-agent-4.3.1-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-package-agent-4.3.1-1.el7.noarch.rpm
+mcollective-package-agent-4.4.0-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-package-agent-4.4.0-1.el7.noarch.rpm
+mcollective-package-client-4.3.1-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-package-client-4.3.1-1.el7.noarch.rpm
+mcollective-package-client-4.4.0-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-package-client-4.4.0-1.el7.noarch.rpm
+mcollective-package-common-4.3.1-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-package-common-4.3.1-1.el7.noarch.rpm
+mcollective-package-common-4.4.0-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-package-common-4.4.0-1.el7.noarch.rpm
+mcollective-puppet-agent-1.10.0-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-puppet-agent-1.10.0-1.el7.noarch.rpm
+mcollective-puppet-agent-1.9.3-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-puppet-agent-1.9.3-1.el7.noarch.rpm
+mcollective-puppet-client-1.10.0-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-puppet-client-1.10.0-1.el7.noarch.rpm
+mcollective-puppet-client-1.9.3-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-puppet-client-1.9.3-1.el7.noarch.rpm
+mcollective-puppet-common-1.10.0-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-puppet-common-1.10.0-1.el7.noarch.rpm
+mcollective-puppet-common-1.9.3-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-puppet-common-1.9.3-1.el7.noarch.rpm
+mcollective-service-agent-3.1.3-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-service-agent-3.1.3-1.el7.noarch.rpm
+mcollective-service-client-3.1.3-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-service-client-3.1.3-1.el7.noarch.rpm
+mcollective-service-common-3.1.3-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-service-common-3.1.3-1.el7.noarch.rpm
+mcollective-shell-agent-0.0.1-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-shell-agent-0.0.1-1.el7.noarch.rpm
+mcollective-shell-agent-0.0.2-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-shell-agent-0.0.2-1.el7.noarch.rpm
+mcollective-shell-client-0.0.1-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-shell-client-0.0.1-1.el7.noarch.rpm
+mcollective-shell-client-0.0.2-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-shell-client-0.0.2-1.el7.noarch.rpm
+mcollective-shell-common-0.0.1-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-shell-common-0.0.1-1.el7.noarch.rpm
+mcollective-shell-common-0.0.2-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-shell-common-0.0.2-1.el7.noarch.rpm
+mcollective-sshkey-security-0.5.0-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-sshkey-security-0.5.0-1.el7.noarch.rpm
+mcollective-sysctl-data-2.0.1-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/mcollective-sysctl-data-2.0.1-1.el7.noarch.rpm
+pdsh-2.29-1el7.x86_64:
+  :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/7/ext/x86_64/pdsh-2.29-1el7.x86_64.rpm
+pdsh-debuginfo-2.29-1el7.x86_64:
+  :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/7/ext/x86_64/pdsh-debuginfo-2.29-1el7.x86_64.rpm
+pdsh-mod-dshgroup-2.29-1el7.x86_64:
+  :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/7/ext/x86_64/pdsh-mod-dshgroup-2.29-1el7.x86_64.rpm
+pdsh-mod-machines-2.29-1el7.x86_64:
+  :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/7/ext/x86_64/pdsh-mod-machines-2.29-1el7.x86_64.rpm
+pdsh-mod-netgroup-2.29-1el7.x86_64:
+  :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/7/ext/x86_64/pdsh-mod-netgroup-2.29-1el7.x86_64.rpm
+pdsh-rcmd-exec-2.29-1el7.x86_64:
+  :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/7/ext/x86_64/pdsh-rcmd-exec-2.29-1el7.x86_64.rpm
+pdsh-rcmd-ssh-2.29-1el7.x86_64:
+  :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/7/ext/x86_64/pdsh-rcmd-ssh-2.29-1el7.x86_64.rpm
+pssh-2.3.1.SIMP-5.el7.noarch:
+  :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/7/ext/x86_64/pssh-2.3.1.SIMP-5.el7.noarch.rpm
+puppet-3.7.4-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppet-3.7.4-1.el7.noarch.rpm
+puppet-3.8.1-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppet-3.8.1-1.el7.noarch.rpm
+puppet-server-3.8.1-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppet-server-3.8.1-1.el7.noarch.rpm
+puppetdb-2.3.2-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppetdb-2.3.2-1.el7.noarch.rpm
+puppetdb-2.3.5-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppetdb-2.3.5-1.el7.noarch.rpm
+puppetdb-terminus-2.3.2-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppetdb-terminus-2.3.2-1.el7.noarch.rpm
+puppetdb-terminus-2.3.5-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppetdb-terminus-2.3.5-1.el7.noarch.rpm
+puppetlabs-release-7-11.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppetlabs-release-7-11.noarch.rpm
+puppetserver-1.0.2-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppetserver-1.0.2-1.el7.noarch.rpm
+puppetserver-1.1.1-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppetserver-1.1.1-1.el7.noarch.rpm
+python-elasticsearch-1.2.0-0.el7.centos.noarch:
+  :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/7/ext/x86_64/python-elasticsearch-1.2.0-0.el7.centos.noarch.rpm
+python-redis-2.10.3-1.el7.noarch:
+  :source: http://lug.mtu.edu/epel/7/x86_64/p/python-redis-2.10.3-1.el7.noarch.rpm
+python-simplejson-3.3.3-1.el7.x86_64:
+  :source: http://lug.mtu.edu/epel/7/x86_64/p/python-simplejson-3.3.3-1.el7.x86_64.rpm
+python-unittest2-0.5.1-6.el7.noarch:
+  :source: http://lug.mtu.edu/epel/7/x86_64/p/python-unittest2-0.5.1-6.el7.noarch.rpm
+razor-server-1.0.1-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/razor-server-1.0.1-1.el7.noarch.rpm
+razor-torquebox-3.1.1.9-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/razor-torquebox-3.1.1.9-1.el7.noarch.rpm
+rrdtool-1.4.8-8.el7.x86_64:
+  :source: http://mirror.metrocast.net/centos/7.1.1503/os/x86_64/Packages/rrdtool-1.4.8-8.el7.x86_64.rpm
+ruby-augeas-0.4.1-3.el7.x86_64:
+  :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/ruby-augeas-0.4.1-3.el7.x86_64.rpm
+ruby-rgen-0.6.5-2.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/ruby-rgen-0.6.5-2.el7.noarch.rpm
+ruby-shadow-2.2.0-2.el7.x86_64:
+  :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/ruby-shadow-2.2.0-2.el7.x86_64.rpm
+rubygem-deep_merge-1.0.0-2.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-deep_merge-1.0.0-2.el7.noarch.rpm
+rubygem-ffi-1.4.0-2.el7.x86_64:
+  :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-ffi-1.4.0-2.el7.x86_64.rpm
+rubygem-net-ping-1.6.2-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-net-ping-1.6.2-1.el7.noarch.rpm
+rubygem-puppet-lint-1.1.0-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-puppet-lint-1.1.0-1.el7.noarch.rpm
+rubygem-rake-compiler-0.9.3-1.el7.noarch:
+  :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-rake-compiler-0.9.3-1.el7.noarch.rpm
+rubygem-stomp-1.3.2-1.el7.noarch:
+  :source: http://lug.mtu.edu/epel/7/x86_64/r/rubygem-stomp-1.3.2-1.el7.noarch.rpm
+rubygem-stomp-doc-1.3.2-1.el7.noarch:
+  :source: http://lug.mtu.edu/epel/7/x86_64/r/rubygem-stomp-doc-1.3.2-1.el7.noarch.rpm
+scap-security-guide-0.1.19-2.el7.noarch:
+  :source: http://mirror.metrocast.net/centos/7.1.1503/os/x86_64/Packages/scap-security-guide-0.1.19-2.el7.noarch.rpm
+simp-hiera-1.3.3-1.el7.noarch:
+  :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/7/ext/x86_64/simp-hiera-1.3.3-1.el7.noarch.rpm
+simp-lastbind-2.4.23-0.x86_64:
+  :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/7/ext/x86_64/simp-lastbind-2.4.23-0.x86_64.rpm
+simp-ppolicy-check-password-2.4.39-0el7.x86_64:
+  :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/7/ext/x86_64/simp-ppolicy-check-password-2.4.39-0el7.x86_64.rpm
+sudosh2-1.0.2-2el7.x86_64:
+  :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/7/ext/x86_64/sudosh2-1.0.2-2el7.x86_64.rpm

--- a/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/repos/centos.repo
+++ b/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/repos/centos.repo
@@ -1,0 +1,11 @@
+[base]
+name=BaseOS
+enabled=1
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&country=US
+failovermethod=priority
+
+[updates]
+name=updates
+enabled=1
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=updates&country=US
+failovermethod=priority

--- a/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/repos/elasticsearch.repo
+++ b/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/repos/elasticsearch.repo
@@ -1,0 +1,13 @@
+[elasticsearch-1.3]
+name=Elasticsearch repository for 1.3.x packages
+baseurl=http://packages.elastic.co/elasticsearch/1.3/centos
+gpgcheck=1
+gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
+enabled=1
+
+[elasticsearch-1.6]
+name=Elasticsearch repository for 1.6.x packages
+baseurl=http://packages.elastic.co/elasticsearch/1.6/centos
+gpgcheck=1
+gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
+enabled=1

--- a/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/repos/epel.repo
+++ b/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/repos/epel.repo
@@ -1,0 +1,5 @@
+[epel]
+name=epel
+#mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=x86_64&country=US
+baseurl=http://lug.mtu.edu/epel/7/x86_64/
+failovermethod=priority

--- a/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/repos/puppet.repo
+++ b/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/repos/puppet.repo
@@ -1,0 +1,7 @@
+[puppet]
+name=puppet
+baseurl=http://yum.puppetlabs.com/el/7/products/x86_64/
+
+[puppet-dependencies]
+name=puppet-dependencies
+baseurl=http://yum.puppetlabs.com/el/7/dependencies/x86_64/

--- a/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/repos/simp.repo
+++ b/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/repos/simp.repo
@@ -1,0 +1,4 @@
+[simp-ext]
+name=simp-ext
+baseurl=https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/7/ext/x86_64
+enabled=1

--- a/rakefiles/build.rake
+++ b/rakefiles/build.rake
@@ -7,438 +7,470 @@ class SIMPBuildException < Exception
 end
 
 namespace :build do
-  @base_dir = File.join(BUILD_DIR,'yum_data')
-  @build_arch = 'x86_64'
+  namespace :yum do
+    @base_dir = File.join(BUILD_DIR,'yum_data')
+    @build_arch = 'x86_64'
 
-  ##############################################################################
-  # Helpers
-  ##############################################################################
+    ##############################################################################
+    # Helpers
+    ##############################################################################
 
-  # Return the target directory
-  # Expects one argument wich is the 'arguments' hash to one of the tasks.
-  def get_target_dir(args)
-    fail("Error: You must specify 'os'") unless args.os
-    fail("Error: You must specify 'os_version'") unless args.os_version
-    fail("Error: You must specify both major and minor version for the OS") unless args.os_version =~ /^.+\..+$/
-    fail("Error: You must specify 'simp_version'") unless args.simp_version
-    fail("Error: You must specify 'arch'") unless args.arch
+    # This is a complete hack to get around the fact that yumdownloader doesn't
+    # cache properly when setting TMPDIR.
+    def clean_yumdownloader_cache_dir
+      require 'etc'
 
-    # Yes, this is a kluge but the amount of variable passing that would need
-    # to be done to support this is silly.
-    @build_arch = args.arch
+      tmp_dir = '/tmp'
+      tmp_dir = ENV['TMPDIR'] if ENV['TMPDIR']
 
-    return File.join(
-      @base_dir,
-      "SIMP#{args.simp_version}_#{args.os}#{args.os_version}_#{args.arch}"
-    )
-  end
+      Dir.glob("#{tmp_dir}/yum-#{Etc.getlogin}-*").each do |cache_dir|
+        cache_dir = File.expand_path(cache_dir)
 
-  # Return where YUM finds the passed RPM
-  def get_rpm_source(rpm,yum_conf)
-    # Do we have what we need?
-
-    unless @have_yumdownloader
-      %x(yumdownloader --version > /dev/null 2>&1)
-
-      if $?.exitstatus == 127
-        fail("Error: Could not find 'yumdownloader'. Please install it and try again.")
-      end
-      @have_yumdownloader = true
-    end
-
-    puts("Looking up: #{rpm}")
-    source = %x(yumdownloader -c #{yum_conf} --urls #{rpm} 2>/dev/null ).split("\n")
-    source = source.grep(/(#{@build_arch}|noarch)\.rpm$/)
-
-    if source.size > 1
-      raise(SIMPBuildException,"More than one file found")
-    end
-
-    unless $?.success?
-      raise(SIMPBuildException,"Could not find a download source")
-    end
-
-    return source.first
-  end
-
-  # Snag an RPM via YUM.
-  # Returns where the tool got the file from.
-  #
-  # If passed a source, simply downloads the file into the packages directory
-  def download_rpm(rpm, yum_conf, source=nil, distro_dir=Dir.pwd)
-    # We're doing this so that we can be 100% sure that we're pulling the RPM
-    # from where the last command indicated. YUM can choose multiple sources
-    # and we definitely want the one that we actually state!
-    source = get_rpm_source(rpm,yum_conf) unless source
-
-    Dir.chdir('packages') do
-      full_pkg = source.split('/').last
-      unless File.exist?(full_pkg)
-        puts("Downloading: #{full_pkg}")
-        %x(curl -L --max-redirs 10 -s -O -k #{source})
-        unless $?.success?
-          raise(SIMPBuildException,"Could not download")
+        puts "Cleaning Yumdownloader Cache Dir '#{cache_dir}'"
+        begin
+          rm_rf(cache_dir)
+        rescue Exception => e
+          puts "Could not remove cache Dir: #{e}"
         end
       end
     end
 
-    return source
-  end
+    # Return the target directory
+    # Expects one argument wich is the 'arguments' hash to one of the tasks.
+    def get_target_dir(args)
+      fail("Error: You must specify 'os'") unless args.os
+      fail("Error: You must specify 'os_version'") unless args.os_version
+      fail("Error: You must specify both major and minor version for the OS") unless args.os_version =~ /^.+\..+$/
+      fail("Error: You must specify 'simp_version'") unless args.simp_version
+      fail("Error: You must specify 'arch'") unless args.arch
 
-  # Create the YUM config file
-  #  * yum_tmp => The directory in which to store the YUM DB and any other
-  #  temporary files.
-  #
-  #  Returns the location of the YUM Configuration
-  def generate_yum_conf(distro_dir=Dir.pwd)
-    yum_conf_template = <<-EOM.gsub(/^\s+/,'')
-    [main]
-    keepcache = 1
-    persistdir = <%= yum_cache %>
-    logfile = <%= yum_logfile %>
-    exactarch = 1
-    obsoletes = 0
-    gpgcheck = 1
-    plugins = 1
-    reposdir = <%= repo_dirs.join(' ') %>
-    assumeyes = 1
-    EOM
+      # Yes, this is a kluge but the amount of variable passing that would need
+      # to be done to support this is silly.
+      @build_arch = args.arch
 
-    yum_conf = nil
-    Dir.chdir(distro_dir) do
-      # Create the target directory
-      yum_tmp = File.join('packages','yum_tmp')
-      mkdir_p(yum_tmp) unless File.directory?(yum_tmp)
-
-      yum_cache = File.expand_path(File.join(yum_tmp,'yum_cache'))
-      mkdir_p(yum_cache) unless File.directory?(yum_cache)
-
-      yum_logfile = File.expand_path(File.join(yum_tmp,'yum.log'))
-
-      repo_dirs = []
-      # Add the global directory
-      repo_dirs << File.expand_path('../my_repos')
-      if File.directory?('my_repos')
-        # Add the local user repos if they exist
-        repo_dirs << File.expand_path('my_repos')
-      else
-        # Add the default Internet repos otherwise
-        repo_dirs << File.expand_path('repos')
-      end
-
-      # Create our YUM config file
-      yum_conf = File.join(yum_tmp,'yum.conf')
-      File.open(yum_conf,'w') do |fh|
-        fh.write(ERB.new(yum_conf_template,nil,'-').result(binding))
-      end
+      return File.join(
+        @base_dir,
+        "SIMP#{args.simp_version}_#{args.os}#{args.os_version}_#{args.arch}"
+      )
     end
 
-    return yum_conf
-  end
+    # Return where YUM finds the passed RPM
+    def get_rpm_source(rpm,yum_conf)
+      # Do we have what we need?
 
-  def get_known_packages(target_dir=Dir.pwd)
-    known_packages_hash = {}
+      unless @have_yumdownloader
+        %x(yumdownloader --version > /dev/null 2>&1)
 
-    Dir.chdir(target_dir) do
-      if File.exist?('packages.yaml')
-        known_packages_hash = YAML::load_file('packages.yaml')
+        if $?.exitstatus == 127
+          fail("Error: Could not find 'yumdownloader'. Please install it and try again.")
+        end
+        @have_yumdownloader = true
       end
+
+      puts("Looking up: #{rpm}")
+      source = %x(yumdownloader -c #{yum_conf} --urls #{rpm} 2>/dev/null ).split("\n")
+
+      source = source.grep(/(#{@build_arch}|noarch)\.rpm$/)
+
+      if source.size > 1
+        raise(SIMPBuildException,"More than one file found")
+      end
+
+      unless $?.success?
+        raise(SIMPBuildException,"Could not find a download source")
+      end
+
+      return source.first
     end
 
-    return known_packages_hash
-  end
+    # Snag an RPM via YUM.
+    # Returns where the tool got the file from.
+    #
+    # If passed a source, simply downloads the file into the packages directory
+    def download_rpm(rpm, yum_conf, source=nil, distro_dir=Dir.pwd)
+      # We're doing this so that we can be 100% sure that we're pulling the RPM
+      # from where the last command indicated. YUM can choose multiple sources
+      # and we definitely want the one that we actually state!
+      source = get_rpm_source(rpm,yum_conf) unless source
 
-  def get_downloaded_packages(target_dir=Dir.pwd)
-    downloaded_packages = []
+      Dir.chdir('packages') do
+        full_pkg = source.split('/').last
+        unless File.exist?(full_pkg)
+          puts("Downloading: #{full_pkg}")
+          %x(curl -L --max-redirs 10 -s -O -k #{source})
+          unless $?.success?
+            raise(SIMPBuildException,"Could not download")
+          end
+        end
+      end
 
-    Dir.chdir(target_dir) do
-      downloaded_packages = Dir.glob('packages/*.rpm').map{|x| File.basename(x,'.rpm')}
+      return source
     end
 
-    return downloaded_packages
-  end
-
-  # Update the packages.yaml and packages/ directories
-  #   * target_dir => The actual distribution directory where packages.yaml and
-  #                   packages/ reside.
-  def update_packages(target_dir,bootstrap=false)
-    # This really should never happen....
-    unless File.directory?(target_dir)
-      fail <<-EOM
-Error: Could not update packages.
-
-Target directory '#{target_dir}' does not exist!
+    # Create the YUM config file
+    #  * yum_tmp => The directory in which to store the YUM DB and any other
+    #  temporary files.
+    #
+    #  Returns the location of the YUM Configuration
+    def generate_yum_conf(distro_dir=Dir.pwd)
+      yum_conf_template = <<-EOM.gsub(/^\s+/,'')
+      [main]
+      keepcache = 1
+      persistdir = <%= yum_cache %>
+      logfile = <%= yum_logfile %>
+      exactarch = 1
+      obsoletes = 0
+      gpgcheck = 1
+      plugins = 1
+      reposdir = <%= repo_dirs.join(' ') %>
+      assumeyes = 1
       EOM
+
+      yum_conf = nil
+      Dir.chdir(distro_dir) do
+        # Create the target directory
+        yum_tmp = File.join('packages','yum_tmp')
+        mkdir_p(yum_tmp) unless File.directory?(yum_tmp)
+
+        yum_cache = File.expand_path(File.join(yum_tmp,'yum_cache'))
+        mkdir_p(yum_cache) unless File.directory?(yum_cache)
+
+        yum_logfile = File.expand_path(File.join(yum_tmp,'yum.log'))
+
+        repo_dirs = []
+        # Add the global directory
+        repo_dirs << File.expand_path('../my_repos')
+        if File.directory?('my_repos')
+          # Add the local user repos if they exist
+          repo_dirs << File.expand_path('my_repos')
+        else
+          # Add the default Internet repos otherwise
+          repo_dirs << File.expand_path('repos')
+        end
+
+        # Create our YUM config file
+        yum_conf = File.join(yum_tmp,'yum.conf')
+        File.open(yum_conf,'w') do |fh|
+          fh.write(ERB.new(yum_conf_template,nil,'-').result(binding))
+        end
+      end
+
+      return yum_conf
     end
 
-    Dir.chdir(target_dir) do
-      unless File.exist?('packages.yaml') || File.directory?('packages')
+    def get_known_packages(target_dir=Dir.pwd)
+      known_packages_hash = {}
+
+      Dir.chdir(target_dir) do
+        if File.exist?('packages.yaml')
+          known_packages_hash = YAML::load_file('packages.yaml')
+        end
+      end
+
+      return known_packages_hash
+    end
+
+    def get_downloaded_packages(target_dir=Dir.pwd)
+      downloaded_packages = []
+
+      Dir.chdir(target_dir) do
+        downloaded_packages = Dir.glob('packages/*.rpm').map{|x| File.basename(x,'.rpm')}
+      end
+
+      return downloaded_packages
+    end
+
+    # Update the packages.yaml and packages/ directories
+    #   * target_dir => The actual distribution directory where packages.yaml and
+    #                   packages/ reside.
+    def update_packages(target_dir,bootstrap=false)
+      # This really should never happen....
+      unless File.directory?(target_dir)
         fail <<-EOM
-Error: Either 'pacakges.yaml' or the 'packages/' directory need to exist under '#{target_dir}
+  Error: Could not update packages.
+
+  Target directory '#{target_dir}' does not exist!
         EOM
       end
 
-      yum_conf = generate_yum_conf
+      Dir.chdir(target_dir) do
+        unless File.exist?('packages.yaml') || File.directory?('packages')
+          fail <<-EOM
+  Error: Either 'pacakges.yaml' or the 'packages/' directory need to exist under '#{target_dir}
+          EOM
+        end
 
-      known_packages_hash = get_known_packages
+        yum_conf = generate_yum_conf
+
+        known_packages_hash = get_known_packages
+
+        known_packages = known_packages_hash.keys
+        downloaded_packages = get_downloaded_packages
+
+        if known_packages.empty? && downloaded_packages.empty?
+          fail <<-EOM
+  Error: Could not find anything to do!
+
+  In #{target_dir}:
+      No packages in either packages.yaml or the packages/ directory
+          EOM
+        end
+
+        failed_updates = {}
+
+        # Let's go ahead and grab everything that we know the source for first!
+        (known_packages - downloaded_packages).sort.each do |package|
+          begin
+            # Do we have a valid external source?
+            if known_packages_hash[package][:source] =~ /^[a-z]+:\/\//
+              download_rpm(package,yum_conf,known_packages_hash[package][:source])
+            else
+              # If you get here, then you'll need to have an internal mirror of the
+              # repositories in question. This covers things like private RPMs as
+              # well as Commercial RPMs from Red Hat.
+              download_rpm(package,yum_conf)
+            end
+          rescue SIMPBuildException => e
+            failed_updates[package] = e
+          end
+        end
+
+        # Now, let's update the known_packages data structure for anything that's
+        # new!
+        (downloaded_packages - known_packages).each do |package|
+          begin
+            known_packages_hash[package] = { :source => get_rpm_source(package,yum_conf) }
+          rescue SIMPBuildException => e
+            failed_updates[package] = e
+          end
+        end
+
+        # OK! In theory, we're done with all of this nonsense! Let's update the
+        # YAML file.
+        File.open('packages.yaml','w') do |fh|
+          # Just want a sorted hash without all the garbage
+          sorted_packages = {}
+          known_packages_hash.keys.sort.each do |k|
+            sorted_packages[k] = known_packages_hash[k]
+          end
+          fh.puts(sorted_packages.to_yaml)
+        end
+
+        # Now, let's tell the user what went wrong.
+        unless failed_updates.empty?
+          $stderr.puts("Warning: There were errors updating some files:")
+
+          failed_updates.keys.sort.each do |k|
+            $stderr.puts("  * #{k} => #{failed_updates[k]}")
+          end
+        end
+      end
+    end
+
+    ##############################################################################
+    # Main tasks
+    ##############################################################################
+
+    desc <<-EOM
+    Create a workspace for a new distribution.
+
+    Creates a YUM scaffold under
+    #{BUILD_DIR}/yum_data/SIMP{:simp_version}_{:os}{:os_version}_{:arch}.
+
+    * :os           - The Operating System that you wish to use.
+                      Supported OSs: #{TARGET_DISTS}.join(', ')
+    * :os_version   - The Major and Minor version of the OS. Ex: 6.6, 7.0, etc...
+    * :simp_version - The Full version of SIMP that you are going to support. Do
+                      not enter the revision number. Ex: 5.1.0, 4.2.0.
+                      Default: Auto
+
+    * :arch         - The architecture that you support. Default: x86_64
+    EOM
+    task :scaffold,[:os,:os_version,:simp_version,:arch] do |t,args|
+      # SIMP_VERSION is set in the main Rakefile
+      args.with_defaults(:simp_version => SIMP_VERSION.split('-').first)
+      args.with_defaults(:arch => @build_arch)
+
+      target_dir = get_target_dir(args)
+
+      unless File.exist?(target_dir)
+        mkdir_p(target_dir)
+        puts("Created #{target_dir}")
+      end
+
+      # Put together the rest of the scaffold directories
+      Dir.chdir(@base_dir) do
+        mkdir('my_repos') unless File.exist?('my_repos')
+      end
+
+      Dir.chdir(target_dir) do
+        mkdir('repos') unless File.exist?('repos')
+        mkdir('packages') unless File.exist?('packages')
+      end
+    end
+
+    desc <<-EOM
+    Download ALL THE PACKAGES.
+
+    Downloads everything as appropriate for the distribution at
+    #{BUILD_DIR}/yum_data/SIMP{:simp_version}_{:os}{:os_version}_{:arch}.
+
+    * :os           - The Operating System that you wish to use.
+                      Supported OSs: #{TARGET_DISTS}.join(', ')
+    * :os_version   - The Major and Minor version of the OS. Ex: 6.6, 7.0, etc...
+    * :simp_version - The Full version of SIMP that you are going to support. Do
+                      not enter the revision number. Ex: 5.1.0, 4.2.0.
+                      Default: Auto
+
+    * :arch         - The architecture that you support. Default: x86_64
+    EOM
+    task :sync,[:os,:os_version,:simp_version,:arch] => [:scaffold] do |t,args|
+      # SIMP_VERSION is set in the main Rakefile
+      args.with_defaults(:simp_version => SIMP_VERSION.split('-').first)
+      args.with_defaults(:arch => @build_arch)
+
+      target_dir = get_target_dir(args)
+
+      update_packages(target_dir)
+    end
+
+    desc <<-EOM
+    Display the difference between record and download.
+
+    Provides a list of the differences between what we have recorded in
+    'packages.yaml' and the downloads in the 'packages' directory.
+
+    * :os           - The Operating System that you wish to use.
+                      Supported OSs: #{TARGET_DISTS}.join(', ')
+    * :os_version   - The Major and Minor version of the OS. Ex: 6.6, 7.0, etc...
+    * :simp_version - The Full version of SIMP that you are going to support. Do
+                      not enter the revision number. Ex: 5.1.0, 4.2.0.
+                      Default: Auto
+
+    * :arch         - The architecture that you support. Default: x86_64
+    EOM
+    task :diff,[:os,:os_version,:simp_version,:arch] => [:scaffold] do |t,args|
+      args.with_defaults(:simp_version => SIMP_VERSION.split('-').first)
+      args.with_defaults(:arch => @build_arch)
+
+      differences_found = false
+
+      target_dir = get_target_dir(args)
+
+      known_packages_hash = get_known_packages(target_dir)
 
       known_packages = known_packages_hash.keys
-      downloaded_packages = get_downloaded_packages
+      downloaded_packages = get_downloaded_packages(target_dir)
 
-      if known_packages.empty? && downloaded_packages.empty?
-        fail <<-EOM
-Error: Could not find anything to do!
+      known_not_downloaded = (known_packages - downloaded_packages).sort
+      unless known_not_downloaded.empty?
+        differences_found = true
 
-In #{target_dir}:
-    No packages in either packages.yaml or the packages/ directory
-        EOM
+        puts("=== Packages Not Downloaded ===")
+        known_not_downloaded.each do |package|
+          puts "  - #{package}"
+        end
       end
 
-      failed_updates = {}
+      downloaded_not_known = (downloaded_packages - known_packages).sort
+      unless downloaded_not_known.empty?
+        differences_found = true
 
-      # Let's go ahead and grab everything that we know the source for first!
-      (known_packages - downloaded_packages).sort.each do |package|
-        begin
-          # Do we have a valid external source?
-          if known_packages_hash[package][:source] =~ /^[a-z]+:\/\//
-            download_rpm(package,yum_conf,known_packages_hash[package][:source])
-          else
-            # If you get here, then you'll need to have an internal mirror of the
-            # repositories in question. This covers things like private RPMs as
-            # well as Commercial RPMs from Red Hat.
-            download_rpm(package,yum_conf)
+        puts ("=== Pacakges Downloaded not Recorded ===")
+        downloaded_not_known.each do |package|
+          puts "  ~ #{package}"
+        end
+      end
+
+      if differences_found
+        exit 1
+      else
+        puts("=== No Differences Found ===")
+        exit 0
+      end
+    end
+
+    desc <<-EOM
+    Download an RPM for the given distribution.
+
+    Fetches the *latest* version of an RPM from the included sources and places
+    it in the downloads directory.
+
+    Any old versions are moved into an 'obsolete' directory.
+
+    This does *not* update the packages.yaml file.
+
+    Note: for convienience, you can specify the output of yum_diff as your input
+          package and it will try to pull down everything in the file.
+          * If you do this, it must be the *full path* to the file.
+
+    * :pkg          - The package that you wish to download.
+    * :os           - The Operating System that you wish to use.
+                      Supported OSs: #{TARGET_DISTS}.join(', ')
+    * :os_version   - The Major and Minor version of the OS. Ex: 6.6, 7.0, etc...
+    * :simp_version - The Full version of SIMP that you are going to support. Do
+                      not enter the revision number. Ex: 5.1.0, 4.2.0.
+                      Default: Auto
+
+    * :arch         - The architecture that you support. Default: x86_64
+    EOM
+    task :fetch,[:pkg,:os,:os_version,:simp_version,:arch] => [:scaffold] do |t,args|
+      args.with_defaults(:simp_version => SIMP_VERSION.split('-').first)
+      args.with_defaults(:arch => @build_arch)
+
+      fail("Error: You must specify 'pkg'") unless args.pkg
+
+      pkgs = []
+      # Handle the output of build:yum_diff
+      if File.readable?(args.pkg)
+        File.read(args.pkg).each_line do |line|
+          if line =~ /\s+~\s+(.*)/
+            pkgs << $1.split(/-\d+/).first
           end
-        rescue SIMPBuildException => e
-          failed_updates[package] = e
         end
+      else
+        # Handle the default case
+        pkgs = [args.pkg]
       end
 
-      # Now, let's update the known_packages data structure for anything that's
-      # new!
-      (downloaded_packages - known_packages).each do |package|
-        begin
-          known_packages_hash[package] = { :source => get_rpm_source(package,yum_conf) }
-        rescue SIMPBuildException => e
-          failed_updates[package] = e
-        end
-      end
+      Dir.chdir(get_target_dir(args)) do
+        pkgs.each do |pkg|
+          # Pull down the RPM
+          begin
+            new_pkg = download_rpm(pkg, generate_yum_conf).split('/').last
 
-      # OK! In theory, we're done with all of this nonsense! Let's update the
-      # YAML file.
-      File.open('packages.yaml','w') do |fh|
-        # Just want a sorted hash without all the garbage
-        sorted_packages = {}
-        known_packages_hash.keys.sort.each do |k|
-          sorted_packages[k] = known_packages_hash[k]
-        end
-        fh.puts(sorted_packages.to_yaml)
-      end
+            Dir.chdir('packages') do
+              new_pkg_info = Simp::RPM.new(new_pkg)
 
-      # Now, let's tell the user what went wrong.
-      unless failed_updates.empty?
-        $stderr.puts("Warning: There were errors updating some files:")
+              # Find any old packages and move them into the 'obsolete' directory.
+              Dir.glob("#{new_pkg_info.basename}*.rpm").each do |old_pkg|
+                old_pkg_info = Simp::RPM.new(old_pkg)
+                next unless new_pkg_info.basename == old_pkg_info.basename
 
-        failed_updates.each_pair do |k,v|
-          $stderr.puts("  * #{k} => #{v}")
-        end
-      end
-    end
-  end
+                %x(rpmdev-vercmp #{new_pkg_info.full_version} #{old_pkg_info.full_version})
+                if $?.exitstatus == 11
+                  mkdir('obsolete') unless File.directory?('obsolete')
 
-  ##############################################################################
-  # Main tasks
-  ##############################################################################
+                  puts("Retiring #{old_pkg}")
 
-  desc <<-EOM
-  Create a workspace for a new distribution.
-
-  Creates a YUM scaffold under
-  #{BUILD_DIR}/yum_data/SIMP{:simp_version}_{:os}{:os_version}_{:arch}.
-
-  * :os           - The Operating System that you wish to use.
-                    Supported OSs: #{TARGET_DISTS}.join(', ')
-  * :os_version   - The Major and Minor version of the OS. Ex: 6.6, 7.0, etc...
-  * :simp_version - The Full version of SIMP that you are going to support. Do
-                    not enter the revision number. Ex: 5.1.0, 4.2.0.
-                    Default: Auto
-
-  * :arch         - The architecture that you support. Default: x86_64
-  EOM
-  task :yum_scaffold,[:os,:os_version,:simp_version,:arch] do |t,args|
-    # SIMP_VERSION is set in the main Rakefile
-    args.with_defaults(:simp_version => SIMP_VERSION.split('-').first)
-    args.with_defaults(:arch => @build_arch)
-
-    target_dir = get_target_dir(args)
-
-    unless File.exist?(target_dir)
-      mkdir_p(target_dir)
-      puts("Created #{target_dir}")
-    end
-
-    # Put together the rest of the scaffold directories
-    Dir.chdir(@base_dir) do
-      mkdir('my_repos') unless File.exist?('my_repos')
-    end
-
-    Dir.chdir(target_dir) do
-      mkdir('repos') unless File.exist?('repos')
-      mkdir('packages') unless File.exist?('packages')
-    end
-  end
-
-  desc <<-EOM
-  Download ALL THE PACKAGES.
-
-  Downloads everything as appropriate for the distribution at
-  #{BUILD_DIR}/yum_data/SIMP{:simp_version}_{:os}{:os_version}_{:arch}.
-
-  * :os           - The Operating System that you wish to use.
-                    Supported OSs: #{TARGET_DISTS}.join(', ')
-  * :os_version   - The Major and Minor version of the OS. Ex: 6.6, 7.0, etc...
-  * :simp_version - The Full version of SIMP that you are going to support. Do
-                    not enter the revision number. Ex: 5.1.0, 4.2.0.
-                    Default: Auto
-
-  * :arch         - The architecture that you support. Default: x86_64
-  EOM
-  task :yum_sync,[:os,:os_version,:simp_version,:arch] => [:yum_scaffold] do |t,args|
-    # SIMP_VERSION is set in the main Rakefile
-    args.with_defaults(:simp_version => SIMP_VERSION.split('-').first)
-    args.with_defaults(:arch => @build_arch)
-
-    target_dir = get_target_dir(args)
-
-    update_packages(target_dir)
-  end
-
-  desc <<-EOM
-  Display the difference between record and download.
-
-  Provides a list of the differences between what we have recorded in
-  'packages.yaml' and the downloads in the 'packages' directory.
-
-  * :os           - The Operating System that you wish to use.
-                    Supported OSs: #{TARGET_DISTS}.join(', ')
-  * :os_version   - The Major and Minor version of the OS. Ex: 6.6, 7.0, etc...
-  * :simp_version - The Full version of SIMP that you are going to support. Do
-                    not enter the revision number. Ex: 5.1.0, 4.2.0.
-                    Default: Auto
-
-  * :arch         - The architecture that you support. Default: x86_64
-  EOM
-  task :yum_diff,[:os,:os_version,:simp_version,:arch] => [:yum_scaffold] do |t,args|
-    args.with_defaults(:simp_version => SIMP_VERSION.split('-').first)
-    args.with_defaults(:arch => @build_arch)
-
-    differences_found = false
-
-    target_dir = get_target_dir(args)
-
-    known_packages_hash = get_known_packages(target_dir)
-
-    known_packages = known_packages_hash.keys
-    downloaded_packages = get_downloaded_packages(target_dir)
-
-    known_not_downloaded = (known_packages - downloaded_packages).sort
-    unless known_not_downloaded.empty?
-      differences_found = true
-
-      puts("=== Packages Not Downloaded ===")
-      known_not_downloaded.each do |package|
-        puts "  - #{package}"
-      end
-    end
-
-    downloaded_not_known = (downloaded_packages - known_packages).sort
-    unless downloaded_not_known.empty?
-      differences_found = true
-
-      puts ("=== Pacakges Downloaded not Recorded ===")
-      downloaded_not_known.each do |package|
-        puts "  ~ #{package}"
-      end
-    end
-
-    if differences_found
-      exit 1
-    else
-      puts("=== No Differences Found ===")
-      exit 0
-    end
-  end
-
-  desc <<-EOM
-  Download an RPM for the given distribution.
-
-  Fetches the *latest* version of an RPM from the included sources and places
-  it in the downloads directory.
-
-  Any old versions are moved into an 'obsolete' directory.
-
-  This does *not* update the packages.yaml file.
-
-  Note: for convienience, you can specify the output of yum_diff as your input
-        package and it will try to pull down everything in the file.
-        * If you do this, it must be the *full path* to the file.
-
-  * :pkg          - The package that you wish to download.
-  * :os           - The Operating System that you wish to use.
-                    Supported OSs: #{TARGET_DISTS}.join(', ')
-  * :os_version   - The Major and Minor version of the OS. Ex: 6.6, 7.0, etc...
-  * :simp_version - The Full version of SIMP that you are going to support. Do
-                    not enter the revision number. Ex: 5.1.0, 4.2.0.
-                    Default: Auto
-
-  * :arch         - The architecture that you support. Default: x86_64
-  EOM
-  task :yum_fetch,[:pkg,:os,:os_version,:simp_version,:arch] => [:yum_scaffold] do |t,args|
-    args.with_defaults(:simp_version => SIMP_VERSION.split('-').first)
-    args.with_defaults(:arch => @build_arch)
-
-    fail("Error: You must specify 'pkg'") unless args.pkg
-
-    pkgs = []
-    # Handle the output of build:yum_diff
-    if File.readable?(args.pkg)
-      File.read(args.pkg).each_line do |line|
-        if line =~ /\s+~\s+(.*)/
-          pkgs << $1.split(/-\d+/).first
-        end
-      end
-    else
-      # Handle the default case
-      pkgs = [args.pkg]
-    end
-
-    Dir.chdir(get_target_dir(args)) do
-      pkgs.each do |pkg|
-        # Pull down the RPM
-        begin
-          new_pkg = download_rpm(pkg, generate_yum_conf).split('/').last
-
-          Dir.chdir('packages') do
-            new_pkg_info = Simp::RPM.new(new_pkg)
-
-            # Find any old packages and move them into the 'obsolete' directory.
-            Dir.glob("#{new_pkg_info.basename}*.rpm").each do |old_pkg|
-              old_pkg_info = Simp::RPM.new(old_pkg)
-              next unless new_pkg_info.basename == old_pkg_info.basename
-
-              %x(rpmdev-vercmp #{new_pkg_info.full_version} #{old_pkg_info.full_version})
-              if $?.exitstatus == 11
-                mkdir('obsolete') unless File.directory?('obsolete')
-
-                puts("Retiring #{old_pkg}")
-
-                mv(old_pkg,'obsolete')
+                  mv(old_pkg,'obsolete')
+                end
               end
             end
+          rescue SIMPBuildException => e
+            puts("Failed to download #{pkg} -> #{e}")
           end
-        rescue SIMPBuildException => e
-          puts("Failed to download #{pkg} -> #{e}")
         end
       end
+    end
+
+    desc <<-EOM
+    Clean the Yumdownloader cache.
+
+    Use this if you're having strange issues fetching packages.
+    EOM
+    task :clean_cache do
+        clean_yumdownloader_cache_dir
     end
   end
 end


### PR DESCRIPTION
Yumdownloader doesn't properly handle either configdir or cachedir. This
provides an update that works around this as well as some helper tasks.

However, it is possible that you may not be able to build both the RHEL7
and RHEL6 systems simultaneously due to this issue.

SIMP-231 #comment Yumdownloader Workarounds in Rake