### PR TITLE
(SIMP-589) Do not chkconfig services in %post

### DIFF
--- a/src/DVD/ks/dvd/auto.cfg
+++ b/src/DVD/ks/dvd/auto.cfg
@@ -140,16 +140,6 @@ DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 titl
 /sbin/grubby --copy-default --make-default --args="boot=${BOOTDEV} fips=1" --add-kernel=`/sbin/grubby --default-kernel` --initrd=${DEFAULT_INITRD} --title="FIPS ${DEFAULT_KERNEL_TITLE}"
 dracut -f
 
-/sbin/chkconfig --add network;
-/sbin/chkconfig --add httpd;
-/sbin/chkconfig --level 2345 puppetmaster on;
-/sbin/chkconfig --level 345 named on;
-/sbin/chkconfig --level 345 nscd on;
-/sbin/chkconfig --level 345 ldap on;
-/sbin/chkconfig --level 345 named on;
-/sbin/chkconfig --level 345 xinetd on;
-/sbin/chkconfig --level 2345 rsyslog on;
-
 sed -i 's/--class os/--class os --unrestricted/g' /boot/grub2/grub.cfg
 
 ostype=`facter operatingsystem`


### PR DESCRIPTION
The default kickstart should not chkconfig any services in the %post
section.

SIMP-589 #close

Change-Id: I83024cdda2fbbb405a35e240ecbf19ec2b9c33b2