### PR TITLE
(SIMP-630) Migrate default hieradata to simplib

### DIFF
--- a/src/puppet/bootstrap/environments/simp/hieradata/simp_classes.yaml
+++ b/src/puppet/bootstrap/environments/simp/hieradata/simp_classes.yaml
@@ -22,26 +22,26 @@ classes:
   # Virus scanning.
   - 'clamav'
   # Ensuring reasonably sane defaults for both at and common.
-  - 'common::at'
-  - 'common::cron'
-  - 'common::chkrootkit'
-  - 'common::etc_default::nss'
-  - 'common::etc_default::useradd'
-  - 'common::host_conf'
-  - 'common::incron'
-  - 'common::issue'
-  - 'common::libuser_conf'
-  - 'common::login_defs'
-  - 'common::localusers'
-  - 'common::modprobe_blacklist'
-  - 'common::nsswitch'
-  - 'common::prelink'
-  - 'common::profile_settings'
-  - 'common::resolv'
-  - 'common::secure_mountpoints'
-  - 'common::sysconfig::init'
-  - 'common::sysctl'
-  - 'common::timezone'
+  - 'simplib::at'
+  - 'simplib::cron'
+  - 'simplib::chkrootkit'
+  - 'simplib::etc_default::nss'
+  - 'simplib::etc_default::useradd'
+  - 'simplib::host_conf'
+  - 'simplib::incron'
+  - 'simplib::issue'
+  - 'simplib::libuser_conf'
+  - 'simplib::login_defs'
+  - 'simplib::localusers'
+  - 'simplib::modprobe_blacklist'
+  - 'simplib::nsswitch'
+  - 'simplib::prelink'
+  - 'simplib::profile_settings'
+  - 'simplib::resolv'
+  - 'simplib::secure_mountpoints'
+  - 'simplib::sysconfig::init'
+  - 'simplib::sysctl'
+  - 'simplib::timezone'
   - 'ntpd'
   - 'openldap::pam'
   # Set up the access.conf basics, allow root locally and deny
@@ -65,7 +65,7 @@ classes:
   # technically optional.
   - 'simp::base_services'
   # This sets up an update schedule.
-  # You should set variables under the common::yum_schedule namespace to
+  # You should set variables under the simplib::yum_schedule namespace to
   # disable updates from specific repositories.
   - 'simp::yum'
   # Set up the SSH server and client.

--- a/src/puppet/bootstrap/environments/simp/hieradata/simp_def.yaml
+++ b/src/puppet/bootstrap/environments/simp/hieradata/simp_def.yaml
@@ -122,4 +122,4 @@ simp::yum::servers :
   - "%{hiera('puppet::server')}"
 
 # Management of Specific Classes
-common::runlevel : '3'
+simplib::runlevel : '3'


### PR DESCRIPTION
Replaced `common::` with `simplib::`

SIMP-630 #comment migrated default hieradata in 5.1.X

Change-Id: I8f05d0901b309a428b6107ce88923b092def5f42