### PR TITLE
(SIMP-598) Clean up yum symlink logic

### DIFF
--- a/build/GPGKEYS/build/simp-gpgkeys.spec
+++ b/build/GPGKEYS/build/simp-gpgkeys.spec
@@ -45,62 +45,60 @@ cp RPM-GPG-KEY* %{buildroot}/%{prefix}
 
 # If we're a SIMP server, place the keys into the appropriate web directory
 
-for dir in '/srv/www/yum/SIMP' '/var/www/yum/SIMP'; do
-  if [ ! -d $dir ]; then
-    mkdir -p -m 0755 "${dir}/GPGKEYS"
+dir='/srv/www/yum/SIMP'
+if [ ! -d $dir ]; then
+  mkdir -p -m 0755 "${dir}/GPGKEYS"
+fi
+cp %{prefix}/RPM-GPG-KEY* "${dir}/GPGKEYS"
+
+# Get rid of any files that are present that aren't in the new directory.
+# Ensure that we don't have issues with operations in progress.
+old_key_list=`mktemp --suffix=.simp_gpgkeys`
+new_key_list=`mktemp --suffix=.simp_gpgkeys`
+
+find "${dir}/GPGKEYS" -name "RPM-GPG-KEY*" -maxdepth 1 -printf "%f\n" | sort -u > $old_key_list
+find "%{prefix}" -name "RPM-GPG-KEY*" -maxdepth 1 -printf "%f\n" | sort -u > $new_key_list
+
+for file in `comm -23 $old_key_list $new_key_list`; do
+  if [ -f "${dir}/GPGKEYS/${file}" ]; then
+    rm -f "${dir}/GPGKEYS/${file}"
   fi
-  cp %{prefix}/RPM-GPG-KEY* "${dir}/GPGKEYS"
-
-  # Get rid of any files that are present that aren't in the new directory.
-  # Ensure that we don't have issues with operations in progress.
-  old_key_list=`mktemp --suffix=.simp_gpgkeys`
-  new_key_list=`mktemp --suffix=.simp_gpgkeys`
-
-  find "${dir}/GPGKEYS" -name "RPM-GPG-KEY*" -maxdepth 1 -printf "%f\n" | sort -u > $old_key_list
-  find "%{prefix}" -name "RPM-GPG-KEY*" -maxdepth 1 -printf "%f\n" | sort -u > $new_key_list
-
-  for file in `comm -23 $old_key_list $new_key_list`; do
-    if [ -f "${dir}/GPGKEYS/${file}" ]; then
-      rm -f "${dir}/GPGKEYS/${file}"
-    fi
-  done
-
-  if [ -f $old_key_list ]; then
-    rm -f $old_key_list
-  fi
-
-  if [ -f $new_key_list ]; then
-    rm -f $new_key_list
-  fi
-
-  # Link system GPG keys into SIMP repo
-  if [ `facter operatingsystem` == 'CentOS' ]; then
-    search_string='.*CentOS-[[:digit:]]'
-  elif [ `facter operatingsystem` == 'RedHat' ]; then
-    search_string='.*redhat.*release.*'
-  else
-    search_string=''
-  fi
-  if [ -n "$search_string" ]; then
-    for file in `find /etc/pki/rpm-gpg/ -regextype posix-extended -regex ${search_string}`; do
-      cp ${file} ${dir}/GPGKEYS
-    done
-  fi
-
-  # Ensure GPG permissions
-  chown -R root:48 ${dir}/GPGKEYS/
-  find ${dir}/GPGKEYS/ -type f -exec chmod 640 {} +
-
 done
+
+if [ -f $old_key_list ]; then
+  rm -f $old_key_list
+fi
+
+if [ -f $new_key_list ]; then
+  rm -f $new_key_list
+fi
+
+# Link system GPG keys into SIMP repo
+if [ `facter operatingsystem` == 'CentOS' ]; then
+  search_string='.*CentOS-[[:digit:]]'
+elif [ `facter operatingsystem` == 'RedHat' ]; then
+  search_string='.*redhat.*release.*'
+else
+  search_string=''
+fi
+if [ -n "$search_string" ]; then
+  for file in `find /etc/pki/rpm-gpg/ -regextype posix-extended -regex ${search_string}`; do
+    cp ${file} ${dir}/GPGKEYS
+  done
+fi
+
+# Ensure GPG permissions
+chown -R root:48 ${dir}/GPGKEYS/
+find ${dir}/GPGKEYS/ -type f -exec chmod 640 {} +
+
 
 %postun
 #!/bin/bash
 
