### PR TITLE
SIMP-396 Updated the pkg:signrpms for force sign

### DIFF
--- a/rakefiles/pkg.rake
+++ b/rakefiles/pkg.rake
@@ -361,9 +361,12 @@ gpg-agent --homedir=#{Dir.pwd} --batch --daemon --pinentry-program /usr/bin/pine
   end
 
   desc "Sign the RPMs."
-  task :signrpms,[:key,:rpm_dir] => [:prep,:mock_prep] do |t,args|
+  task :signrpms,[:key,:rpm_dir,:force] => [:prep,:mock_prep] do |t,args|
     args.with_defaults(:key => 'dev')
     args.with_defaults(:rpm_dir => "#{BUILD_DIR}/SIMP/*RPMS")
+    args.with_default(:force => false)
+
+    force = (args.force.to_s == 'false' ? false : true)
 
     rpm_dirs = Dir.glob(args.rpm_dir)
     to_sign = []
@@ -381,7 +384,7 @@ gpg-agent --homedir=#{Dir.pwd} --batch --daemon --pinentry-program /usr/bin/pine
       :progress => t.name
     ) do |rpm|
       rpminfo = %x{rpm -qip #{rpm} 2>/dev/null}.split("\n")
-      unless rpminfo.grep(/Signature\s+:\s+\(none\)/).empty?
+      if (force || !rpminfo.grep(/Signature\s+:\s+\(none\)/).empty?)
         Simp::RPM.signrpm(rpm,"#{BUILD_DIR}/build_keys/#{args.key}")
       end
     end


### PR DESCRIPTION
This updates the pkg:signrpms task to add a third option for forcing the
signature of a set of RPMs. This allows you to update an entire batch of
previously signed RPMs with a new key.

SIMP-396 #comment Helper for signing RPMs prior to pushing to BinTray

Change-Id: I438c214a3e62276565a16140daced882f6687699