### PR TITLE
SIMP-689 move submodules checkout to librarian

### DIFF
--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -138,7 +138,7 @@ mod 'simp-logrotate',
   :ref => 'master'
 mod 'simp-logstash',
   :git => 'git://github.com/simp/puppet-logstash',
-  :ref => 'master'
+  :ref => 'simp-master'
 mod 'simp-mcafee',
   :git => 'git://github.com/simp/pupmod-simp-mcafee',
   :ref => 'master'


### PR DESCRIPTION
This fix updates 4.2 so that the Gem updates, build:bundle, refers to
the librarian list of modules.  It also updates an error in the Puppetfile.tracking for logstash.

(SIMP-689) #updated