### PR TITLE
(SIMP-717) unpack_dvd handles not existent directories

### DIFF
--- a/src/utils/scripts/bin/unpack_dvd
+++ b/src/utils/scripts/bin/unpack_dvd
@@ -139,10 +139,13 @@ end
 
 opts.parse!
 
+# Option checking
 if not ARGV.length > 0 then
   $stderr.puts("Error: You must pass the path to an ISO to unpack\n\n#{opts}")
   exit 1
 end
+fail("Could not find a SIMP default output directory and no --dest option provided") unless options[:dest]
+fail("Destination directory does not exist") if not File.directory?(options[:dest])
 
 discattrs = {
   :family => nil,
@@ -151,8 +154,6 @@ discattrs = {
   :path => nil
 }
 
-# Option checking
-fail("Could not find a SIMP default output directory and no --dest option provided") unless options[:dest]
 
 discattrs[:path] = ARGV.first
 if not File.readable?(discattrs[:path]) then


### PR DESCRIPTION
Prior to this commit, unpack_dvd did not check for the
existence of the unpack directory.

SIMP-717 #comment unpack_dvd 4.2