### PR TITLE
(SIMP-592) Added a script for converting to Hiera3

### DIFF
--- a/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/packages.yaml
+++ b/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/packages.yaml
@@ -92,6 +92,9 @@ gweb:
 haveged:
   :rpm_name: haveged-1.9.1-1.el7.x86_64.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/h/haveged-1.9.1-1.el7.x86_64.rpm
+hiera:
+  :rpm_name: hiera-3.0.2-1.el7.noarch.rpm
+  :source: https://dl.bintray.com/simp/5.1.X/hiera-3.0.2-1.el7.noarch.rpm
 hmaccalc:
   :rpm_name: hmaccalc-0.9.13-4.el7.x86_64.rpm
   :source: http://mirror.ash.fastserv.com/pub/linux/centos/7.1.1503/os/x86_64/Packages/hmaccalc-0.9.13-4.el7.x86_64.rpm
@@ -330,17 +333,14 @@ rubygem-rake-compiler:
   :rpm_name: rubygem-rake-compiler-0.9.3-1.el7.noarch.rpm
   :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-rake-compiler-0.9.3-1.el7.noarch.rpm
 rubygem-stomp:
-  :rpm_name: rubygem-stomp-1.3.2-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/r/rubygem-stomp-1.3.2-1.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/r/rubygem-stomp-1.3.4-2.el7.noarch.rpm
+  :rpm_name: rubygem-stomp-1.3.4-2.el7.noarch.rpm
 rubygem-stomp-doc:
-  :rpm_name: rubygem-stomp-doc-1.3.2-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/r/rubygem-stomp-doc-1.3.2-1.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/r/rubygem-stomp-doc-1.3.4-2.el7.noarch.rpm
+  :rpm_name: rubygem-stomp-doc-1.3.4-2.el7.noarch.rpm
 scap-security-guide:
   :rpm_name: scap-security-guide-0.1.19-2.el7.noarch.rpm
   :source: http://mirrors.advancedhosters.com/centos/7.1.1503/os/x86_64/Packages/scap-security-guide-0.1.19-2.el7.noarch.rpm
-simp-hiera:
-  :rpm_name: simp-hiera-1.3.3-1.el7.noarch.rpm
-  :source: https://dl.bintray.com/simp/5.1.X-Ext/simp-hiera-1.3.3-1.el7.noarch.rpm
 simp-lastbind:
   :rpm_name: simp-lastbind-2.4.23-0.x86_64.rpm
   :source: https://dl.bintray.com/simp/5.1.X-Ext/simp-lastbind-2.4.23-0.x86_64.rpm

--- a/build/yum_data/SIMP5.1.0_RHEL7.1_x86_64/packages.yaml
+++ b/build/yum_data/SIMP5.1.0_RHEL7.1_x86_64/packages.yaml
@@ -368,9 +368,9 @@ rubygem-stomp-doc:
 scap-security-guide:
   :rpm_name: scap-security-guide-0.1.19-2.el7.noarch.rpm
   :source: Red Hat Updates Repository
-simp-hiera:
-  :rpm_name: simp-hiera-1.3.3-1.el7.noarch.rpm
-  :source: https://dl.bintray.com/simp/5.1.X-Ext/simp-hiera-1.3.3-1.el7.noarch.rpm
+hiera:
+  :rpm_name: hiera-3.0.2-1.el7.noarch.rpm
+  :source: https://dl.bintray.com/simp/5.1.X/hiera-3.0.2-1.el7.noarch.rpm
 simp-lastbind:
   :rpm_name: simp-lastbind-2.4.23-0.x86_64.rpm
   :source: https://dl.bintray.com/simp/5.1.X-Ext/simp-lastbind-2.4.23-0.x86_64.rpm

--- a/src/build/simp.spec
+++ b/src/build/simp.spec
@@ -1,7 +1,7 @@
 Summary: SIMP Full Install
 Name: simp
 Version: 5.1.0
-Release: RC1%{?snapshot_release}
+Release: RC1.1446834077%{?snapshot_release}
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -11,33 +11,33 @@ Requires: createrepo
 Requires: lsb
 Requires: puppetserver >= 1.0.0
 Requires: facter > 1:2.4.0
-Requires: simp-hiera >= 1.3.2-2
+Requires: hiera >= 3.0.2
 Requires: puppetlabs-stdlib
 Requires: httpd >= 2.2
 #Begin AUTOGEN
 #End AUTOGEN
 
-Prefix: /etc/puppet
+Prefix: %{_sysconfdir}/puppet
 
 %description
 Stub for installing everything needed for a full SIMP system
 
 %prep
-%setup
+%setup -q
 
 %build
 
 %install
-mkdir -p %{buildroot}/etc/simp
-echo "%{version}-%{release}" > %{buildroot}/etc/simp/simp.version
-chmod u=rwX,g=rX,o=rX -R %{buildroot}/etc/simp
+mkdir -p %{buildroot}%{_sysconfdir}/simp
+echo "%{version}-%{release}" > %{buildroot}%{_sysconfdir}/simp/simp.version
+chmod u=rwX,g=rX,o=rX -R %{buildroot}%{_sysconfdir}/simp
 
 %clean
 [ "%{buildroot}" != "/" ] && rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
