### PR TITLE
(SIMP-244) Updates for RHEL6.6

### DIFF
--- a/build/yum_data/SIMP4.2.0_RHEL6.6_x86_64/packages.yaml
+++ b/build/yum_data/SIMP4.2.0_RHEL6.6_x86_64/packages.yaml
@@ -6,13 +6,13 @@ activemq-5.9.1-2.el6.noarch:
 activemq-info-provider-5.9.1-2.el6.noarch:
   :source: http://yum.puppetlabs.com/el/6/dependencies/x86_64/activemq-info-provider-5.9.1-2.el6.noarch.rpm
 bitmap-console-fonts-0.3-15.el6.noarch:
-  :source: http://mirrors.advancedhosters.com/centos/6.6/os/x86_64/Packages/bitmap-console-fonts-0.3-15.el6.noarch.rpm
+  :source: Red Hat Optional Repository
 bitmap-fangsongti-fonts-0.3-15.el6.noarch:
-  :source: http://mirrors.advancedhosters.com/centos/6.6/os/x86_64/Packages/bitmap-fangsongti-fonts-0.3-15.el6.noarch.rpm
+  :source: Red Hat Optional Repository
 bitmap-fonts-compat-0.3-15.el6.noarch:
-  :source: http://mirrors.advancedhosters.com/centos/6.6/os/x86_64/Packages/bitmap-fonts-compat-0.3-15.el6.noarch.rpm
+  :source: Red Hat Optional Repository
 bitmap-miscfixed-fonts-0.3-15.el6.noarch:
-  :source: http://mirrors.advancedhosters.com/centos/6.6/os/x86_64/Packages/bitmap-miscfixed-fonts-0.3-15.el6.noarch.rpm
+  :source: Red Hat Optional Repository
 chkrootkit-0.49-9.el6.x86_64:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/chkrootkit-0.49-9.el6.x86_64.rpm
 clamav-0.98.7-1.el6.x86_64:
@@ -32,17 +32,17 @@ clamsmtp-1.10-6.el6.x86_64:
 clamz-0.5-0.el6.x86_64:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/clamz-0.5-0.el6.x86_64.rpm
 dejavu-lgc-sans-fonts-2.30-2.el6.noarch:
-  :source: http://mirrors.advancedhosters.com/centos/6.6/os/x86_64/Packages/dejavu-lgc-sans-fonts-2.30-2.el6.noarch.rpm
+  :source: Red Hat Optional Repository
 dejavu-lgc-serif-fonts-2.30-2.el6.noarch:
-  :source: http://mirrors.advancedhosters.com/centos/6.6/os/x86_64/Packages/dejavu-lgc-serif-fonts-2.30-2.el6.noarch.rpm
+  :source: Red Hat Optional Repository
 dracut-004-356.el6_6.2.noarch:
-  :source: http://centos.mirror.constant.com/6.6/updates/x86_64/Packages/dracut-004-356.el6_6.2.noarch.rpm
+  :source: Red Hat Updates Repository
 dracut-fips-004-356.el6_6.2.noarch:
-  :source: http://centos.mirror.constant.com/6.6/updates/x86_64/Packages/dracut-fips-004-356.el6_6.2.noarch.rpm
+  :source: Red Hat Updates Repository
 dracut-kernel-004-356.el6_6.2.noarch:
-  :source: http://centos.mirror.constant.com/6.6/updates/x86_64/Packages/dracut-kernel-004-356.el6_6.2.noarch.rpm
+  :source: Red Hat Updates Repository
 elasticsearch-1.3.2.noarch:
-  :source: https://download.elasticsearch.org/elasticsearch/elasticsearch/packages/centos/elasticsearch-1.3.2.noarch.rpm
+  :source: https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.3.2.noarch.rpm
 elasticsearch-curator-1.1.1-0.el6.noarch:
   :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/6/ext/x86_64/elasticsearch-curator-1.1.1-0.el6.noarch.rpm
 es2unix-1.6.1-0.el6.noarch:
