### PR TITLE
(SIMP-233) Add ruby-ldap to the RH7 stack

### DIFF
--- a/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/packages.yaml
+++ b/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/packages.yaml
@@ -229,6 +229,8 @@ rrdtool-1.4.8-8.el7.x86_64:
   :source: http://mirror.metrocast.net/centos/7.1.1503/os/x86_64/Packages/rrdtool-1.4.8-8.el7.x86_64.rpm
 ruby-augeas-0.4.1-3.el7.x86_64:
   :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/ruby-augeas-0.4.1-3.el7.x86_64.rpm
+ruby-ldap-0.9.16-1.el7.x86_64:
+  :source: http://lug.mtu.edu/epel/7/x86_64/r/ruby-ldap-0.9.16-1.el7.x86_64.rpm
 ruby-rgen-0.6.5-2.el7.noarch:
   :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/ruby-rgen-0.6.5-2.el7.noarch.rpm
 ruby-shadow-2.2.0-2.el7.x86_64:

--- a/build/yum_data/SIMP5.1.0_RHEL7.1_x86_64/packages.yaml
+++ b/build/yum_data/SIMP5.1.0_RHEL7.1_x86_64/packages.yaml
@@ -229,6 +229,8 @@ rrdtool-1.4.8-8.el7.x86_64:
   :source: Red Hat Updates Repository
 ruby-augeas-0.4.1-3.el7.x86_64:
   :source: http:/yum.puppetlabs.com/el/7/dependencies/x86_64/ruby-augeas-0.4.1-3.el7.x86_64.rpm
+ruby-ldap-0.9.16-1.el7.x86_64:
+  :source: http://lug.mtu.edu/epel/7/x86_64/r/ruby-ldap-0.9.16-1.el7.x86_64.rpm
 ruby-rgen-0.6.5-2.el7.noarch:
   :source: http:/yum.puppetlabs.com/el/7/dependencies/x86_64/ruby-rgen-0.6.5-2.el7.noarch.rpm
 ruby-shadow-2.2.0-2.el7.x86_64:


### PR DESCRIPTION
Required by the openldap module

SIMP-233 #comment missed ruby-ldap

Change-Id: I2946dedaca02a38247c9054dc06133d3271f641e