### PR TITLE
(SIMP-712) Disable remote OS repos on the puppet server by default

### DIFF
--- a/src/puppet/bootstrap/environments/simp/hieradata/hosts/puppet.your.domain.yaml
+++ b/src/puppet/bootstrap/environments/simp/hieradata/hosts/puppet.your.domain.yaml
@@ -8,12 +8,13 @@ apache::conf::allowroot : "%{alias('client_nets')}"
 
 rsync::server : '127.0.0.1'
 
-# Disable hooking to the remote SIMP repos so that the local filesystem is
+# Disable hooking to the remote SIMP and OS repos so that the local filesystem is
 # always hit first.
 #
 # You should change this if using external yum repositories.
 #
 simp::yum::enable_simp_repos : false
+simp::yum::enable_os_repos : false
 
 # Enable PuppetDB on this system by default
 simp::server::enable_puppetdb : true


### PR DESCRIPTION
In connection with SIMP-707, simp::yum::enable_os_repos needs
to be set to false in the default puppet server hieradata.

SIMP-712 #comment 4.2.X