### PR TITLE
(SIMP-687) Update dependencies

### DIFF
--- a/src/Rakefile
+++ b/src/Rakefile
@@ -49,6 +49,11 @@ class SrcPkg < Simp::Rake::Pkg
     reqstatements = []
 
     if generate then
+      content = File.read(autoreq_file).strip
+      if !content || content.empty?
+        raise "Error: The '#{autoreq_file}' file is empty!"
+      end
+
       File.read(autoreq_file).each_line do |req|
         req.strip!
         next if req.empty? or req =~ /\s*#/

--- a/src/build/simp.spec
+++ b/src/build/simp.spec
@@ -1,7 +1,7 @@
 Summary: SIMP Full Install
 Name: simp
 Version: 5.1.0
-Release: 1%{?snapshot_release}
+Release: 2%{?snapshot_release}
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -77,6 +77,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Fri Dec 04 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.1.0-2
+- Update to properly include the dependencies in the main simp RPM
+
 * Fri Dec 04 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.1.0-1
 - Included missing documentation updates
 - Fixed the simp-bootstrap version update which missed the common -> simplib


### PR DESCRIPTION
The 5.1.0-1 build inadvertently omitted the automatically generated
dependencies for the main 'simp' RPM.

This update corrects that omission

SIMP-687 #close

Change-Id: I5baee45d943585dc273ee44f7436da18e1123408