-/etc/simp/simp.version
+%{_sysconfdir}/simp/simp.version
 
 %post
 # Post installation stuff
@@ -46,16 +46,20 @@ if [ -f %{prefix}/autosign.conf ]; then
   chmod 644 %{prefix}/autosign.conf;
 fi
 
-if [ -x '/usr/local/sbin/puppetserver_clear_environment_cache' ]; then
-  /usr/local/sbin/puppetserver_clear_environment_cache
+if [ -f '%{_usr}/local/sbin/hiera_upgrade' ]; then
+  %{_usr}/local/sbin/hiera_upgrade || true
 fi
 
-if [ -x '/usr/local/sbin/puppetserver_reload' ]; then
-  /usr/local/sbin/puppetserver_reload
+if [ -x '%{_usr}/local/sbin/puppetserver_clear_environment_cache' ]; then
+  %{_usr}/local/sbin/puppetserver_clear_environment_cache
 fi
 
-rpm_link_target="/var/www/yum/`facter operatingsystem`/`facter lsbmajdistrelease`"
-rpm_link="/var/www/yum/`facter operatingsystem`/`facter lsbdistrelease`"
+if [ -x '%{_usr}/local/sbin/puppetserver_reload' ]; then
+  %{_usr}/local/sbin/puppetserver_reload
+fi
+
+rpm_link_target="%{_var}/www/yum/`facter operatingsystem`/`facter operatingsystemmajrelease`"
+rpm_link="%{_var}/www/yum/`facter operatingsystem`/`facter operatingsystemrelease`"
 rpm_dir="$rpm_link/`facter hardwaremodel`/Updates"
 
 umask 022;
@@ -72,6 +76,12 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Fri Oct 06 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.1.0-RC1.1446834077
+- Upgraded to Hiera 3 from Puppet Labs
+- Incorporated a migration script for updating from the old simp-hiera
+- Replaced facter calls to 'lsb*' with 'operatingsystem*' in the 'post' section
+  of the RPM
+
 * Tue Sep 29 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.1.0-RC1
 - Bump for RC1
 - FIPS mode now fully active out of the box!
@@ -103,7 +113,7 @@ fi
 
 * Fri Dec 05 2014 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-1
 - Update to the first release of 5.0.0 patching several bugs
-- Updated changelog in regards to GUI and /var/tmp noexec issues
+- Updated changelog in regards to GUI and %{_var}/tmp noexec issues
 - Added patches for POODLE and Shellshock
 - Added GPG keys for RHEL/EPEL/CentOS 7
 - Fixed the puppet cron job
@@ -121,7 +131,7 @@ fi
 - Releases now only include modules that have been verified to work.
 
 * Mon Jul 21 2014 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-Beta
-- Updated to use /var instead of /srv for most data.
+- Updated to use %{_var} instead of /srv for most data.
 
 * Fri Jun 27 2014 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-Alpha
 - Added a dependency on the new passenger-service package and removed the
@@ -159,7 +169,7 @@ fi
 * Tue Sep 24 2013 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.0.5-1
 - Major changes:
   - Added ability to not automaticaly restart the network
-  - Updated to use new passenger temp directory of /var/run/passenger.
+  - Updated to use new passenger temp directory of %{_var}/run/passenger.
   - Updated rsync to default to contimeout instead of I/O timeout.
 
 * Thu Sep 12 2013 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.0.5-0
@@ -257,7 +267,7 @@ fi
 - Added a file /etc/simp/simp.version that contains the version from
   this RPM for distribution to the clients.
 - Added requires for ruby-ldap and rubygem-hiera to simp-mit
-- Moved MIT libraries to /usr/share/simp/tests/modules/mit_common
+- Moved MIT libraries to %{_usr}/share/simp/tests/modules/mit_common
 - Updated the PuppetUtils in MIT library to offer more puppet functionality
 - Added 'disable_agent' and 'enable_agent' steps to the MIT common
   library.
@@ -325,7 +335,7 @@ fi
 
 * Mon Jan 03 2011 Maintenance 1.3.0-RC1
 - First release candidate of 1.3.0
-- Added useful LDIFs to /usr/share/doc/simp-<version>/ldifs.
+- Added useful LDIFs to %{_usr}/share/doc/simp-<version>/ldifs.
 
 * Wed Jun 23 2010 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.3.0-alpha
 - Initial release of 1.3.0
@@ -340,7 +350,7 @@ fi
 - Documentation updates.
 
 * Mon May 10 2010 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.2.6-4
-- Added a 'if' statement to the %post section to preclude inappropriate failure
+- Added a 'if' statement to the 'post 'section to preclude inappropriate failure
   messages if httpd can't restart for some reason.
 
 * Mon Apr 27 2010 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.2.6-3