@@ -52,39 +52,39 @@ facter-2.4.1-1.el6.x86_64:
 fping-2.4b2-10.el6.x86_64:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/fping-2.4b2-10.el6.x86_64.rpm
 freeradius-ldap-2.1.12-6.el6.x86_64:
-  :source: http://linux.cc.lehigh.edu/centos/6.6/os/x86_64/Packages/freeradius-ldap-2.1.12-6.el6.x86_64.rpm
+  :source: Red Hat Optional Repository
 freeradius-utils-2.1.12-6.el6.x86_64:
-  :source: http://linux.cc.lehigh.edu/centos/6.6/os/x86_64/Packages/freeradius-utils-2.1.12-6.el6.x86_64.rpm
-ganglia-3.7.1-1.el6.x86_64:
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/ganglia-3.7.1-1.el6.x86_64.rpm
-ganglia-devel-3.7.1-1.el6.x86_64:
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/ganglia-devel-3.7.1-1.el6.x86_64.rpm
-ganglia-gmetad-3.7.1-1.el6.x86_64:
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/ganglia-gmetad-3.7.1-1.el6.x86_64.rpm
-ganglia-gmond-3.7.1-1.el6.x86_64:
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/ganglia-gmond-3.7.1-1.el6.x86_64.rpm
-ganglia-gmond-python-3.7.1-1.el6.x86_64:
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/ganglia-gmond-python-3.7.1-1.el6.x86_64.rpm
+  :source: Red Hat Optional Repository
+ganglia-3.7.1-2.el6.x86_64:
+  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/ganglia-3.7.1-2.el6.x86_64.rpm
+ganglia-devel-3.7.1-2.el6.x86_64:
+  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/ganglia-devel-3.7.1-2.el6.x86_64.rpm
+ganglia-gmetad-3.7.1-2.el6.x86_64:
+  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/ganglia-gmetad-3.7.1-2.el6.x86_64.rpm
+ganglia-gmond-3.7.1-2.el6.x86_64:
+  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/ganglia-gmond-3.7.1-2.el6.x86_64.rpm
+ganglia-gmond-python-3.7.1-2.el6.x86_64:
+  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/ganglia-gmond-python-3.7.1-2.el6.x86_64.rpm
 glibc-2.12-1.149.el6_6.9.i686:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/glibc-2.12-1.149.el6_6.9.i686.rpm
+  :source: Red Hat Updates Repository
 glibc-2.12-1.149.el6_6.9.x86_64:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/glibc-2.12-1.149.el6_6.9.x86_64.rpm
+  :source: Red Hat Updates Repository
 glibc-common-2.12-1.149.el6_6.9.x86_64:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/glibc-common-2.12-1.149.el6_6.9.x86_64.rpm
+  :source: Red Hat Updates Repository
 glibc-devel-2.12-1.149.el6_6.9.i686:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/glibc-devel-2.12-1.149.el6_6.9.i686.rpm
+  :source: Red Hat Updates Repository
 glibc-devel-2.12-1.149.el6_6.9.x86_64:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/glibc-devel-2.12-1.149.el6_6.9.x86_64.rpm
+  :source: Red Hat Updates Repository
 glibc-headers-2.12-1.149.el6_6.9.x86_64:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/glibc-headers-2.12-1.149.el6_6.9.x86_64.rpm
+  :source: Red Hat Updates Repository
 glibc-static-2.12-1.149.el6_6.9.x86_64:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/glibc-static-2.12-1.149.el6_6.9.x86_64.rpm
+  :source: Red Hat Optional Repository
 glibc-utils-2.12-1.149.el6_6.9.x86_64:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/glibc-utils-2.12-1.149.el6_6.9.x86_64.rpm
+  :source: Red Hat Updates Repository
 globus-callout-3.13-2.el6.x86_64:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-callout-3.13-2.el6.x86_64.rpm
-globus-common-15.29-1.el6.x86_64:
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-common-15.29-1.el6.x86_64.rpm
+globus-common-15.30-1.el6.x86_64:
+  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-common-15.30-1.el6.x86_64.rpm
 globus-gsi-callback-5.7-1.el6.x86_64:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-gsi-callback-5.7-1.el6.x86_64.rpm
 globus-gsi-cert-utils-9.10-2.el6.x86_64:
