### PR TITLE
(SIMP-767) Add rake task to build ISO from scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ src/rubygems
 src/doc
 src/rsync
 /.tmp
+.*.sw?
+SIMP_ISO
+SIMP_ISO_STAGING

--- a/Gemfile
+++ b/Gemfile
@@ -1,24 +1,11 @@
-# Gemfile for bundler (gem install bundler)
+# Variables:
 #
-# To update all gem dependencies:
-#
-#   bundle
-#
-# To build a tar ball:
-#   bundle exec rake tar:build[epel-6-x86_64]
-# ruby=2.1
+# SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
+# PUPPET_VERSION   | specifies the version of the puppet gem to load
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
+gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
-
-# Allow a comma or space-delimited list of gem servers
-if simp_gem_server =  ENV.fetch( 'SIMP_GEM_SERVERS', false )
-  simp_gem_server.split( / |,/ ).each{ |gem_server|
-    source gem_server
-  }
-else
-  # watch the name, or RVM will flip out
-  source 'https://rubygems.org'
-end
-
+gem_sources.each { |gem_source| source gem_source }
 
 # In offline CI environments, the only copy of simp-rake-helpers will be in the
 # local source tree.  Unless the SIMP_NO_LOCAL_RAKE_HELPERS environment variable
@@ -34,10 +21,11 @@ end
 gem 'bundler'
 gem 'rake'
 gem 'coderay'
-gem 'puppet'
+gem 'puppet', puppetversion
 gem 'puppet-lint'
 gem 'puppetlabs_spec_helper'
-gem 'simp-rake-helpers', '>=1.0.11'
+gem 'simp-rake-helpers', '>=1.0.13'
+gem 'simp-build-helpers', '>=0.1.0'
 gem 'parallel'
 gem 'dotenv'
 gem 'ruby-progressbar'

--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -97,9 +97,6 @@ mod 'simp-dhcp',
 mod 'simp-elasticsearch',
   :git => 'git://github.com/simp/puppet-elasticsearch',
   :ref => 'simp-master'
-mod 'simp-foreman',
-  :git => 'https://github.com/simp/pupmod-simp-foreman',
-  :ref => 'master'
 mod 'simp-freeradius',
   :git => 'git://github.com/simp/pupmod-simp-freeradius',
   :ref => 'master'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,55 @@
 ## SIMP Core
 
