### PR TITLE
(SIMP-870) Updated mcollective-common dependency

### DIFF
--- a/build/yum_data/SIMP4.2.0_CentOS6.7_x86_64/packages.yaml
+++ b/build/yum_data/SIMP4.2.0_CentOS6.7_x86_64/packages.yaml
@@ -265,7 +265,7 @@ mcollective-client:
   :source: http://yum.puppetlabs.com/el/6/products/x86_64/mcollective-client-2.8.4-1.el6.noarch.rpm
 mcollective-common:
   :rpm_name: mcollective-common-2.2.3-1.SIMP.1.el6.noarch.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/mcollective-common-2.2.3-1.SIMP.1.el6.noarch.rpm
+  :source: https://dl.bintray.com/simp/4.2.X/mcollective-common-2.2.3-1.SIMP.1.el6.noarch.rpm
 mcollective-filemgr-agent:
   :source: http://yum.puppetlabs.com/el/6/products/x86_64/mcollective-filemgr-agent-1.1.0-1.el6.noarch.rpm
   :rpm_name: mcollective-filemgr-agent-1.1.0-1.el6.noarch.rpm
@@ -603,5 +603,5 @@ trousers:
   :rpm_name: trousers-0.3.13-2.el6.x86_64.rpm
   :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.7/os/x86_64/Packages/trousers-0.3.13-2.el6.x86_64.rpm
 voms:
-  :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/voms-2.0.12-7.el6.x86_64.rpm
-  :rpm_name: voms-2.0.12-7.el6.x86_64.rpm
+  :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/voms-2.0.13-1.el6.x86_64.rpm
+  :rpm_name: voms-2.0.13-1.el6.x86_64.rpm


### PR DESCRIPTION
The mcollective-common package needed to be updated to meet the new
dependency chain.

Brought voms along for the ride.

SIMP-870 #comment mcollective-common dependency updated