@@ -101,28 +101,28 @@ globus-gsi-sysconfig-6.8-2.el6.x86_64:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-gsi-sysconfig-6.8-2.el6.x86_64.rpm
 globus-gss-assist-10.13-2.el6.x86_64:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-gss-assist-10.13-2.el6.x86_64.rpm
-globus-gssapi-gsi-11.18-1.el6.x86_64:
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-gssapi-gsi-11.18-1.el6.x86_64.rpm
+globus-gssapi-gsi-11.19-1.el6.x86_64:
+  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-gssapi-gsi-11.19-1.el6.x86_64.rpm
 globus-openssl-module-4.6-2.el6.x86_64:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-openssl-module-4.6-2.el6.x86_64.rpm
 gpxe-bootimgs-0.9.7-6.12.el6.noarch:
-  :source: http://mirrors.advancedhosters.com/centos/6.6/os/x86_64/Packages/gpxe-bootimgs-0.9.7-6.12.el6.noarch.rpm
+  :source: Red Hat Optional Repository
 gpxe-roms-qemu-0.9.7-6.12.el6.noarch:
-  :source: http://mirrors.advancedhosters.com/centos/6.6/os/x86_64/Packages/gpxe-roms-qemu-0.9.7-6.12.el6.noarch.rpm
+  :source: Red Hat Updates Repository
 gweb-2.1.8-1.noarch:
   :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/6/ext/x86_64/gweb-2.1.8-1.noarch.rpm
 hmaccalc-0.9.12-2.el6.x86_64:
-  :source: http://mirrors.advancedhosters.com/centos/6.6/os/x86_64/Packages/hmaccalc-0.9.12-2.el6.x86_64.rpm
+  :source: Red Hat Updates Repository
 incron-0.5.9-1.el6.x86_64:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/incron-0.5.9-1.el6.x86_64.rpm
 java-1.7.0-openjdk-1.7.0.85-2.6.1.3.el6_6.x86_64:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/java-1.7.0-openjdk-1.7.0.85-2.6.1.3.el6_6.x86_64.rpm
+  :source: Red Hat Updates Repository
 java-1.7.0-openjdk-demo-1.7.0.85-2.6.1.3.el6_6.x86_64:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/java-1.7.0-openjdk-demo-1.7.0.85-2.6.1.3.el6_6.x86_64.rpm
+  :source: Red Hat Optional Repository
 java-1.7.0-openjdk-devel-1.7.0.85-2.6.1.3.el6_6.x86_64:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/java-1.7.0-openjdk-devel-1.7.0.85-2.6.1.3.el6_6.x86_64.rpm
+  :source: Red Hat Updates Repository
 java-1.7.0-openjdk-src-1.7.0.85-2.6.1.3.el6_6.x86_64:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/java-1.7.0-openjdk-src-1.7.0.85-2.6.1.3.el6_6.x86_64.rpm
+  :source: Red Hat Optional Repository
 kibana-3.1.0.SIMP-0.noarch:
   :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/6/ext/x86_64/kibana-3.1.0.SIMP-0.noarch.rpm
 lcgdm-libs-1.8.9-2.el6.x86_64:
@@ -133,6 +133,8 @@ lfc-libs-1.8.9-2.el6.x86_64:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/lfc-libs-1.8.9-2.el6.x86_64.rpm
 lfc-python-1.8.9-2.el6.x86_64:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/lfc-python-1.8.9-2.el6.x86_64.rpm
+libarchive-devel-2.8.3-4.el6_2.x86_64:
+  :source: Red Hat Optional Repository
 libconfuse-2.7-4.el6.x86_64:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/libconfuse-2.7-4.el6.x86_64.rpm
 libconfuse-devel-2.7-4.el6.x86_64:
@@ -140,7 +142,7 @@ libconfuse-devel-2.7-4.el6.x86_64:
 libev-4.03-3.el6.x86_64:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/libev-4.03-3.el6.x86_64.rpm
 libselinux-ruby-2.0.94-5.8.el6.x86_64:
