### PR TITLE
(SIMP-722) Add latest Hiera package

### DIFF
--- a/build/yum_data/SIMP4.2.0_CentOS6.7_x86_64/packages.yaml
+++ b/build/yum_data/SIMP4.2.0_CentOS6.7_x86_64/packages.yaml
@@ -171,8 +171,8 @@ haveged:
   :rpm_name: haveged-1.9.1-2.el6.x86_64.rpm
   :source: http://lug.mtu.edu/epel/6/x86_64/haveged-1.9.1-2.el6.x86_64.rpm
 hiera:
-  :source: https://dl.bintray.com/simp/4.2.X/hiera-3.0.2-1.el6.noarch.rpm
-  :rpm_name: hiera-3.0.2-1.el6.noarch.rpm
+  :source: https://dl.bintray.com/simp/4.2.X/hiera-3.0.5-1.el6.noarch.rpm
+  :rpm_name: hiera-3.0.5-1.el6.noarch.rpm
 hmaccalc:
   :rpm_name: hmaccalc-0.9.12-2.el6.x86_64.rpm
   :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.7/os/x86_64/Packages/hmaccalc-0.9.12-2.el6.x86_64.rpm

--- a/build/yum_data/SIMP4.2.0_RHEL6.7_x86_64/packages.yaml
+++ b/build/yum_data/SIMP4.2.0_RHEL6.7_x86_64/packages.yaml
@@ -588,8 +588,8 @@ sendmail-milter:
   :rpm_name: sendmail-milter-8.14.4-9.el6.x86_64.rpm
   :source: http://mirror.netdepot.com/centos/6.7/os/x86_64/Packages/sendmail-milter-8.14.4-9.el6.x86_64.rpm
 hiera:
-  :rpm_name: hiera-3.0.2-1.el6.noarch.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/hiera-3.0.2-1.el6.noarch.rpm
+  :rpm_name: hiera-3.0.5-1.el6.noarch.rpm
+  :source: https://dl.bintray.com/simp/4.2.X/hiera-3.0.5-1.el6.noarch.rpm
 simp-lastbind:
   :rpm_name: simp-lastbind-2.4.23-0.x86_64.rpm
   :source: https://dl.bintray.com/simp/4.2.X-Ext/simp-lastbind-2.4.23-0.x86_64.rpm


### PR DESCRIPTION
The Epoch for Hiera was changed in EPEL so we needed to upload a
corresponding change to our distributed repositories.

SIMP-722 #comment Update for 4.2.X