### PR TITLE
(SIMP-899) Fix output bug in `rake build:auto`

### DIFF
--- a/rakefiles/build_auto.rake
+++ b/rakefiles/build_auto.rake
@@ -236,7 +236,7 @@ namespace :build do
     puts
 
     iso = File.join(output_dir,output_file)
-    FileUtils.mkdir_p output_dir, :verbose => verbose
+    FileUtils.mkdir_p File.dirname(iso), :verbose => verbose
     FileUtils.mv(@simp_output_iso, iso, :verbose => verbose)
 
     # write vars.json for packer build


### PR DESCRIPTION
Before this commit, `rake build:auto` would fail if the `mkdir_p
output_dir` did not create all the required directories.  This patch
expands the scope of the `mkdir_p` and prevents last-minute failures
within CI builds.

SIMP-899 #close #comment Fixed for 5.1.X