### PR TITLE
SIMP-351 Remove conflict of rsyslog and rsyslog7

### DIFF
--- a/src/DVD/ks/dvd/include/common_ks_base
+++ b/src/DVD/ks/dvd/include/common_ks_base
@@ -82,6 +82,7 @@ vlock
 mutt
 subversion
 -sysklogd
+-rsyslog
 rsyslog7
 lsof
 vim-enhanced

--- a/src/DVD/ks/pupclient_x86_64.cfg
+++ b/src/DVD/ks/pupclient_x86_64.cfg
@@ -90,6 +90,7 @@ mutt
 subversion
 -sysklogd
 rsyslog7
+-rsyslog
 lsof
 vim-enhanced
 -sendmail

--- a/src/DVD/ks/puppet_x86_64.cfg
+++ b/src/DVD/ks/puppet_x86_64.cfg
@@ -90,6 +90,7 @@ mutt
 subversion
 -sysklogd
 rsyslog7
+-rsyslog
 lsof
 vim-enhanced
 -sendmail


### PR DESCRIPTION
The rsyslog package must be explicitly removed from the kickstart
package list so that it does not conflict with the installation of
rsyslog7 and/or cause dependency resolution issues.

SIMP-369 #close #comment Fix rsyslog/rsyslog7 kickstart dependency
issues.