### PR TITLE
(SIMP-404) Password change should not prompt twice

### DIFF
--- a/src/DVD/ks/dvd/auto.cfg
+++ b/src/DVD/ks/dvd/auto.cfg
@@ -244,10 +244,10 @@ chage -d 0 simp;
 
 pam_mod="password     requisite     pam_cracklib.so try_first_pass difok=4 retry=3 minlen=14 minclass=3 maxrepeat=2 maxsequence=4 dcredit=-1 ucredit=-1 lcredit=-1 ocredit=-1 gecoscheck reject_username enforce_for_root\n"
 for auth_file in password system; do
-  # A double check to make sure we're not running this on a managed system...
-  if [ ! `grep -q 'Puppet' /etc/pam.d/${auth_file}-auth` ]; then
-    sed -i "s/\(password.*pam_unix.so.*\)/${pam_mod}\1/" /etc/pam.d/${auth_file}-auth
-  fi
+  if [ -f /etc/pam.d/${auth_file}-auth ] && [ ! `grep -q 'Puppet' /etc/pam.d/${auth_file}-auth` ]; then
+    # Remove the items that will double prompt us out of the box
+    sed -i "/pam_\(pwquality\|cracklib\).so/d" /etc/pam.d/${auth_file}-auth
+    # Add our cracklib line
 done
 
 simp_opt=`awk -F "simp_opt=" '{print $2}' /proc/cmdline | cut -f1 -d' '`

--- a/src/DVD/ks/dvd/min.cfg
+++ b/src/DVD/ks/dvd/min.cfg
@@ -45,10 +45,10 @@ chage -d 0 simp;
 
 pam_mod="password     requisite     pam_cracklib.so try_first_pass difok=4 retry=3 minlen=14 minclass=3 maxrepeat=2 maxsequence=4 dcredit=-1 ucredit=-1 lcredit=-1 ocredit=-1 gecoscheck reject_username enforce_for_root\n"
 for auth_file in password system; do
-  # A double check to make sure we're not running this on a managed system...
-  if [ ! `grep -q 'Puppet' /etc/pam.d/${auth_file}-auth` ]; then
-    sed -i "s/\(password.*pam_unix.so.*\)/${pam_mod}\1/" /etc/pam.d/${auth_file}-auth
-  fi
+  if [ -f /etc/pam.d/${auth_file}-auth ] && [ ! `grep -q 'Puppet' /etc/pam.d/${auth_file}-auth` ]; then
+    # Remove the items that will double prompt us out of the box
+    sed -i "/pam_\(pwquality\|cracklib\).so/d" /etc/pam.d/${auth_file}-auth
+    # Add our cracklib line
 done
 
 %end


### PR DESCRIPTION
The original PAM library that checks for password complexity was not
removed from the PAM stack at kickstart time.

This made our addition of cracklib cause a duplicate password prompt.

SIMP-404 #close #comment Fixed for 4.2.X

Change-Id: I8a522dba9c6715631599837e15274fd307838f4e