### PR TITLE
(SIMP-685) 5.1 Does not allow ldap to be turned off

### DIFF
--- a/src/puppet/bootstrap/environments/simp/hieradata/simp_classes.yaml
+++ b/src/puppet/bootstrap/environments/simp/hieradata/simp_classes.yaml
@@ -43,7 +43,6 @@ classes:
   - 'simplib::sysctl'
   - 'simplib::timezone'
   - 'ntpd'
-  - 'openldap::pam'
   # Set up the access.conf basics, allow root locally and deny
   # everyone else from everywhere by default.
   - 'pam::access'


### PR DESCRIPTION
The default simp classes included openldap::pam which
requires variables that are set when you select LDAP.
It seems, from testing, this module is not required if
LDAP is not used so it is removed from default list.
If use_ldap is set to true simp/init.pp includes it.

SIMP-685 #close