### PR TITLE
(SIMP-962) Update openssh-ldap package

### DIFF
--- a/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/packages.yaml
+++ b/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/packages.yaml
@@ -203,6 +203,9 @@ mcollective-sysctl-data:
 mod_ldap:
   :rpm_name: mod_ldap-2.4.6-40.el7.centos.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/centos/7.2.1511/os/x86_64/Packages/mod_ldap-2.4.6-40.el7.centos.x86_64.rpm
+openssh-ldap:
+  :rpm_name: openssh-ldap-6.6.1p1-22.el7.x86_64.rpm
+  :source: http://mirror.cogentco.com/pub/linux/centos/7.2.1511/os/x86_64/Packages/openssh-ldap-6.6.1p1-22.el7.x86_64.rpm
 pdsh:
   :rpm_name: pdsh-2.29-1el7.x86_64.rpm
   :source: https://dl.bintray.com/simp/5.1.X-Ext/pdsh-2.29-1el7.x86_64.rpm

--- a/build/yum_data/SIMP5.1.0_RHEL7.1_x86_64/packages.yaml
+++ b/build/yum_data/SIMP5.1.0_RHEL7.1_x86_64/packages.yaml
@@ -231,22 +231,22 @@ mod_ldap:
   :rpm_name: mod_ldap-2.4.6-40.el7.x86_64.rpm
   :source: Red Hat Optional Repository
 openssh:
-  :rpm_name: openssh-6.6.1p1-12.el7_1.x86_64.rpm
+  :rpm_name: openssh-6.6.1p1-22.el7_1.x86_64.rpm
   :source: Red Hat Updates Repository
 openssh-askpass:
-  :rpm_name: openssh-askpass-6.6.1p1-12.el7_1.x86_64.rpm
+  :rpm_name: openssh-askpass-6.6.1p1-22.el7_1.x86_64.rpm
   :source: Red Hat Updates Repository
 openssh-clients:
-  :rpm_name: openssh-clients-6.6.1p1-12.el7_1.x86_64.rpm
+  :rpm_name: openssh-clients-6.6.1p1-22.el7_1.x86_64.rpm
   :source: Red Hat Updates Repository
 openssh-keycat:
-  :rpm_name: openssh-keycat-6.6.1p1-12.el7_1.x86_64.rpm
+  :rpm_name: openssh-keycat-6.6.1p1-22.el7_1.x86_64.rpm
   :source: Red Hat Updates Repository
 openssh-ldap:
-  :rpm_name: openssh-ldap-6.6.1p1-12.el7_1.x86_64.rpm
+  :rpm_name: openssh-ldap-6.6.1p1-22.el7_1.x86_64.rpm
   :source: Red Hat Optional Repository
 openssh-server:
-  :rpm_name: openssh-server-6.6.1p1-12.el7_1.x86_64.rpm
+  :rpm_name: openssh-server-6.6.1p1-22.el7_1.x86_64.rpm
   :source: Red Hat Updates Repository
 pdsh:
   :rpm_name: pdsh-2.29-1el7.x86_64.rpm


### PR DESCRIPTION
The openssh-ldap package is not part of the base disc and needs to be
present if using nscd.

SIMP-962 #comment Update openssh-ldap package

Change-Id: I544c859c50d60fa124d41934701a31a436413162