### PR TITLE
SIMP-595  Update a comment in Kickstart file

### DIFF
--- a/src/DVD/ks/pupclient_x86_64.cfg
+++ b/src/DVD/ks/pupclient_x86_64.cfg
@@ -1,7 +1,7 @@
 # Replace the following strings in this file
 # #BOOTPASS# - Your SHA-512 hashed bootloader password
 # #ROOTPASS# - Your SHA-512 hashed root password
-# #KSSERVER# - The IP address of your YUM server
+# #KSSERVER# - The IP address of your Kickstart server
 # #YUMSERVER# - The IP address of your YUM server
 # #LINUXDIST# - The LINUX Distribution you are kickstarting
 #        - Current CASE SENSITIVE options: RedHat CentOS


### PR DESCRIPTION
    this change updates a comment in the kickstart file pupclient
    it incorrectly used YUM server instead of kickstart server

SIMP-595  #close