### PR TITLE
(SIMP-256) Update core for the latest puppetdb.

### DIFF
--- a/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/packages.yaml
+++ b/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/packages.yaml
@@ -267,11 +267,11 @@ puppet-server:
   :rpm_name: puppet-server-3.8.1-1.el7.noarch.rpm
   :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppet-server-3.8.1-1.el7.noarch.rpm
 puppetdb:
-  :rpm_name: puppetdb-2.3.5-1.el7.noarch.rpm
-  :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppetdb-2.3.5-1.el7.noarch.rpm
+  :rpm_name: puppetdb-2.3.8-1.el7.noarch.rpm
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppetdb-2.3.8-1.el7.noarch.rpm
 puppetdb-terminus:
-  :rpm_name: puppetdb-terminus-2.3.5-1.el7.noarch.rpm
-  :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppetdb-terminus-2.3.5-1.el7.noarch.rpm
+  :rpm_name: puppetdb-terminus-2.3.8-1.el7.noarch.rpm
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppetdb-terminus-2.3.8-1.el7.noarch.rpm
 puppetlabs-release:
   :rpm_name: puppetlabs-release-7-11.noarch.rpm
   :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppetlabs-release-7-11.noarch.rpm

--- a/build/yum_data/SIMP5.1.0_RHEL7.1_x86_64/packages.yaml
+++ b/build/yum_data/SIMP5.1.0_RHEL7.1_x86_64/packages.yaml
@@ -294,11 +294,11 @@ puppet-server:
   :rpm_name: puppet-server-3.8.1-1.el7.noarch.rpm
   :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppet-server-3.8.1-1.el7.noarch.rpm
 puppetdb:
-  :rpm_name: puppetdb-2.3.5-1.el7.noarch.rpm
-  :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppetdb-2.3.5-1.el7.noarch.rpm
+  :rpm_name: puppetdb-2.3.8-1.el7.noarch.rpm
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppetdb-2.3.8-1.el7.noarch.rpm
 puppetdb-terminus:
-  :rpm_name: puppetdb-terminus-2.3.5-1.el7.noarch.rpm
-  :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppetdb-terminus-2.3.5-1.el7.noarch.rpm
+  :rpm_name: puppetdb-terminus-2.3.8-1.el7.noarch.rpm
+  :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppetdb-terminus-2.3.8-1.el7.noarch.rpm
 puppetlabs-release:
   :rpm_name: puppetlabs-release-7-11.noarch.rpm
   :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppetlabs-release-7-11.noarch.rpm

--- a/src/puppet/bootstrap/environments/simp/hieradata/hosts/puppet.your.domain.yaml
+++ b/src/puppet/bootstrap/environments/simp/hieradata/hosts/puppet.your.domain.yaml
@@ -21,7 +21,12 @@ simp::server::enable_puppetdb : true
 # The service name of the Puppet Server service for use with PuppetDB
 #
 # TODO: This should probably be a Fact
-puppetdb::master::puppet_service_name : 'puppetserver'
+puppetdb::master::config::puppet_service_name : 'puppetserver'
+
+# The puppetdb version needs to be explicitly set, else 'present'
+# or 'latest' will bring in the latest puppetdb-termini package.
+#
+puppetdb::globals::version: '2.3.8-1.el7'
 
 classes :
   - 'simp::server'


### PR DESCRIPTION
- In Hiera, the PuppetDB package version is set.
- Brought in the latest version of PuppetDB2, 2.3.8-1

SIMP-537 #comment Modified default hieradata
SIMP-546 #comment Updated PuppetDB package