-  :source: http://mirrors.advancedhosters.com/centos/6.6/os/x86_64/Packages/libselinux-ruby-2.0.94-5.8.el6.x86_64.rpm
+  :source: Red Hat Updates Repository
 libyaml-0.1.4-2.el6.x86_64:
   :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/6/ext/x86_64/libyaml-0.1.4-2.el6.x86_64.rpm
 libyaml-devel-0.1.4-2.el6.x86_64:
@@ -202,25 +204,25 @@ mrepo-0.8.7-2.el6.noarch:
 mysql-connector-python-1.1.6-1.el6.noarch:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/mysql-connector-python-1.1.6-1.el6.noarch.rpm
 nscd-2.12-1.149.el6_6.9.x86_64:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/nscd-2.12-1.149.el6_6.9.x86_64.rpm
+  :source: Red Hat Updates Repository
 nspr-4.10.8-1.el6_6.x86_64:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/nspr-4.10.8-1.el6_6.x86_64.rpm
+  :source: Red Hat Updates Repository
 nss-3.19.1-3.el6_6.x86_64:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/nss-3.19.1-3.el6_6.x86_64.rpm
+  :source: Red Hat Updates Repository
 nss-softokn-3.14.3-22.el6_6.x86_64:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/nss-softokn-3.14.3-22.el6_6.x86_64.rpm
+  :source: Red Hat Updates Repository
 nss-softokn-freebl-3.14.3-22.el6_6.x86_64:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/nss-softokn-freebl-3.14.3-22.el6_6.x86_64.rpm
+  :source: Red Hat Updates Repository
 nss-sysinit-3.19.1-3.el6_6.x86_64:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/nss-sysinit-3.19.1-3.el6_6.x86_64.rpm
+  :source: Red Hat Updates Repository
 nss-tools-3.19.1-3.el6_6.x86_64:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/nss-tools-3.19.1-3.el6_6.x86_64.rpm
+  :source: Red Hat Updates Repository
 nss-util-3.19.1-1.el6_6.x86_64:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/nss-util-3.19.1-1.el6_6.x86_64.rpm
-openssl-1.0.1e-30.el6.11.x86_64:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/openssl-1.0.1e-30.el6.11.x86_64.rpm
-openssl-devel-1.0.1e-30.el6.11.x86_64:
-  :source: http://mirror.es.its.nyu.edu/centos/6.6/updates/x86_64/Packages/openssl-devel-1.0.1e-30.el6.11.x86_64.rpm
+  :source: Red Hat Updates Repository
+openssl-1.0.1e-30.el6_6.11.x86_64:
+  :source: Red Hat Updates Repository
+openssl-devel-1.0.1e-30.el6_6.11.x86_64:
+  :source: Red Hat Updates Repository
 pdsh-2.28-0.x86_64:
   :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/6/ext/x86_64/pdsh-2.28-0.x86_64.rpm
 pdsh-mod-dshgroup-2.28-0.x86_64:
@@ -234,23 +236,19 @@ pdsh-rcmd-exec-2.28-0.x86_64:
 pdsh-rcmd-ssh-2.28-0.x86_64:
   :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/6/ext/x86_64/pdsh-rcmd-ssh-2.28-0.x86_64.rpm
 perl-Archive-Zip-1.30-2.el6.noarch:
-  :source: http://mirrors.advancedhosters.com/centos/6.6/os/x86_64/Packages/perl-Archive-Zip-1.30-2.el6.noarch.rpm
+  :source: Red Hat Optional Repository
 perl-Crypt-DES-2.05-9.el6.x86_64:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/perl-Crypt-DES-2.05-9.el6.x86_64.rpm
 perl-DateTime-Format-DateParse-0.04-1.1.el6.noarch:
-  :source: http://linux.cc.lehigh.edu/centos/6.6/os/x86_64/Packages/perl-DateTime-Format-DateParse-0.04-1.1.el6.noarch.rpm
-perl-DateTime-Format-DateParse-0.05-4.el6.noarch:
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/perl-DateTime-Format-DateParse-0.05-4.el6.noarch.rpm
+  :source: Red Hat Optional Repository
 perl-DateTime-Format-Mail-0.3001-6.el6.noarch:
