### PR TITLE
(SIMP-610) Update the default passwords

### DIFF
--- a/src/DVD/ks/dvd/auto.cfg
+++ b/src/DVD/ks/dvd/auto.cfg
@@ -234,7 +234,7 @@ EOF
 enabled=0' /etc/yum.repos.d/CentOS-Base.repo;
 fi
 
-pass_hash='$6$To3L7VhrftMmeSwt$d4a2eqWghCwNA2fv0piCd3xISKbh/9w/9YUESH7nfc.S7rJFTm3G8fbzrjoYqn5purLRAtDhwR36R/AQZRJDZ.'
+pass_hash='$6$1tkixqzp$iihri50cUBpvDcIfq1ieftkj6ToRBrlQutpzP2sdGo5/h6dDfdXvFkmVtODwEJD0W2XYScmKrnkqRnnMEkaRi.'
 
 groupadd -g 1777 simp >& /dev/null;
 useradd -d /var/local/simp -g simp -m -p $pass_hash -s /bin/bash -u 1777 -K PASS_MAX_DAYS=90 -K PASS_MIN_DAYS=1 -K PASS_WARN_AGE=7 simp >& /dev/null;

--- a/src/DVD/ks/dvd/include/common_ks_base
+++ b/src/DVD/ks/dvd/include/common_ks_base
@@ -1,8 +1,8 @@
 authconfig --enableshadow --passalgo=sha512 --enablemd5
 network --nodns --hostname=puppet.change.me
 skipx
-rootpw --iscrypted $6$cKH4tleUAthZBrFM$ZnXngjlvHTDCJOJWZOcOWXH5UHR9v75XbkGzshrBaR8LC30Jkxf/KP4kIFrSFOMgxDmha/SuXv9I8N2C0RPV1.
-bootloader --location=mbr --driveorder=sda,hda --append="fips=1 console=ttyS1,57600 console=tty0" --iscrypted --password=$6$Y3AnAvsj52K3HOvh$s.BH/N1MzeTTk/5U/6C55FsG0839vCIj0RPmEaGMM4Sqz5i.VtW.RNPND1nXJKbthvUw9AKMRcNL/fucnSn/L1
+rootpw --iscrypted $6$80gio95q$anOG/VG/cs0vNfYblxQKnH7J3z9omZbxe3Gpa2VojlNf8CbWmtZWXbd/O.4HdlGbGFTRLmvtVe8.jEjQpbxDl/
+bootloader --location=mbr --driveorder=sda,hda --append="console=ttyS1,57600 console=tty0" --iscrypted --password=$6$EiDpY9dX.blbssNm$9KxoNaquKc1HEAjO.uH1EqFO.PpC.uJyfvjoIAvgojAKoio7MXHCwxm4vwBW4TNlKQxkZaNRJ9cxDmmStDe9H.
 zerombr
 key --skip
 firewall --enabled --ssh

--- a/src/DVD/ks/dvd/min.cfg
+++ b/src/DVD/ks/dvd/min.cfg
@@ -48,7 +48,7 @@ dracut -f
 /sbin/chkconfig --level 345 nscd on;
 /sbin/chkconfig --level 2345 rsyslog on;
 
-pass_hash='$6$To3L7VhrftMmeSwt$d4a2eqWghCwNA2fv0piCd3xISKbh/9w/9YUESH7nfc.S7rJFTm3G8fbzrjoYqn5purLRAtDhwR36R/AQZRJDZ.'
+pass_hash='$6$1tkixqzp$iihri50cUBpvDcIfq1ieftkj6ToRBrlQutpzP2sdGo5/h6dDfdXvFkmVtODwEJD0W2XYScmKrnkqRnnMEkaRi.'
 
 groupadd -g 1777 simp >& /dev/null;
 useradd -d /var/local/simp -g simp -m -p $pass_hash -s /bin/bash -u 1777 -K PASS_MAX_DAYS=90 -K PASS_MIN_DAYS=1 -K PASS_WARN_AGE=7 simp >& /dev/null;


### PR DESCRIPTION
The previous passwords were too difficult for users to type so they have
been changed to something quite simple.

root => RootPass
simp => UserPass
grub => GrubPass

SIMP-610 #close #comment Updated for 4.2.X

Change-Id: Ib62342e0de3d1f633281b8b9104a8e19c3eec590