### PR TITLE
(SIMP-486) Disable FIPS.

### DIFF
--- a/src/DVD/ks/dvd/include/common_ks_base
+++ b/src/DVD/ks/dvd/include/common_ks_base
@@ -2,7 +2,7 @@ authconfig --enableshadow --passalgo=sha512 --enablemd5
 network --nodns --hostname=puppet.change.me
 skipx
 rootpw --iscrypted $6$cKH4tleUAthZBrFM$ZnXngjlvHTDCJOJWZOcOWXH5UHR9v75XbkGzshrBaR8LC30Jkxf/KP4kIFrSFOMgxDmha/SuXv9I8N2C0RPV1.
-bootloader --location=mbr --driveorder=sda,hda --append="fips=1 console=ttyS1,57600 console=tty0" --iscrypted --password=$6$Y3AnAvsj52K3HOvh$s.BH/N1MzeTTk/5U/6C55FsG0839vCIj0RPmEaGMM4Sqz5i.VtW.RNPND1nXJKbthvUw9AKMRcNL/fucnSn/L1
+bootloader --location=mbr --driveorder=sda,hda --append="console=ttyS1,57600 console=tty0" --iscrypted --password=$6$Y3AnAvsj52K3HOvh$s.BH/N1MzeTTk/5U/6C55FsG0839vCIj0RPmEaGMM4Sqz5i.VtW.RNPND1nXJKbthvUw9AKMRcNL/fucnSn/L1
 zerombr
 key --skip
 firewall --enabled --ssh


### PR DESCRIPTION
FIPS integrity check fails with the current kernel.

SIMP-486 #comment Disable FIPS.