-  :source: http://mirrors.advancedhosters.com/centos/6.6/os/x86_64/Packages/perl-DateTime-Format-Mail-0.3001-6.el6.noarch.rpm
+  :source: Red Hat Optional Repository
 perl-DateTime-Format-W3CDTF-0.04-8.el6.noarch:
-  :source: http://mirrors.advancedhosters.com/centos/6.6/os/x86_64/Packages/perl-DateTime-Format-W3CDTF-0.04-8.el6.noarch.rpm
+  :source: Red Hat Optional Repository
 perl-File-RsyncP-0.72-1.el6.x86_64:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/perl-File-RsyncP-0.72-1.el6.x86_64.rpm
 perl-Math-Calc-Units-1.07-6.el6.noarch:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/perl-Math-Calc-Units-1.07-6.el6.noarch.rpm
-perl-Nagios-Plugin-0.35-1.el6.noarch:
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/perl-Nagios-Plugin-0.35-1.el6.noarch.rpm
 perl-Net-FTP-AutoReconnect-0.3-3.el6.noarch:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/perl-Net-FTP-AutoReconnect-0.3-3.el6.noarch.rpm
 perl-Net-FTP-RetrHandle-0.2-3.el6.noarch:
@@ -260,9 +258,9 @@ perl-Net-SNMP-5.2.0-4.el6.noarch:
 perl-Sort-Versions-1.5-12.el6.noarch:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/perl-Sort-Versions-1.5-12.el6.noarch.rpm
 perl-Time-modules-2006.0814-5.el6.noarch:
-  :source: http://mirrors.advancedhosters.com/centos/6.6/os/x86_64/Packages/perl-Time-modules-2006.0814-5.el6.noarch.rpm
+  :source: Red Hat Optional Repository
 perl-XML-RSS-1.45-2.el6.noarch:
-  :source: http://mirrors.advancedhosters.com/centos/6.6/os/x86_64/Packages/perl-XML-RSS-1.45-2.el6.noarch.rpm
+  :source: Red Hat Optional Repository
 pssh-2.3.1-5.el6.noarch:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/pssh-2.3.1-5.el6.noarch.rpm
 puppet-3.7.4-1.el6.noarch:
@@ -361,6 +359,8 @@ rubygem-puppet-lint-1.1.0-1.el6.noarch:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/rubygem-puppet-lint-1.1.0-1.el6.noarch.rpm
 rubygem-rack-1.0.1-2.el6.noarch:
   :source: http://yum.puppetlabs.com/el/6/dependencies/x86_64/rubygem-rack-1.0.1-2.el6.noarch.rpm
+rubygem-rake-0.8.7-2.1.el6.noarch:
+  :source: Red Hat Optional Repository
 rubygem-rake-compiler-0.9.3-2.el6.noarch:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/rubygem-rake-compiler-0.9.3-2.el6.noarch.rpm
 rubygem-rake-compiler-doc-0.9.3-2.el6.noarch:
@@ -374,7 +374,9 @@ rubygem-stomp-1.3.2-1.el6.noarch:
 rubygem-stomp-doc-1.3.2-1.el6.noarch:
   :source: http://yum.puppetlabs.com/el/6/dependencies/x86_64/rubygem-stomp-doc-1.3.2-1.el6.noarch.rpm
 scap-security-guide-0.1.18-3.el6.noarch:
-  :source: http://mirrors.advancedhosters.com/centos/6.6/os/x86_64/Packages/scap-security-guide-0.1.18-3.el6.noarch.rpm
+  :source: Red Hat Updates Repository
+sendmail-milter-8.14.4-8.el6.x86_64:
+  :source: Red Hat Optional Repository
 simp-hiera-1.3.4-3.el6.noarch:
   :source: https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/6/ext/x86_64/simp-hiera-1.3.4-3.el6.noarch.rpm
 simp-lastbind-2.4.23-0.x86_64:
