### PR TITLE
(SIMP-404) Password change should not prompt twice

### DIFF
--- a/src/DVD/ks/dvd/auto.cfg
+++ b/src/DVD/ks/dvd/auto.cfg
@@ -190,7 +190,10 @@ chage -d 0 simp;
 pam_mod="password     requisite     pam_cracklib.so try_first_pass difok=4 retry=3 minlen=14 minclass=3 maxrepeat=2 maxsequence=4 dcredit=-1 ucredit=-1 lcredit=-1 ocredit=-1 gecoscheck reject_username enforce_for_root\n"
 for auth_file in password system; do
   # A double check to make sure we're not running this on a managed system...
-  if [ ! `grep -q 'Puppet' /etc/pam.d/${auth_file}-auth` ]; then
+  if [ -f /etc/pam.d/${auth_file}-auth ] && [ ! `grep -q 'Puppet' /etc/pam.d/${auth_file}-auth` ]; then
+    # Remove the items that will double prompt us out of the box
+    sed -i "/pam_\(pwquality\|cracklib\).so/d" /etc/pam.d/${auth_file}-auth
+    # Add our cracklib line
     sed -i "s/\(password.*pam_unix.so.*\)/${pam_mod}\1/" /etc/pam.d/${auth_file}-auth
   fi  
 done

--- a/src/DVD/ks/dvd/min.cfg
+++ b/src/DVD/ks/dvd/min.cfg
@@ -56,9 +56,9 @@ chage -d 0 simp;
 
 pam_mod="password     requisite     pam_cracklib.so try_first_pass difok=4 retry=3 minlen=14 minclass=3 maxrepeat=2 maxsequence=4 dcredit=-1 ucredit=-1 lcredit=-1 ocredit=-1 gecoscheck reject_username enforce_for_root\n"
 for auth_file in password system; do
-  # A double check to make sure we're not running this on a managed system...
-  if [ ! `grep -q 'Puppet' /etc/pam.d/${auth_file}-auth` ]; then
-    sed -i "s/\(password.*pam_unix.so.*\)/${pam_mod}\1/" /etc/pam.d/${auth_file}-auth
-  fi  
+  if [ -f /etc/pam.d/${auth_file}-auth ] && [ ! `grep -q 'Puppet' /etc/pam.d/${auth_file}-auth` ]; then
+    # Remove the items that will double prompt us out of the box
+    sed -i "/pam_\(pwquality\|cracklib\).so/d" /etc/pam.d/${auth_file}-auth
+    # Add our cracklib line
 done
 %end


### PR DESCRIPTION
The original PAM library that checks for password complexity was not
removed from the PAM stack at kickstart time.

This made our addition of cracklib cause a duplicate password prompt.

SIMP-404 #close #comment Fixed for 5.1.X

Change-Id: I0676d567001530792ed439d485d4b38c4d911513

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/simp/simp-core/109)
<!-- Reviewable:end -->