--- a/src/utils/build/simp-utils.spec
+++ b/src/utils/build/simp-utils.spec
@@ -48,7 +48,9 @@ chmod -R u=rwX,g=rX,o=rX %{buildroot}/usr/share/man
 /usr/local/sbin/puppetlast
 /usr/local/sbin/gen-ldap-update
 /usr/local/sbin/updaterepos
+/usr/local/sbin/hiera_upgrade
 /usr/share/simp
+%exclude /usr/share/simp/upgrade_scripts
 %attr(0750,-,-) /usr/share/simp/upgrade_scripts
 %doc /usr/share/man/*/*
 
@@ -59,6 +61,10 @@ chmod -R u=rwX,g=rX,o=rX %{buildroot}/usr/share/man
 # Post uninstall stuff
 
 %changelog
+* Thu Nov 05 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-8
+- Added a 'hiera_upgrade' script that moves away from the SIMP patched one to
+  the use of the 'alias' function.
+
 * Tue Apr 28 2015 Nick Markowski <nmarkowski@keywcorp.com> - 5.0.0-7
 - Removed old simp config from site_ruby.
 
@@ -289,7 +295,7 @@ chmod -R u=rwX,g=rX,o=rX %{buildroot}/usr/share/man
 - Added options to 'simp check' to check for unscoped function calls and
 global resource defaults
 
-* Thu Nov 20 2010 Maintenance - 1.0-3
+* Sat Nov 20 2010 Maintenance - 1.0-3
 - The 'simp config' utility now configures the keydist directory for the server.
 - The 'simp bootstrap' utility has been added to be run after 'simp config'.
 - The 'simp config' command now fully configures the Apache YUM repository.

--- a/src/utils/scripts/sbin/hiera_upgrade
+++ b/src/utils/scripts/sbin/hiera_upgrade
@@ -1,0 +1,99 @@
+#!/usr/bin/env ruby
+
+# This script is intended to assist users in upgrading from the SIMP fork of
+# Hiera to the latest Puppet Labs supported release.
+#
+# By default this will only upgrade the 'simp' environment as distributed by
+# simp-bootstrap
+#
+# You can set the environment variable HIERA_UPGRADE to a hieradata path to
+# run this script on a directory of your choosing.
+
+hieradata_path = ENV['HIERA_UPGRADE']
+
+hieradata_path = %(#{%x(puppet config print environmentpath).strip}/simp) unless hieradata_path
+
+canary_file = File.join(hieradata_path,'simp','.simp_migrated')
+if File.exist?(canary_file)
+  exit 0
+end
+
+unless File.directory?(hieradata_path)
+  $stderr.puts(%(Error: Directory '#{hieradata_path}' does not exist))
+  exit 1
+end
+
+require 'find'
+require 'yaml'
+
+def backup_data(src_dir)
+  require 'fileutils'
+
+  # Back everything up
+
+  backup_path = src_dir + '.simp_hiera_upgrade.bak.' + Time.now.strftime('%Y_%m_%d_%s')
+
+  puts %(Making backup at #{backup_path})
+
+  FileUtils.cp_r(src_dir, backup_path)
+end
+
+# Hold all hiera array and hash keys from every file for reference
+hiera_keys = []
+
+# Some basic tracking
+converted_variables = 0
+
+phases = [
+  'Gathering Keys',
+  'Converting Variables'
+]
+
+phases.each do |phase|
+  data_backed_up = false
+  puts %(In phase "#{phase}")
+
+  Find.find(hieradata_path) do |path|
+    next unless (File.file?(path) && (path.split('.').last == 'yaml'))
+
+    file_content = IO.read(path)
+    tmp_data = YAML.load(file_content)
+
+    if phase == 'Gathering Keys'
+      # We only want things that are Hashes or Arrays
+      mappable_keys = tmp_data.select{|k,v| v.is_a?(Hash) || v.is_a?(Array)}.map{|x| x.first}
+      hiera_keys += mappable_keys
+      hiera_keys = hiera_keys.flatten.uniq
+    end
+
+    if phase == 'Converting Variables'
+      content_changed = false
+
+      hiera_keys.each do |key|
+        convert_from = %(%{hiera('#{key}')})
+        convert_to = %(%{alias('#{key}')})
+
+        if file_content.include?(convert_from)
+          unless data_backed_up
+            backup_data(hieradata_path)
+            data_backed_up = true
+          end
+
+          content_changed = true
+          file_content.gsub!(convert_from, convert_to)
+
+          puts %(Converted '#{key}' in #{path})
+          converted_variables += 1
+        end
+      end
+
+      if content_changed
+        File.open(path,'w').puts(file_content)
+      end
+    end
+  end
+end
+
+puts %(Found #{converted_variables} variables to convert)
+
+FileUtils.touch(canary_file)


### PR DESCRIPTION
Hiera 3 adds quite a few new features as well as fixing the 'alias'
issue that we originally created simp-hiera to work around.

The upgrade to Hiera 3 seems to go perfectly well so long as you run a
puppetserver_reload afterwards (which the simp RPM does).

SIMP-592 #close #comment Update for 5.1.X

Change-Id: I534b49406fbcca4045874743075215f71e0a18a0