### PR TITLE
(SIMP-488) Updated the puppetserver RPM

### DIFF
--- a/build/yum_data/SIMP4.2.0_CentOS6.7_x86_64/packages.yaml
+++ b/build/yum_data/SIMP4.2.0_CentOS6.7_x86_64/packages.yaml
@@ -438,8 +438,8 @@ puppetlabs-stdlib:
   :rpm_name: puppetlabs-stdlib-4.5.1-2.20150121git7a91f20.el6.noarch.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/puppetlabs-stdlib-4.5.1-2.20150121git7a91f20.el6.noarch.rpm
 puppetserver:
-  :rpm_name: puppetserver-1.0.2-1.el6.noarch.rpm
-  :source: http://yum.puppetlabs.com/el/6/products/x86_64/puppetserver-1.0.2-1.el6.noarch.rpm
+  :rpm_name: puppetserver-1.1.1-1.el6.noarch.rpm
+  :source: http://yum.puppetlabs.com/el/6/products/x86_64/puppetserver-1.1.1-1.el6.noarch.rpm
 python-argparse:
   :rpm_name: python-argparse-1.2.1-2.el6.noarch.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/python-argparse-1.2.1-2.el6.noarch.rpm

--- a/build/yum_data/SIMP4.2.0_RHEL6.7_x86_64/packages.yaml
+++ b/build/yum_data/SIMP4.2.0_RHEL6.7_x86_64/packages.yaml
@@ -438,8 +438,8 @@ puppetlabs-stdlib:
   :rpm_name: puppetlabs-stdlib-4.5.1-2.20150121git7a91f20.el6.noarch.rpm
   :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/puppetlabs-stdlib-4.5.1-2.20150121git7a91f20.el6.noarch.rpm
 puppetserver:
-  :rpm_name: puppetserver-1.0.2-1.el6.noarch.rpm
-  :source: http://yum.puppetlabs.com/el/6/products/x86_64/puppetserver-1.0.2-1.el6.noarch.rpm
+  :rpm_name: puppetserver-1.1.1-1.el6.noarch.rpm
+  :source: http://yum.puppetlabs.com/el/6/products/x86_64/puppetserver-1.1.1-1.el6.noarch.rpm
 python-argparse:
   :rpm_name: python-argparse-1.2.1-2.el6.noarch.rpm
   :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/python-argparse-1.2.1-2.el6.noarch.rpm


### PR DESCRIPTION
This updates the puppetserver RPM to the 1.1.1 version which allows us
to modify the keylengths to work with enforcing FIPS mode.

SIMP-488 #close #comment Updated RPM

Change-Id: I4c3c8967d938194b8b7c89eb41df4a34865bed70