@@ -386,6 +388,6 @@ sudosh2-1.0.2-2.el6.x86_64:
 tanukiwrapper-3.5.9-1.el6.x86_64:
   :source: http://yum.puppetlabs.com/el/6/dependencies/x86_64/tanukiwrapper-3.5.9-1.el6.x86_64.rpm
 trousers-0.3.13-2.el6.x86_64:
-  :source: http://linux.cc.lehigh.edu/centos/6.6/os/x86_64/Packages/trousers-0.3.13-2.el6.x86_64.rpm
+  :source: Red Hat Updates Repository
 voms-2.0.12-3.el6.x86_64:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/voms-2.0.12-3.el6.x86_64.rpm

--- a/build/yum_data/SIMP4.2.0_RHEL6.6_x86_64/repos/elasticsearch.repo
+++ b/build/yum_data/SIMP4.2.0_RHEL6.6_x86_64/repos/elasticsearch.repo
@@ -1,0 +1,13 @@
+[elasticsearch-1.3]
+name=Elasticsearch repository for 1.3.x packages
+baseurl=http://packages.elastic.co/elasticsearch/1.3/centos
+gpgcheck=1
+gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
+enabled=1
+
+[elasticsearch-1.6]
+name=Elasticsearch repository for 1.6.x packages
+baseurl=http://packages.elastic.co/elasticsearch/1.6/centos
+gpgcheck=1
+gpgkey=http://packages.elastic.co/GPG-KEY-elasticsearch
+enabled=1

--- a/build/yum_data/SIMP4.2.0_RHEL6.6_x86_64/repos/epel.repo
+++ b/build/yum_data/SIMP4.2.0_RHEL6.6_x86_64/repos/epel.repo
@@ -1,0 +1,4 @@
+[epel]
+name=epel
+mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=x86_64&country=US
+failovermethod=priority

--- a/build/yum_data/SIMP4.2.0_RHEL6.6_x86_64/repos/puppet.repo
+++ b/build/yum_data/SIMP4.2.0_RHEL6.6_x86_64/repos/puppet.repo
@@ -1,0 +1,7 @@
+[puppet]
+name=puppet
+baseurl=http://yum.puppetlabs.com/el/6/products/x86_64/
+
+[puppet-dependencies]
+name=puppet-dependencies
+baseurl=http://yum.puppetlabs.com/el/6/dependencies/x86_64/

--- a/build/yum_data/SIMP4.2.0_RHEL6.6_x86_64/repos/scl.repo
+++ b/build/yum_data/SIMP4.2.0_RHEL6.6_x86_64/repos/scl.repo
@@ -1,0 +1,5 @@
+[scl-ruby193]
+name=scl-ruby193
+baseurl=https://www.softwarecollections.org/repos/rhscl/ruby193/epel-6-x86_64/
+enabled=1
+gpgcheck=0

--- a/build/yum_data/SIMP4.2.0_RHEL6.6_x86_64/repos/simp.repo
+++ b/build/yum_data/SIMP4.2.0_RHEL6.6_x86_64/repos/simp.repo
@@ -1,0 +1,3 @@
+[simp-ext]
+name=simp-ext
+baseurl=https://sourceforge.net/projects/sys-integrity-mgmt-platform/files/yum/el/6/ext/x86_64

--- a/src/DVD/6-simp_pkglist.txt
+++ b/src/DVD/6-simp_pkglist.txt
@@ -301,6 +301,7 @@ gpg-pubkey
 gpgme
 gpm
 gpm-libs
+gpxe-roms-qemu
 grep
 groff
 grub
@@ -994,6 +995,7 @@ samba-common
 samba-winbind
 samba-winbind-clients
 samba4-libs
+scap-security-guide
 screen
 sed
 selinux-policy
@@ -1065,6 +1067,8 @@ time
 tk
 tmpwatch
 tokyocabinet
+tpm-tools
+trousers
 ttmkfdir
 tuned
 tzdata


### PR DESCRIPTION
This adds the updates for RHEL6.6 complete with the source place holders
for downloads directly from the RHEL repositories.

The rakefiles were additionally updated to handle the download of
specific architecture RPMs for patching in critical security updates
when necessary.

SIMP-244 #comment RHEL6.6 complete