### PR TITLE
(SIMP-264) Kernel images should be world readable.

### DIFF
--- a/src/DVD/ks/dvd/auto.cfg
+++ b/src/DVD/ks/dvd/auto.cfg
@@ -121,6 +121,9 @@ if [ -d "${src_dir}" ]; then
       ln -s "${rsync_target}" "${rsync_link}"
       cp -a "${src_dir}/vmlinuz" "${rsync_target}"
       cp -a "${src_dir}/initrd.img" "${rsync_target}"
+      chown -R root.nobody "${rsync_target}"
+      chmod 750 "{rsync_target}"
+      find "${rsync_target}" -type f -exec chmod 644 {} \;
       popd
 
       tftpboot_setup_success=0


### PR DESCRIPTION
Vmlinuz and initrd should be root:nobody, world-readable.

SIMP-264 #comment Kernel images world readable.