### PR TITLE
(SIMP-17) Remove openldap::pam from simp_classes

### DIFF
--- a/src/puppet/bootstrap/environments/simp/hieradata/hosts/puppet.your.domain.yaml
+++ b/src/puppet/bootstrap/environments/simp/hieradata/hosts/puppet.your.domain.yaml
@@ -26,6 +26,5 @@ puppetdb::master::puppet_service_name : 'puppetserver'
 classes :
   - 'simp::server'
   - 'simp::puppetdb'
-  - 'simp::ldap_server'
   - 'simp::yum_server'
   - 'simp::kickstart_server'

--- a/src/puppet/bootstrap/environments/simp/hieradata/simp_classes.yaml
+++ b/src/puppet/bootstrap/environments/simp/hieradata/simp_classes.yaml
@@ -43,7 +43,6 @@ classes:
   - 'common::sysctl'
   - 'common::timezone'
   - 'ntpd'
-  - 'openldap::pam'
   # Set up the access.conf basics, allow root locally and deny
   # everyone else from everywhere by default.
   - 'pam::access'


### PR DESCRIPTION
The inclusion of openldap::pam is moved to openldap/init.pp to ensure
that SIMP can be used without LDAP.

SIMP-17 #comment Removed openldap::pam from simp_bootstrap.yaml