### PR TITLE
(SIMP-773) Fixed typo in auto.cfg

### DIFF
--- a/src/DVD/ks/dvd/auto.cfg
+++ b/src/DVD/ks/dvd/auto.cfg
@@ -122,7 +122,7 @@ if [ -d "${src_dir}" ]; then
       cp -a "${src_dir}/vmlinuz" "${rsync_target}"
       cp -a "${src_dir}/initrd.img" "${rsync_target}"
       chown -R root.nobody "${rsync_target}"
-      chmod 750 "{rsync_target}"
+      chmod 750 "${rsync_target}"
       find "${rsync_target}" -type f -exec chmod 644 {} \;
       popd
 


### PR DESCRIPTION
Setting the mode on the rsync directory was missing a '$' which made the
statement useless.

SIMP-773 #close

Change-Id: I03282f6ad3351db927b28b25bdd1d5d8e9988d2f