### PR TITLE
SIMP-241 Allow for inclusion of arbitrary RPMs

### DIFF
--- a/build/yum_data/README.md
+++ b/build/yum_data/README.md
@@ -44,6 +44,13 @@ This file contains a hash of the following form:
    source: 'http://the_full_download_location'
 ```
 
+#### aux_packages/
+
+A directory of packages that will be included in your build.
+
+This can be used to include arbitrary RPMs in your ISO build. Take care not to
+push past the limits of the single installation ISO.
+
 #### packages/
 
 The actual packages for the given build.

--- a/rakefiles/iso.rake
+++ b/rakefiles/iso.rake
@@ -171,9 +171,17 @@ Build the SIMP ISO(s).
             fail("Could not find dependency directory at #{yum_dep_location}")
           end
 
-          yum_dep_rpms = Dir.glob(%(#{yum_dep_location}/*.rpm))
+          yum_dep_rpms = Dir.glob(File.join(yum_dep_location,'*.rpm'))
           if yum_dep_rpms.empty?
             fail("Could not find any dependency RPMs at #{yum_dep_location}")
+          end
+
+          # Add any one-off RPMs that you might want to add to your own build
+          # These are *not* checked to make sure that they actually match your
+          # environment
+          aux_packages = File.join(BUILD_DIR,'yum_data',simp_dep_src,'aux_packages')
+          if File.directory?(aux_packages)
+            yum_dep_rpms += Dir.glob(File.join(aux_packages,'*.rpm'))
           end
 
           yum_dep_rpms.each do |rpm|


### PR DESCRIPTION
This allows for the creation of an aux_packages directory where
arbitrary RPMs can be placed for inclusion in the resulting ISO.

There are no assumptions or checks made on the validity of these RPMs.

SIMP-241 #close #comment Added to 4.2.X

Change-Id: I5a2a378e270335ad855a8da1534d4436b757db2b