### PR TITLE
(SIMP-477) Install Dracut-FIPS at boot and kickstart times

### DIFF
--- a/src/DVD/ks/dvd/include/common_ks_base
+++ b/src/DVD/ks/dvd/include/common_ks_base
@@ -38,6 +38,8 @@ coolkey
 cpuspeed
 cryptsetup-luks
 dhclient
+dracut
+dracut-fips
 git
 gnupg
 gpm

--- a/src/DVD/ks/dvd/include/min_ks_base
+++ b/src/DVD/ks/dvd/include/min_ks_base
@@ -38,6 +38,8 @@ coolkey
 cpuspeed
 cryptsetup-luks
 dhclient
+dracut
+dracut-fips
 gnupg
 irqbalance
 krb5-workstation


### PR DESCRIPTION
Updated package list to ensure dracut-fips is installed at kickstart.

SIMP-477 #close

Change-Id: Idb97cf9fb7ad39f74f89542fc78337cebcd8cda6