-This is the 4.2 series of the SIMP supermodule.
+This is the 4.2 series of the [SIMP](https://github.com/NationalSecurityAgency/SIMP) supermodule.
 
-This branch supports RHEL/CentOS 6.6
+
+1. [Supported releases](#supported-releases)
+2. [Building the SIMP ISO](#building-the-simp-iso)
+  1. [Prerequisites](#prerequisites)
+  2. [Quickstart](#quickstart)
+  3. [Full build procedure](#full-procedure)
+3. [Links](#links)
+
+
+## Supported releases
+This branch supports:
+  - [RHEL 6.7](https://access.redhat.com/downloads/)
+  - CentOS 6.7
+    - [Disc 1](http://isoredirect.centos.org/centos/6.7/isos/x86_64/CentOS-6.7-x86_64-bin-DVD1.iso)
+    - [Disc 2](http://isoredirect.centos.org/centos/6.7/isos/x86_64/CentOS-6.7-x86_64-bin-DVD2.iso)
+
+
+## Building the SIMP ISO
+
+
+**NOTE** The following examples use the Disc 1 and Disc 2 of the CentOS 6.7 distribution above.
+
+### Prerequisites
+   - You must first:
+     - [Set up your build environment](https://simp-project.atlassian.net/wiki/display/SD/Setting+up+your+build+environment)
+     - Download an appropriate source ISO to overlay (in this example
+     - If building the release tarballs from scratch:
+        - ~70GB free in the mock root directory (generally this is `/var/lib/mock`)
+
+### Quickstart
+
+
+The minimum necessary command to build SIMP from scratch is:
+```bash
+bundle exec rake build:auto[4.2.X,path/to/directory/holding/CentOS/ISOs]
+```
+
+
+If building from published [release tarball](https://bintray.com/artifact/download/simp/Releases/SIMP-DVD-CentOS-4.2.0-1.tar.gz):
+```bash
+bundle exec rake build:auto[4.2.X,path/to/directory/holding/CentOS/ISOs,path/to/SIMP-DVD-CentOS-5.1.0-2.tar.gz]
+```
+
+
+### Full procedure
+There is full procedure for [compiling the SIMP tarball and ISO](https://simp-project.atlassian.net/wiki/display/SD/Compiling+the+SIMP+Tarball+and+ISO) in the [SIMP Development](https://simp-project.atlassian.net/wiki/display/SD/) documentation.
+
+## Links
+- [SIMP master repository](https://github.com/NationalSecurityAgency/SIMP)
+- [SIMP Development documentation](https://simp-project.atlassian.net/wiki/display/SD)
+- [SIMP admin/user documentation](http://simp.readthedocs.org/en/latest/)

--- a/Rakefile
+++ b/Rakefile
@@ -54,7 +54,8 @@ CLEAN.include(
   "#{DIST_DIR}/*",
   ".discinfo",
   DVD_DIR,
-  "#{BUILD_DIR}/SIMP"
+  "#{BUILD_DIR}/SIMP",
+  "#{BASEDIR}/SIMP_ISO*"
 )
 
 CLOBBER.include(

--- a/build/GPGKEYS/build/simp-gpgkeys.spec
+++ b/build/GPGKEYS/build/simp-gpgkeys.spec
@@ -4,7 +4,7 @@ Version: 2.0.0
 Release: 3%{?dist}
 License: Public Domain
 Group: Applications/System
-Source: %{name}-%{version}-3.tar.gz
+Source: %{name}-%{version}-%{release}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Buildarch: noarch
 Requires: facter

--- a/build/release_mappings.yaml
+++ b/build/release_mappings.yaml
@@ -1,0 +1,83 @@
+---
+# This file houses the *officially supported* SIMP release combinations
+# Other build combinations may work, but unexpected issues may arise.
+simp_releases:
+  4.2.X:
+    flavors:
+      CentOS:
+        isos:
+          - name:     'CentOS-6.7-x86_64-bin-DVD1.iso'
+            size:     3895459840
+            checksum: 'c0c1a05d3d74fb093c6232003da4b22b0680f59d3b2fa2cb7da736bc40b3f2c5'
+          - name:     'CentOS-6.7-x86_64-bin-DVD2.iso'
+            size:     2154524672
+            checksum: 'f973ac2453af9815d2db944f3c7383bb3061b6b0c12fb58dadf843e1cad67ab6'
+        build_command: 'bundle exec rake build:auto[4.2.X,/path/to/CentOS-6.7/DVDs]'
+        mock:          'epel-6-x86_64'
+        os_version:   '6.7'
+      RedHat:
+        isos:
+          - name:     'rhel-server-6.7-x86_64-dvd.iso'
+            size:     3841982464
+            checksum: '0e0acb2a544f4d58f10292144161f40439734c6e98b13ba8c595372b20354bc5'
+        build_command: 'bundle exec rake build:auto[4.2.X,rhel-server-6.7-x86_64-dvd.iso]'
+        mock:          'epel-6-x86_64'
+        os_version:   '6.7'
+  4.2.0-1:
+    flavors:
+      CentOS:
+        isos:
+          - name:     'CentOS-6.7-x86_64-bin-DVD1.iso'
+            size:     3895459840
+            checksum: 'c0c1a05d3d74fb093c6232003da4b22b0680f59d3b2fa2cb7da736bc40b3f2c5'
+          - name:     'CentOS-6.7-x86_64-bin-DVD2.iso'
+            size:     2154524672
+            checksum: 'f973ac2453af9815d2db944f3c7383bb3061b6b0c12fb58dadf843e1cad67ab6'
+        build_command: 'bundle exec rake build:auto[4.2.X,/path/to/CentOS-6.7/DVDs]'
+        mock:          'epel-6-x86_64'
+        os_version:   '6.7'
+      RedHat:
+        isos:
+          - name:     'rhel-server-6.7-x86_64-dvd.iso'
+            size:     3841982464
+            checksum: '0e0acb2a544f4d58f10292144161f40439734c6e98b13ba8c595372b20354bc5'
+        build_command: 'bundle exec rake build:auto[4.2.0-1,rhel-server-6.7-x86_64-dvd.iso]'
+        mock:          'epel-6-x86_64'
+        os_version:   '6.7'
+  5.1.X:
+    flavors:
+      CentOS:
+        isos:
+          - name:     'CentOS-7-x86_64-DVD-1511.iso'
+            size:     4329570304
+            checksum: '907e5755f824c5848b9c8efbb484f3cd945e93faa024bad6ba875226f9683b16'
+        build_command: 'bundle exec rake build:auto[5.1.X,CentOS-7-x86_64-DVD-1511.iso]'
+        mock:          'epel-7-x86_64'
+        os_version:   '7.0'
+      RedHat:
+        isos:
+          - name:     'rhel-server-7.2-x86_64-dvd.iso'
+            size:     4043309056
+            checksum: '03f3a0291634335f6995534d829bd21ffaa0d000004dfeb1b2fb81052d64a4d5'
+        build_command: 'bundle exec rake build:auto[5.1.X,RedHat-7-x86_64-DVD-1511.iso]'
+        mock:          'epel-7-x86_64'
+        os_version:   '7.2'
+  5.1.0-2:
+    flavors:
+      CentOS:
+        isos:
+          - name:     'CentOS-7-x86_64-DVD-1503-01.iso'
+            size:     4310695936
+            checksum: '85bcf62462fb678adc0cec159bf8b39ab5515404bc3828c432f743a1b0b30157'
+        build_command: 'bundle exec rake bulid:auto[5.1.0-2,CentOS-7-x86_64-DVD-1503-01.iso]'
+        mock:          'epel-7-x86_64'
+        os_version:   '7.0'
+      RedHat:
+        isos:
+          - name:     'rhel-server-7.2-x86_64-dvd.iso'
+            size:     4043309056
+            checksum: '03f3a0291634335f6995534d829bd21ffaa0d000004dfeb1b2fb81052d64a4d5'
+        build_command: 'bundle exec rake build:auto[5.1.0-2,RedHat-7-x86_64-DVD-1511.iso]'
+        mock:          'epel-7-x86_64'
+        os_version:   '7.2'
+

--- a/build/yum_data/SIMP4.2.0_CentOS6.7_x86_64/packages.yaml
+++ b/build/yum_data/SIMP4.2.0_CentOS6.7_x86_64/packages.yaml
@@ -24,23 +24,23 @@ chkrootkit:
   :rpm_name: chkrootkit-0.49-9.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/chkrootkit-0.49-9.el6.x86_64.rpm
 clamav:
-  :rpm_name: clamav-0.98.7-1.el6.x86_64.rpm
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/clamav-0.98.7-1.el6.x86_64.rpm
+  :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/clamav-0.99-3.el6.x86_64.rpm
+  :rpm_name: clamav-0.99-3.el6.x86_64.rpm
 clamav-db:
-  :rpm_name: clamav-db-0.98.7-1.el6.x86_64.rpm
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/clamav-db-0.98.7-1.el6.x86_64.rpm
+  :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/clamav-db-0.99-3.el6.x86_64.rpm
+  :rpm_name: clamav-db-0.99-3.el6.x86_64.rpm
 clamav-devel:
-  :rpm_name: clamav-devel-0.98.7-1.el6.x86_64.rpm
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/clamav-devel-0.98.7-1.el6.x86_64.rpm
+  :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/clamav-devel-0.99-3.el6.x86_64.rpm
+  :rpm_name: clamav-devel-0.99-3.el6.x86_64.rpm
 clamav-milter:
-  :rpm_name: clamav-milter-0.98.7-1.el6.x86_64.rpm
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/clamav-milter-0.98.7-1.el6.x86_64.rpm
+  :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/clamav-milter-0.99-3.el6.x86_64.rpm
+  :rpm_name: clamav-milter-0.99-3.el6.x86_64.rpm
 clamav-unofficial-sigs:
   :rpm_name: clamav-unofficial-sigs-3.7.1-7.el6.noarch.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/clamav-unofficial-sigs-3.7.1-7.el6.noarch.rpm
 clamd:
-  :rpm_name: clamd-0.98.7-1.el6.x86_64.rpm
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/clamd-0.98.7-1.el6.x86_64.rpm
+  :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/clamd-0.99-3.el6.x86_64.rpm
+  :rpm_name: clamd-0.99-3.el6.x86_64.rpm
 clamsmtp:
   :rpm_name: clamsmtp-1.10-6.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/clamsmtp-1.10-6.el6.x86_64.rpm
@@ -126,8 +126,8 @@ globus-callout:
   :rpm_name: globus-callout-3.13-2.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-callout-3.13-2.el6.x86_64.rpm
 globus-common:
-  :rpm_name: globus-common-15.30-1.el6.x86_64.rpm
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-common-15.30-1.el6.x86_64.rpm
+  :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/globus-common-16.0-1.el6.x86_64.rpm
+  :rpm_name: globus-common-16.0-1.el6.x86_64.rpm
 globus-gsi-callback:
   :rpm_name: globus-gsi-callback-5.8-1.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-gsi-callback-5.8-1.el6.x86_64.rpm
@@ -141,20 +141,20 @@ globus-gsi-openssl-error:
   :rpm_name: globus-gsi-openssl-error-3.5-2.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-gsi-openssl-error-3.5-2.el6.x86_64.rpm
 globus-gsi-proxy-core:
-  :rpm_name: globus-gsi-proxy-core-7.7-2.el6.x86_64.rpm
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-gsi-proxy-core-7.7-2.el6.x86_64.rpm
+  :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/globus-gsi-proxy-core-7.9-1.el6.x86_64.rpm
+  :rpm_name: globus-gsi-proxy-core-7.9-1.el6.x86_64.rpm
 globus-gsi-proxy-ssl:
   :rpm_name: globus-gsi-proxy-ssl-5.7-2.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-gsi-proxy-ssl-5.7-2.el6.x86_64.rpm
 globus-gsi-sysconfig:
-  :rpm_name: globus-gsi-sysconfig-6.8-2.el6.x86_64.rpm
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-gsi-sysconfig-6.8-2.el6.x86_64.rpm
+  :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/globus-gsi-sysconfig-6.9-1.el6.x86_64.rpm
+  :rpm_name: globus-gsi-sysconfig-6.9-1.el6.x86_64.rpm
 globus-gss-assist:
   :rpm_name: globus-gss-assist-10.15-1.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-gss-assist-10.15-1.el6.x86_64.rpm
 globus-gssapi-gsi:
-  :rpm_name: globus-gssapi-gsi-11.22-1.el6.x86_64.rpm
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-gssapi-gsi-11.22-1.el6.x86_64.rpm
+  :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/globus-gssapi-gsi-11.25-1.el6.x86_64.rpm
+  :rpm_name: globus-gssapi-gsi-11.25-1.el6.x86_64.rpm
 globus-openssl-module:
   :rpm_name: globus-openssl-module-4.6-2.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-openssl-module-4.6-2.el6.x86_64.rpm
@@ -609,5 +609,5 @@ trousers:
   :rpm_name: trousers-0.3.13-2.el6.x86_64.rpm
   :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.7/os/x86_64/Packages/trousers-0.3.13-2.el6.x86_64.rpm
 voms:
-  :rpm_name: voms-2.0.12-3.el6.x86_64.rpm
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/voms-2.0.12-3.el6.x86_64.rpm
+  :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/voms-2.0.12-7.el6.x86_64.rpm
+  :rpm_name: voms-2.0.12-7.el6.x86_64.rpm

--- a/rakefiles/build_auto.rake
+++ b/rakefiles/build_auto.rake
@@ -1,0 +1,338 @@
+#!/usr/bin/rake -T
+
+require 'simp/rake'
+require 'json'
+include Simp::Rake
+
+class SIMPBuildException < Exception
+end
+
+require 'simp/build/release_mapper'
+namespace :build do
+  desc <<-EOM
+  Automatically detect and build a SIMP ISO for a target SIMP release.
+
+  This task runs all other build tasks
+
+  Arguments:
+    * :release     => SIMP release to build (e.g., '5.1.X')
+    - :iso_paths   => path to source ISO(s) (colon-delimited list of files/directories) [Default: '.']
+    - :tarball     => SIMP build tarball file; if given, skips tar build.  [Default: 'false']
+    - :output_dir  => path to write SIMP ISO.   [Default: './SIMP_ISO']
+    - :do_checksum => Use sha256sum checksum to compare each ISO.  [Default: 'false']
+    - :key_name    => Key name to sign packages [Default: 'dev']
+    - :packer_vars => Write a packer vars.json to go with this ISO [Default: 'true']
+    - :verbose     => Enable verbose reporting. [Default: 'false']
+
+  ENV vars:
+    - SIMP_BUILD_staging_dir    => Path to stage big build assets [Default: './SIMP_ISO_STAGING']
+    - SIMP_BUILD_rm_staging_dir => 'yes' forcibly removes the staging dir before starting
+    - SIMP_BUILD_force_dirty    => 'yes' tries to checks out subrepos even if dirty
+    - SIMP_BUILD_docs           => 'yes' builds & includes documentation
+    - SIMP_BUILD_bundle         => 'no' skips running bundle in each subrepo
+    - SIMP_BUILD_unpack         => 'no' skips the unpack section
+    - SIMP_BUILD_unpack_merge   => 'no' prevents auto-merging the unpacked DVD
+    - SIMP_BUILD_prune          => 'no' passes :prune=>false to iso:build
+    - SIMP_BUILD_iso_name       => Renames the output ISO filename [Default: false]
+    - SIMP_BUILD_iso_tag        => Appended to the output ISO's filename [Default: false]
+
+  Notes:
+    - To skip `tar:build` (including `pkg:build`), use the `tarball` argument
+  EOM
+
+  task :auto,  [:release,
+                :iso_paths,
+                :tarball,
+                :output_dir,
+                :do_checksum,
+                :key_name,
+                :packer_vars,
+                :verbose] do |t, args|
+    # set up data
+    # --------------------------------------------------------------------------
+
+    args.with_defaults(
+      :iso_paths   => Dir.pwd,
+      :tarball     => 'false',
+      :output_dir  => '',
+      :do_checksum => 'false',
+      :key_name    => 'dev',
+      :packer_vars => 'true',
+      :verbose     => 'false',
+    )
+
+    # locals
+    target_release   = args[:release]
+    iso_paths        = File.expand_path(args[:iso_paths])
+    tarball          = (args.tarball =~ /^(false|)$/ ? false : args.tarball)
+    output_dir       = args[:output_dir].sub(/^$/, File.expand_path( 'SIMP_ISO', Dir.pwd ))
+    do_checksum      = (args.do_checksum =~ /^$/ ? 'false' : args.do_checksum)
+    key_name         = args[:key_name]
+    staging_dir      = ENV.fetch('SIMP_BUILD_staging_dir',
+                                  File.expand_path( 'SIMP_ISO_STAGING', Dir.pwd ))
+    do_packer_vars   = (args.packer_vars == 'false' ? false : true)
+    verbose          = (args.verbose == 'false' ? false : true)
+
+    yaml_file        = File.expand_path('../build/release_mappings.yaml',
+                                          File.dirname(__FILE__))
+    pwd              = Dir.pwd
+    repo_root_dir    = File.expand_path( '..', File.dirname(__FILE__) )
+    method           = ENV.fetch('SIMP_BUILD_puppetfile','tracking')
+    do_rm_staging    = ENV['SIMP_BUILD_rm_staging_dir'] == 'yes'
+    do_docs          = ENV['SIMP_BUILD_docs'] == 'yes' ? 'true' : 'false'
+    do_unpack        = ENV['SIMP_BUILD_unpack'] != 'no'
+    do_merge         = ENV['SIMP_BUILD_unpack_merge'] != 'no'
+    do_prune         = ENV['SIMP_BUILD_prune'] != 'no' ? 'true' : 'false'
+    do_bundle        = ENV['SIMP_BUILD_bundle'] != 'no'
+    full_iso_name    = ENV.fetch('SIMP_BUILD_iso_name', false)
+    iso_name_tag     = ENV.fetch('SIMP_BUILD_iso_tag', false)
+    @dirty_repos     = nil
+    @simp_output_iso = nil
+
+
+    # Build environment sanity checks
+    # --------------------
+    if do_rm_staging && !do_unpack
+      fail SIMPBuildException, "ERROR: Mixing `SIMP_BUILD_rm_staging_dir=yes` and `SIMP_BUILD_unpack=no` is silly."
+    end
+
+    if File.exists?(output_dir) && !File.directory?(output_dir)
+      fail SIMPBuildException, "ERROR: ISO output dir exists but is not a directory:\n\n" +
+                               "    '#{output_dir}'\n\n"
+    end
+
+
+    # Look up ISOs against known build assets
+    # --------------------
+    target_data = get_target_data(target_release, iso_paths, yaml_file, do_checksum, verbose )
+
+    # IDEA: check for prequisite build tools
+
+    # check out subrepos
+    # --------------------
+    puts
+    puts '='*80
+    puts "## Checking out subrepositories"
+    puts '='*80
+    Dir.chdir repo_root_dir
+    Rake::Task['deps:status'].invoke
+    if @dirty_repos && !ENV['SIMP_BUILD_force_dirty'] == 'yes'
+      raise SIMPBuildException, "ERROR: Dirty repos detected!  I refuse to destroy uncommitted work."
+    else
+      puts
+      puts '-'*80
+      puts "#### Checking out subrepositories using method '#{method}'"
+      puts '-'*80
+      Rake::Task['deps:checkout'].invoke(method)
+    end
+
+    if do_bundle
+      puts
+      puts '-'*80
+      puts "#### Running bundler in all repos"
+      puts '     (Disable with `SIMP_BUILD_bundle=no`)'
+      puts '-'*80
+      Rake::Task['build:bundle'].invoke
+    else
+      puts
+      puts '-'*80
+      puts "#### SKIPPED: bundler in all repos"
+      puts '     (Force with `SIMP_BUILD_bundle=yes`)'
+      puts '-'*80
+    end
+
+    # build tarball
+    # --------------------
+    if tarball
+      puts
+      puts '-'*80
+      puts "#### Using pre-existing tarball:"
+      puts "           '#{tarball}'"
+      puts
+      puts '-'*80
+
+      ver=target_data['os_version'].split('.').first
+      repo_pkglist_file = File.expand_path( "src/DVD/#{ver}-simp_pkglist.txt",
+                                            repo_root_dir
+                                          )
+      if File.file? repo_pkglist_file
+        puts "#### setting SIMP_PKGLIST_FILE=#{repo_pkglist_file}"
+        ENV['SIMP_PKGLIST_FILE']=repo_pkglist_file
+      else
+        puts "#### WARNING: repo pkglist file not found:"
+        puts "              '#{repo_pkglist_file}'"
+        puts
+      end
+    else
+      puts
+      puts '='*80
+      puts "#### Running tar:build in all repos"
+      puts '='*80
+      @simp_tarballs = {}
+      Rake::Task['tar:build'].invoke(target_data['mock'],key_name,do_docs)
+      tarball = @simp_tarballs.fetch(target_data['flavor'])
+    end
+
+    # yum sync
+    # --------------------
+    puts
+    puts '-'*80
+    puts "#### rake build:yum:sync[#{target_data['flavor']},#{target_data['os_version']}]"
+    puts '-'*80
+    Rake::Task['build:yum:sync'].invoke(target_data['flavor'],target_data['os_version'])
+
+    # If you have previously downloaded packages from yum, you may need to run
+    # $ rake build:yum:clean_cache
+
+    # Optionally, you may drop in custom packages you wish to have available during an install into build/yum_data/SIMP<simp_version>_<CentOS or RHEL><os_version>_<architecture>/packages
+    # TODO: ENV var for optional packages
+
+    prepare_staging_dir( staging_dir, do_rm_staging, repo_root_dir, verbose )
+    Dir.chdir staging_dir
+
+    #
+    # --------------------
+    if do_unpack
+      puts
+      puts '='*80
+      puts "#### unpack ISOs into staging directory"
+      puts "     staging area: '#{staging_dir}'"
+      puts
+      puts "     (skip with `SIMP_BUILD_unpack=no`)"
+      puts '='*80
+      puts
+      target_data['isos'].each do |iso|
+        puts "---- rake unpack[#{iso}]"
+        Dir.glob( File.join(staging_dir, "#{target_data['flavor']}*/") ).each do |f|
+          FileUtils.rm_f( f , :verbose => verbose )
+        end
+        Rake::Task['unpack'].invoke(iso,do_merge,Dir.pwd,'isoinfo',target_data['os_version'])
+      end
+    else
+      puts
+      puts '='*80
+      puts "#### skipping ISOs unpack (because `SIMP_BUILD_unpack=no`)"
+      puts
+    end
+
+    puts
+    puts '='*80
+    puts "#### iso:build[#{tarball}]"
+    puts '='*80
+    puts
+
+    Rake::Task['iso:build'].invoke(tarball,staging_dir,do_prune)
+
+    output_file = full_iso_name ? full_iso_name : @simp_output_iso
+    if iso_name_tag
+      output_file.sub!(/\.iso$/i, "__#{iso_name_tag}.iso")
+    end
+
+    puts
+    puts '='*80
+    puts "#### Moving '#{@simp_output_iso}' into:"
+    puts "       '#{output_dir}/#{output_file}'"
+    puts '='*80
+    puts
+
+    iso = File.join(output_dir,output_file)
+    FileUtils.mkdir_p output_dir, :verbose => verbose
+    FileUtils.mv(@simp_output_iso, iso, :verbose => verbose)
+
+    # write vars.json for packer build
+    # --------------------------------------
+    vars_file = iso.sub(/.iso$/, '.json')
+    puts
+    puts '='*80
+    puts "#### Checksumming #{iso}..."
+    puts '='*80
+    puts
+
+    sum = `sha256sum "#{iso}"`.split(/ +/).first
+
+    puts
+    puts '='*80
+    puts "#### Writing packer data to:"
+    puts "       '#{vars_file}'"
+    puts '='*80
+    puts
+    packer_vars = {
+      'box_simp_release'   => target_release,
+      'box_distro_release' => "SIMP-#{target_release}-#{target_data['isos'].first.sub(/\.iso$|-x86_64/,'')}",
+      'iso_url'            => iso,
+      'iso_checksum'       => sum,
+      'iso_checksum_type'  => 'sha256',
+      'new_password'       => 'suP3rP@ssw0r!suP3rP@ssw0r!suP3rP@ssw0r!',
+      'output_directory'   => './OUTPUT',
+    }
+    File.open(vars_file, 'w'){|f| f.puts packer_vars.to_json }
+
+    puts
+    puts '='*80
+    puts "#### FINIS!"
+    puts '='*80
+    puts
+  end
+
+end
+
+def get_target_data(target_release, iso_paths, yaml_file, do_checksum, verbose )
+  puts '='*80
+  puts "## validating ISOs for target:"
+  puts "      '#{target_release}' in '#{iso_paths}'"
+  puts '='*80
+  puts
+
+  mapper          = Simp::Build::ReleaseMapper.new(target_release, yaml_file, do_checksum == 'true')
+  mapper.verbose  = true || verbose
+  target_data     = mapper.autoscan_unpack_list( iso_paths )
+
+  puts '-'*80
+  puts "## target data:"
+  puts ''
+  puts "     target release: '#{target_release}'"
+  puts "     target flavor:  '#{target_data['flavor']}'"
+  puts "     source isos:"
+  target_data['isos'].each do |iso|
+    puts "        - #{iso}"
+  end
+  puts '-'*80
+  puts
+  sleep 3.seconds
+
+  target_data
+end
+
+
+def prepare_staging_dir( staging_dir, do_rm_staging, repo_root_dir, verbose )
+  if ['','/',Dir.home,repo_root_dir].include? staging_dir
+    fail SIMPBuildException,
+         "ERROR: staging directoy path is too stupid to be believed:\n"+
+         "         '#{staging_dir}'\n\n" +
+         "       Use SIMP_BUILD_staging_dir='path/to/staging/dir'\n\n"
+  end
+  if do_rm_staging
+    puts
+    puts '-'*80
+    puts '#### Ensuring previous staging directory is removed:'
+    puts "       '#{staging_dir}'"
+    puts
+    puts '     (disable this with `SIMP_BUILD_rm_staging_dir=no`)'
+    puts '-'*80
+
+    FileUtils.rm_rf staging_dir, :verbose => verbose
+  elsif File.exists? staging_dir
+    warn ''
+    warn '!'*80
+    warn '#### WARNING: staging dir already exists at:'
+    warn "              '#{staging_dir}'"
+    warn ''
+    warn '              - Previously staged assets in this directory may cause problems.'
+    warn '              - Use `SIMP_BUILD_rm_staging_dir=yes` to remove it automatically.'
+    warn ''
+    warn '!'*80
+    warn ''
+    sleep 10.seconds
+  end
+  FileUtils.mkdir_p staging_dir, :verbose => verbose
+end

--- a/rakefiles/deps.rake
+++ b/rakefiles/deps.rake
@@ -133,6 +133,7 @@ namespace :deps do
   EOM
   task :status, [:method] do |t,args|
     args.with_defaults(:method => 'tracking')
+    @dirty_repos = nil
 
     fake_lp = FakeLibrarian.new("Puppetfile.#{args[:method]}")
     mods_with_changes = {}
@@ -157,9 +158,12 @@ namespace :deps do
 
     if mods_with_changes.empty?
       puts "No repositories have changes."
+      @dirty_repos = false
     else
       puts "The following repositories have changes:"
       puts mods_with_changes.map{|k,v| "  + #{k} => #{v}"}.join("\n")
+
+      @dirty_repos = true
     end
 
     unknown_mods = fake_lp.unknown_modules

--- a/rakefiles/iso.rake
+++ b/rakefiles/iso.rake
@@ -101,7 +101,7 @@ Build the SIMP ISO(s).
 
       iso_dirs = Dir.glob("#{File.expand_path(args.unpacked_dvds)}/#{baseos}*")
       if iso_dirs.empty?
-        fail("Error: No unpacked DVD directories found for '#{baseos}'")
+        fail("Error: No unpacked DVD directories found for '#{baseos}' under '#{File.expand_path(args.unpacked_dvds)}'")
       end
 
       # Process each unpacked base OS ISO directory found
@@ -149,7 +149,20 @@ Build the SIMP ISO(s).
         rescue
           # Does not matter if the command fails
         end
-        if (args.prune.casecmp("false") != 0) && File.exist?("#{dir}/#{baseosver.split('.').first}-simp_pkglist.txt")
+        pkglist_file = ENV.fetch(
+                                 'SIMP_PKGLIST_FILE',
+                                  File.join(dir,"#{baseosver.split('.').first}-simp_pkglist.txt")
+                                )
+        puts
+        puts '-'*80
+        puts "### Pruning packages not in file '#{pkglist_file}'"
+        puts
+        puts '   (override this with `SIMP_PKGLIST_FILE=<file>`)'
+        puts
+        puts '-'*80
+        puts
+
+        if (args.prune.casecmp("false") != 0) && File.exist?(pkglist_file)
           exclude_pkgs = Array.new
           File.read("#{dir}/#{baseosver.split('.').first}-simp_pkglist.txt").each_line do |line|
             next if line =~ /^(\s+|#.*)$/
@@ -224,7 +237,8 @@ Build the SIMP ISO(s).
 
         # Do some sane chmod'ing and build ISO
         system("chmod -fR u+rwX,g+rX,o=g #{dir}")
-        system("mkisofs -uid 0 -gid 0 -o SIMP-#{simpver}-#{baseos}-#{baseosver}-#{arch}.iso -b isolinux/isolinux.bin -c boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -r -m TRANS.TBL #{dir}")
+        @simp_output_iso = "SIMP-#{simpver}-#{baseos}-#{baseosver}-#{arch}.iso"
+        system("mkisofs -uid 0 -gid 0 -o #{@simp_output_iso} -b isolinux/isolinux.bin -c boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -r -m TRANS.TBL #{dir}")
       end
     end # End of tarfiles loop
   end

--- a/rakefiles/pkg.rake
+++ b/rakefiles/pkg.rake
@@ -125,7 +125,7 @@ namespace :pkg do
         end
 
         if days_left > 0
-          puts "GPG key will expire in #{days_left} days." 
+          puts "GPG key will expire in #{days_left} days."
         else
           puts "Generating new GPG key"
 
@@ -518,32 +518,39 @@ protect=1
         end
       end
 
-      Dir.chdir(temp_pkg_dir) {
+      Dir.chdir(temp_pkg_dir) do
         repo_files = []
         Dir.glob('repos/*').each do |repo|
           if File.directory?(repo)
-            Dir.chdir(repo) {
-              sh %{createrepo .}
-            }
+            Dir.chdir(repo) { sh %{createrepo .} }
 
             repo_name = File.basename(repo)
             repo_path = File.expand_path(repo)
             conf_file = "#{temp_pkg_dir}/#{repo_name}.conf"
 
-            File.open(conf_file,'w') { |file|
+            File.open(conf_file,'w') do |file|
               file.write(ERB.new(yum_repo_template,nil,'-').result(binding))
-            }
+            end
 
             repo_files << conf_file
           end
         end
 
-        File.open('yum.conf', 'w') { |file|
+        File.open('yum.conf', 'w') do |file|
           file.write(ERB.new(yum_conf_template,nil,'-').result(binding))
-        }
+        end
 
-        sh %{repoclosure -c repodata -n -t -r base -l lookaside -c yum.conf}
-      }
+        cmd = 'repoclosure -c repodata -n -t -r base -l lookaside -c yum.conf'
+
+        if ENV['SIMP_BUILD_verbose'] == 'yes'
+          puts
+          puts '-'*80
+          puts "#### RUNNING: `#{cmd}`"
+          puts "     in path '#{Dir.pwd}'"
+          puts '-'*80
+        end
+        sh cmd
+      end
     ensure
       remove_entry_secure temp_pkg_dir
     end

--- a/rakefiles/tar.rake
+++ b/rakefiles/tar.rake
@@ -99,6 +99,7 @@ namespace :tar do
     end
 
     #Seeing race conditions when this is parallelized.
+    @simp_tarballs = {}
     TARGET_DISTS.each do |dist|
       base_dir = "#{DVD_DIR}/#{dist}/staging"
       dvd_name = [ 'SIMP', 'DVD', dist, get_simp_version ]
@@ -109,6 +110,7 @@ namespace :tar do
       end
 
       puts "Package DVD: #{DVD_DIR}/#{dvd_tarball}"
+      @simp_tarballs[dist] = "#{DVD_DIR}/#{dvd_tarball}"
       rm_rf(base_dir)
     end
   end

--- a/rakefiles/unpack.rake
+++ b/rakefiles/unpack.rake
@@ -8,19 +8,24 @@ desc "Unpack an ISO. Unpacks either a RHEL or CentOS ISO into
  * :targetdir - The parent directory for the to-be-created directory
    containing the unpacked ISO. Defaults to the current directory.
  * :isoinfo - The isoinfo executable to use to extract stuff from the ISO.
-   Defaults to 'isoinfo'."
-task :unpack,[:iso_path, :merge, :targetdir, :isoinfo] do |t,args|
+   Defaults to 'isoinfo'.
+ * :version - optional override for the <version> number (e.g., '7.0' instead of '7')
+
+"
+task :unpack,[:iso_path, :merge, :targetdir, :isoinfo, :version] do |t,args|
   args.with_defaults(
-    :iso_path => '',
-    :isoinfo   => 'isoinfo',
-    :targetdir => Dir.pwd,
-    :merge     => false
+    :iso_path   => '',
+    :isoinfo    => 'isoinfo',
+    :targetdir  => Dir.pwd,
+    :merge      => false,
+    :version => false,
   )
 
-  iso_path = args.iso_path
-  iso_info = which(args.isoinfo)
-  targetdir = args.targetdir
-  merge = args.merge
+  iso_path   = args.iso_path
+  iso_info   = which(args.isoinfo)
+  targetdir  = args.targetdir
+  merge      = args.merge
+  version = args.version
 
   # Checking for valid arguments
   File.exist?(args.iso_path) or
@@ -38,14 +43,14 @@ task :unpack,[:iso_path, :merge, :targetdir, :isoinfo] do |t,args|
     #   rhel-server-<version>-<arch>-<whatever>
     'rhel' => {
       'baseos'  => 'RHEL',
-      'version' => pieces[2],
+      'version' => version || pieces[2],
       'arch'    => pieces[3]
     },
     # CentOS structure as provided from the CentOS website:
     #   CentOS-<version>-<arch>-<whatever>
     'CentOS' => {
       'baseos'  => 'CentOS',
-      'version' => pieces[1],
+      'version' => version || pieces[1],
       'arch'    => pieces[2]
     }
   }


### PR DESCRIPTION
Before this commit, building a SIMP ISO was an awkward mix of manual
and automated tasks.  The patch automates the entire SIMP build process
(assuming a few perquisites) using the new rake task `build:auto`.

SIMP-767 #comment Update for 4.2.X
SIMP-782 #close