-for dir in '/srv/www/yum/SIMP' '/var/www/yum/SIMP'; do
-  if [ -d "${dir}/GPGKEYS" ]; then
-    find -P "${dir}/GPGKEYS/" -type f -xdev -xautofs -delete
-  fi
-done
+dir='/srv/www/yum/SIMP'
+if [ -d "${dir}/GPGKEYS" ]; then
+  find -P "${dir}/GPGKEYS/" -type f -xdev -xautofs -delete
+fi
 
 %changelog
 * Tue Oct 27 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.0.0-3

--- a/src/DVD/ks/dvd/auto.cfg
+++ b/src/DVD/ks/dvd/auto.cfg
@@ -156,9 +156,6 @@ DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 titl
 /sbin/grubby --copy-default --make-default --args="boot=${BOOTDEV} fips=1" --add-kernel=`/sbin/grubby --default-kernel` --initrd=${DEFAULT_INITRD} --title="FIPS ${DEFAULT_KERNEL_TITLE}"
 dracut -f
 
-ln -s /srv/www/yum /var/www/yum;
-ln -s /srv/www/ks /var/www/ks;
-
 ostype=`lsb_release -i | awk '{print $3}'`;
 if [ $ostype == "RedHatEnterpriseServer" ]; then
   ostype="RedHat"

--- a/src/DVD/ks/dvd/workstation_auto.cfg
+++ b/src/DVD/ks/dvd/workstation_auto.cfg
@@ -127,9 +127,6 @@ eject /tmp/cdrom
 /sbin/chkconfig --level 345 xinetd on;
 /sbin/chkconfig --level 2345 rsyslog on;
 
-ln -s /srv/www/yum /var/www/yum;
-ln -s /srv/www/ks /var/www/ks;
-
 ostype=`lsb_release -i | awk '{print $3}'`;
 if [ $ostype == "RedHatEnterpriseServer" ]; then
   ostype="RedHat"

--- a/src/puppet/bootstrap/build/simp-bootstrap.spec
+++ b/src/puppet/bootstrap/build/simp-bootstrap.spec
@@ -1,7 +1,7 @@
 Summary: SIMP Bootstrap
 Name: simp-bootstrap
 Version: 4.2.0
-Release: 2
+Release: 3
 License: Apache License 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -270,6 +270,15 @@ else
   fi
 fi
 
+# Link yum and ks
+for dir in 'yum' 'ks'; do
+  if [ -d "/var/www/${dir}" ]; then
+    echo "Warning: /var/www/${dir} exists, not linking to /srv/www/${dir}";
+  else
+    ln -s "/srv/www/${dir}" "/var/www/${dir}";
+  fi
+done
+
 sed -i "s|baseurl=file:///srv/www/yum/SIMP/\?$|baseurl=file:///srv/www/yum/SIMP/$arch|" /etc/yum.repos.d/*.repo
 
 # Set up the simp directory environment
@@ -291,6 +300,10 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Thu Nov 05 2015 Nick Markowski <nmarkowski@keywcorp.com> - 4.2.0-3
+- Symlink /srv/www/yum|ks to /var/www.  This used to happen post kickstart
+  but users need this functionality when not installing from the ISO.
+
 * Tue Jun 09 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.2.0-2
 - Made some minor fixes to prepare for public release.
 - Added a global Exec default for the command path.


### PR DESCRIPTION
- No longer link yum and ks in post kickstart.  Moved to
  bootstrap for benefit of users not installing from ISO.
- ks and yum links not created if directories already exist
  in their place.
- Removed direct creation of /var/www/yum/SIMP.

SIMP-598 #close Fix yum symlinks

Moved symlink of /var/www/yum|ks to /srv/www/yum|ks from post
kickstart to bootstrap