### PR TITLE
(SIMP-96) Updated to move from Librarian to R10k

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,12 +24,11 @@ gem 'coderay'
 gem 'puppet', puppetversion
 gem 'puppet-lint'
 gem 'puppetlabs_spec_helper'
-gem 'simp-rake-helpers', '~>1.1'
+gem 'simp-rake-helpers', '~>2.0'
 gem 'simp-build-helpers', '>=0.1.0'
 gem 'parallel'
 gem 'dotenv'
 gem 'ruby-progressbar'
-gem 'librarian-puppet-pr328', '>=2.2.3'
 
 # nice-to-have gems (for debugging)
 group :debug do

--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -1,285 +1,375 @@
-forge 'https://forgeapi.puppetlabs.com'
+# refs recorded for SIMP release 4.2.0-3
 
-# Build Repositories
-mod 'simp_doc',
-  :git  => 'git://github.com/simp/simp-doc',
-  :ref  => 'simp-4.2.X',
-  :path => './src/doc'
-mod 'simp_rsync',
-  :git  => 'git://github.com/simp/simp-rsync',
-  :ref => 'simp-4.2.X',
-  :path => './src/rsync'
-mod 'rubygems-simp-cli',
-  :git  => 'git://github.com/simp/rubygem-simp-cli',
-  :ref => 'master',
-  :path => './src/rubygems/simp-cli'
-mod 'rubygems-simp-rake-helpers',
-  :git  => 'git://github.com/simp/rubygem-simp-rake-helpers',
-  :ref => 'master',
-  :path => './src/rubygems/simp-rake-helpers'
+moduledir 'src'
 
-# Puppet Modules
-mod 'simp-acpid',
-  :git => 'git://github.com/simp/pupmod-simp-acpid',
-  :ref => 'master'
-mod 'simp-activemq',
-  :git => 'git://github.com/simp/pupmod-simp-activemq',
-  :ref => 'master'
-mod 'simp-aide',
-  :git => 'git://github.com/simp/pupmod-simp-aide',
-  :ref => 'master'
-mod 'simp-apache',
-  :git => 'git://github.com/simp/pupmod-simp-apache',
-  :ref => 'master'
-mod 'simp-auditd',
-  :git => 'git://github.com/simp/pupmod-simp-auditd',
-  :ref => 'master'
-mod 'simp-augeasproviders',
-  :git => 'git://github.com/simp/augeasproviders',
-  :ref => 'simp-master'
-mod 'simp-augeasproviders_apache',
-  :git => 'git://github.com/simp/augeasproviders_apache',
-  :ref => 'simp-master'
-mod 'simp-augeasproviders_base',
-  :git => 'git://github.com/simp/augeasproviders_base',
-  :ref => 'simp-master'
-mod 'simp-augeasproviders_core',
-  :git => 'git://github.com/simp/augeasproviders_core',
-  :ref => 'simp-master'
-mod 'simp-augeasproviders_grub',
-  :git => 'git://github.com/simp/augeasproviders_grub',
-  :ref => 'simp-master'
-mod 'simp-augeasproviders_mounttab',
-  :git => 'git://github.com/simp/augeasproviders_mounttab',
-  :ref => 'simp-master'
-mod 'simp-augeasproviders_nagios',
-  :git => 'git://github.com/simp/augeasproviders_nagios',
-  :ref => 'simp-master'
-mod 'simp-augeasproviders_pam',
-  :git => 'git://github.com/simp/augeasproviders_pam',
-  :ref => 'simp-master'
-mod 'simp-augeasproviders_postgresql',
-  :git => 'git://github.com/simp/augeasproviders_postgresql',
-  :ref => 'simp-master'
-mod 'simp-augeasproviders_puppet',
-  :git => 'git://github.com/simp/augeasproviders_puppet',
-  :ref => 'simp-master'
-mod 'simp-augeasproviders_shellvar',
-  :git => 'git://github.com/simp/augeasproviders_shellvar',
-  :ref => 'simp-master'
-mod 'simp-augeasproviders_ssh',
-  :git => 'git://github.com/simp/augeasproviders_ssh',
-  :ref => 'simp-master'
-mod 'simp-augeasproviders_sysctl',
-  :git => 'git://github.com/simp/augeasproviders_sysctl',
-  :ref => 'simp-master'
-mod 'simp-autofs',
-  :git => 'git://github.com/simp/pupmod-simp-autofs',
-  :ref => 'master'
-mod 'simp-backuppc',
-  :git => 'git://github.com/simp/pupmod-simp-backuppc',
-  :ref => 'master'
-mod 'simp-cgroups',
-  :git => 'git://github.com/simp/pupmod-simp-cgroups',
-  :ref => 'master'
-mod 'simp-clamav',
-  :git => 'git://github.com/simp/pupmod-simp-clamav',
-  :ref => 'master'
-mod 'simp-concat',
-  :git => 'git://github.com/simp/pupmod-simp-concat',
-  :ref => 'master'
-mod 'simp-datacat',
-  :git => 'git://github.com/simp/puppet-datacat',
-  :ref => 'simp-master'
-mod 'simp-dhcp',
-  :git => 'git://github.com/simp/pupmod-simp-dhcp',
-  :ref => 'master'
-mod 'simp-elasticsearch',
-  :git => 'git://github.com/simp/puppet-elasticsearch',
-  :ref => 'simp-master'
-mod 'simp-foreman',
-  :git => 'git://github.com/simp/pupmod-simp-foreman',
-  :ref => 'master'
-mod 'simp-freeradius',
-  :git => 'git://github.com/simp/pupmod-simp-freeradius',
-  :ref => 'master'
-mod 'simp-ganglia',
-  :git => 'git://github.com/simp/pupmod-simp-ganglia',
-  :ref => 'master'
-mod 'simp-gfs2',
-  :git => 'git://github.com/simp/pupmod-simp-gfs2',
-  :ref => 'master'
-mod 'simp-gpasswd',
-  :git => 'git://github.com/simp/puppet-gpasswd',
-  :ref => 'simp-master'
-mod 'simp-inifile',
-  :git => 'git://github.com/simp/puppetlabs-inifile',
-  :ref => 'simp-master'
-mod 'simp-iptables',
-  :git => 'git://github.com/simp/pupmod-simp-iptables',
-  :ref => 'master'
-mod 'simp-java',
-  :git => 'git://github.com/simp/puppetlabs-java',
-  :ref => 'simp-master'
-mod 'simp-java_ks',
-  :git => 'git://github.com/simp/puppetlabs-java_ks',
-  :ref => 'simp-master'
-mod 'simp-jenkins',
-  :git => 'git://github.com/simp/pupmod-simp-jenkins',
-  :ref => 'master'
-mod 'simp-kibana',
-  :git => 'git://github.com/simp/pupmod-simp-kibana',
-  :ref => 'master'
-mod 'simp-krb5',
-  :git => 'git://github.com/simp/pupmod-simp-krb5',
-  :ref => 'master'
-mod 'simp-libvirt',
-  :git => 'git://github.com/simp/pupmod-simp-libvirt',
-  :ref => 'master'
-mod 'simp-logrotate',
-  :git => 'git://github.com/simp/pupmod-simp-logrotate',
-  :ref => 'master'
-mod 'simp-logstash',
-  :git => 'git://github.com/simp/puppet-logstash',
-  :ref => 'simp-master'
-mod 'simp-mcafee',
-  :git => 'git://github.com/simp/pupmod-simp-mcafee',
-  :ref => 'master'
-mod 'simp-mcollective',
-  :git => 'git://github.com/simp/pupmod-simp-mcollective',
-  :ref => 'master'
-mod 'simp-memcached',
-  :git => 'git://github.com/simp/puppet-memcached',
-  :ref => 'simp-master'
-mod 'simp-mozilla',
-  :git => 'git://github.com/simp/pupmod-simp-mozilla',
-  :ref => 'master'
-mod 'simp-multipathd',
-  :git => 'git://github.com/simp/pupmod-simp-multipathd',
-  :ref => 'master'
-mod 'simp-mysql',
-  :git => 'git://github.com/simp/puppetlabs-mysql',
-  :ref => 'simp-master'
-mod 'simp-named',
-  :git => 'git://github.com/simp/pupmod-simp-named',
-  :ref => 'master'
-mod 'simp-network',
-  :git => 'git://github.com/simp/pupmod-simp-network',
-  :ref => 'master'
-mod 'simp-nfs',
-  :git => 'git://github.com/simp/pupmod-simp-nfs',
-  :ref => 'master'
-mod 'simp-nscd',
-  :git => 'git://github.com/simp/pupmod-simp-nscd',
-  :ref => 'master'
-mod 'simp-ntpd',
-  :git => 'git://github.com/simp/pupmod-simp-ntpd',
-  :ref => 'master'
-mod 'simp-oddjob',
-  :git => 'git://github.com/simp/pupmod-simp-oddjob',
-  :ref => 'master'
-mod 'simp-openldap',
-  :git => 'git://github.com/simp/pupmod-simp-openldap',
-  :ref => 'master'
-mod 'simp-openscap',
-  :git => 'git://github.com/simp/pupmod-simp-openscap',
-  :ref => 'master'
-mod 'simp-pam',
-  :git => 'git://github.com/simp/pupmod-simp-pam',
-  :ref => 'master'
-mod 'simp-pki',
-  :git => 'git://github.com/simp/pupmod-simp-pki',
-  :ref => 'master'
-mod 'simp-polkit',
-  :git => 'git://github.com/simp/pupmod-simp-polkit',
-  :ref => 'master'
-mod 'simp-postfix',
-  :git => 'git://github.com/simp/pupmod-simp-postfix',
-  :ref => 'master'
-mod 'simp-postgresql',
-  :git => 'git://github.com/simp/puppetlabs-postgresql',
-  :ref => 'simp-master'
-mod 'simp-pupmod',
-  :git => 'git://github.com/simp/pupmod-simp-pupmod',
-  :ref => 'master'
-mod 'simp-puppetdb',
-  :git => 'git://github.com/simp/puppetlabs-puppetdb',
-  :ref => 'simp-master'
-mod 'simp-puppetlabs_apache',
-  :git => 'git://github.com/simp/puppetlabs-apache',
-  :ref => 'simp-master'
+mod 'simp-doc',
+  :git => 'https://github.com/simp/simp-doc',
+  :ref => 'simp-4.2.X'
+
 mod 'simp-rsync',
-  :git => 'git://github.com/simp/pupmod-simp-rsync',
+  :git => 'https://github.com/simp/simp-rsync',
+  :ref => 'simp-4.2.X'
+
+moduledir 'src/rubygems'
+
+mod 'rubygem-simp_cli',
+  :git => 'https://github.com/simp/rubygem-simp-cli',
   :ref => 'master'
-mod 'simp-rsyslog',
-  :git => 'git://github.com/simp/pupmod-simp-rsyslog',
+
+mod 'rubygem-simp_rake_helpers',
+  :git => 'https://github.com/simp/rubygem-simp-rake-helpers',
   :ref => 'master'
-mod 'simp-selinux',
-  :git => 'git://github.com/simp/pupmod-simp-selinux',
+
+moduledir 'src/puppet/modules'
+
+mod 'simp-acpid',
+  :git => 'https://github.com/simp/pupmod-simp-acpid',
   :ref => 'master'
-mod 'simp-simp',
-  :git => 'git://github.com/simp/pupmod-simp-simp',
+
+mod 'simp-activemq',
+  :git => 'https://github.com/simp/pupmod-simp-activemq',
   :ref => 'master'
-mod 'simp-simplib',
-  :git => 'git://github.com/simp/pupmod-simp-simplib',
+
+mod 'simp-aide',
+  :git => 'https://github.com/simp/pupmod-simp-aide',
   :ref => 'master'
-mod 'simp-site',
-  :git => 'git://github.com/simp/pupmod-simp-site',
+
+mod 'simp-apache',
+  :git => 'https://github.com/simp/pupmod-simp-apache',
   :ref => 'master'
-mod 'simp-snmpd',
-  :git => 'git://github.com/simp/pupmod-simp-snmpd',
+
+mod 'simp-auditd',
+  :git => 'https://github.com/simp/pupmod-simp-auditd',
   :ref => 'master'
-mod 'simp-ssh',
-  :git => 'git://github.com/simp/pupmod-simp-ssh',
-  :ref => 'master'
-mod 'simp-sssd',
-  :git => 'git://github.com/simp/pupmod-simp-sssd',
-  :ref => 'master'
-mod 'simp-stdlib',
-  :git => 'git://github.com/simp/puppetlabs-stdlib',
+
+mod 'simp-augeasproviders',
+  :git => 'https://github.com/simp/augeasproviders',
   :ref => 'simp-master'
+
+mod 'simp-augeasproviders_apache',
+  :git => 'https://github.com/simp/augeasproviders_apache',
+  :ref => 'simp-master'
+
+mod 'simp-augeasproviders_base',
+  :git => 'https://github.com/simp/augeasproviders_base',
+  :ref => 'simp-master'
+
+mod 'simp-augeasproviders_core',
+  :git => 'https://github.com/simp/augeasproviders_core',
+  :ref => 'simp-master'
+
+mod 'simp-augeasproviders_grub',
+  :git => 'https://github.com/simp/augeasproviders_grub',
+  :ref => 'simp-master'
+
+mod 'simp-augeasproviders_mounttab',
+  :git => 'https://github.com/simp/augeasproviders_mounttab',
+  :ref => 'simp-master'
+
+mod 'simp-augeasproviders_nagios',
+  :git => 'https://github.com/simp/augeasproviders_nagios',
+  :ref => 'simp-master'
+
+mod 'simp-augeasproviders_pam',
+  :git => 'https://github.com/simp/augeasproviders_pam',
+  :ref => 'simp-master'
+
+mod 'simp-augeasproviders_postgresql',
+  :git => 'https://github.com/simp/augeasproviders_postgresql',
+  :ref => 'simp-master'
+
+mod 'simp-augeasproviders_puppet',
+  :git => 'https://github.com/simp/augeasproviders_puppet',
+  :ref => 'simp-master'
+
+mod 'simp-augeasproviders_shellvar',
+  :git => 'https://github.com/simp/augeasproviders_shellvar',
+  :ref => 'simp-master'
+
+mod 'simp-augeasproviders_ssh',
+  :git => 'https://github.com/simp/augeasproviders_ssh',
+  :ref => 'simp-master'
+
+mod 'simp-augeasproviders_sysctl',
+  :git => 'https://github.com/simp/augeasproviders_sysctl',
+  :ref => 'simp-master'
+
+mod 'simp-autofs',
+  :git => 'https://github.com/simp/pupmod-simp-autofs',
+  :ref => 'master'
+
+mod 'simp-backuppc',
+  :git => 'https://github.com/simp/pupmod-simp-backuppc',
+  :ref => 'master'
+
+mod 'simp-cgroups',
+  :git => 'https://github.com/simp/pupmod-simp-cgroups',
+  :ref => 'master'
+
+mod 'simp-clamav',
+  :git => 'https://github.com/simp/pupmod-simp-clamav',
+  :ref => 'master'
+
+mod 'simp-concat',
+  :git => 'https://github.com/simp/pupmod-simp-concat',
+  :ref => 'master'
+
+mod 'simp-datacat',
+  :git => 'https://github.com/simp/puppet-datacat',
+  :ref => 'simp-master'
+
+mod 'simp-dhcp',
+  :git => 'https://github.com/simp/pupmod-simp-dhcp',
+  :ref => 'master'
+
+mod 'simp-elasticsearch',
+  :git => 'https://github.com/simp/puppet-elasticsearch',
+  :ref => 'simp-master'
+
+mod 'simp-foreman',
+  :git => 'https://github.com/simp/pupmod-simp-foreman',
+  :ref => 'master'
+
+mod 'simp-freeradius',
+  :git => 'https://github.com/simp/pupmod-simp-freeradius',
+  :ref => 'master'
+
+mod 'simp-ganglia',
+  :git => 'https://github.com/simp/pupmod-simp-ganglia',
+  :ref => 'master'
+
+mod 'simp-gfs2',
+  :git => 'https://github.com/simp/pupmod-simp-gfs2',
+  :ref => 'master'
+
+mod 'simp-gpasswd',
+  :git => 'https://github.com/simp/puppet-gpasswd',
+  :ref => 'simp-master'
+
+mod 'simp-inifile',
+  :git => 'https://github.com/simp/puppetlabs-inifile',
+  :ref => 'simp-master'
+
+mod 'simp-iptables',
+  :git => 'https://github.com/simp/pupmod-simp-iptables',
+  :ref => 'master'
+
+mod 'simp-java',
+  :git => 'https://github.com/simp/puppetlabs-java',
+  :ref => 'simp-master'
+
+mod 'simp-java_ks',
+  :git => 'https://github.com/simp/puppetlabs-java_ks',
+  :ref => 'simp-master'
+
+mod 'simp-jenkins',
+  :git => 'https://github.com/simp/pupmod-simp-jenkins',
+  :ref => 'master'
+
+mod 'simp-kibana',
+  :git => 'https://github.com/simp/pupmod-simp-kibana',
+  :ref => 'master'
+
+mod 'simp-krb5',
+  :git => 'https://github.com/simp/pupmod-simp-krb5',
+  :ref => 'master'
+
+mod 'simp-libvirt',
+  :git => 'https://github.com/simp/pupmod-simp-libvirt',
+  :ref => 'master'
+
+mod 'simp-logrotate',
+  :git => 'https://github.com/simp/pupmod-simp-logrotate',
+  :ref => 'master'
+
+mod 'simp-logstash',
+  :git => 'https://github.com/simp/puppet-logstash',
+  :ref => 'simp-master'
+
+mod 'simp-mcafee',
+  :git => 'https://github.com/simp/pupmod-simp-mcafee',
+  :ref => 'master'
+
+mod 'simp-mcollective',
+  :git => 'https://github.com/simp/pupmod-simp-mcollective',
+  :ref => 'master'
+
+mod 'simp-memcached',
+  :git => 'https://github.com/simp/puppet-memcached',
+  :ref => 'simp-master'
+
+mod 'simp-mozilla',
+  :git => 'https://github.com/simp/pupmod-simp-mozilla',
+  :ref => 'master'
+
+mod 'simp-multipathd',
+  :git => 'https://github.com/simp/pupmod-simp-multipathd',
+  :ref => 'master'
+
+mod 'simp-mysql',
+  :git => 'https://github.com/simp/puppetlabs-mysql',
+  :ref => 'simp-master'
+
+mod 'simp-named',
+  :git => 'https://github.com/simp/pupmod-simp-named',
+  :ref => 'master'
+
+mod 'simp-network',
+  :git => 'https://github.com/simp/pupmod-simp-network',
+  :ref => 'master'
+
+mod 'simp-nfs',
+  :git => 'https://github.com/simp/pupmod-simp-nfs',
+  :ref => 'master'
+
+mod 'simp-nscd',
+  :git => 'https://github.com/simp/pupmod-simp-nscd',
+  :ref => 'master'
+
+mod 'simp-ntpd',
+  :git => 'https://github.com/simp/pupmod-simp-ntpd',
+  :ref => 'master'
+
+mod 'simp-oddjob',
+  :git => 'https://github.com/simp/pupmod-simp-oddjob',
+  :ref => 'master'
+
+mod 'simp-openldap',
+  :git => 'https://github.com/simp/pupmod-simp-openldap',
+  :ref => 'master'
+
+mod 'simp-openscap',
+  :git => 'https://github.com/simp/pupmod-simp-openscap',
+  :ref => 'master'
+
+mod 'simp-pam',
+  :git => 'https://github.com/simp/pupmod-simp-pam',
+  :ref => 'master'
+
+mod 'simp-pki',
+  :git => 'https://github.com/simp/pupmod-simp-pki',
+  :ref => 'master'
+
+mod 'simp-polkit',
+  :git => 'https://github.com/simp/pupmod-simp-polkit',
+  :ref => 'master'
+
+mod 'simp-postfix',
+  :git => 'https://github.com/simp/pupmod-simp-postfix',
+  :ref => 'master'
+
+mod 'simp-postgresql',
+  :git => 'https://github.com/simp/puppetlabs-postgresql',
+  :ref => 'simp-master'
+
+mod 'simp-pupmod',
+  :git => 'https://github.com/simp/pupmod-simp-pupmod',
+  :ref => 'master'
+
+mod 'simp-puppetdb',
+  :git => 'https://github.com/simp/puppetlabs-puppetdb',
+  :ref => 'simp-master'
+
+mod 'simp-puppetlabs_apache',
+  :git => 'https://github.com/simp/puppetlabs-apache',
+  :ref => 'simp-master'
+
+mod 'simp-rsync',
+  :git => 'https://github.com/simp/pupmod-simp-rsync',
+  :ref => 'master'
+
+mod 'simp-rsyslog',
+  :git => 'https://github.com/simp/pupmod-simp-rsyslog',
+  :ref => 'master'
+
+mod 'simp-selinux',
+  :git => 'https://github.com/simp/pupmod-simp-selinux',
+  :ref => 'master'
+
+mod 'simp-simp',
+  :git => 'https://github.com/simp/pupmod-simp-simp',
+  :ref => 'master'
+
+mod 'simp-simplib',
+  :git => 'https://github.com/simp/pupmod-simp-simplib',
+  :ref => 'master'
+
+mod 'simp-site',
+  :git => 'https://github.com/simp/pupmod-simp-site',
+  :ref => 'master'
+
+mod 'simp-snmpd',
+  :git => 'https://github.com/simp/pupmod-simp-snmpd',
+  :ref => 'master'
+
+mod 'simp-ssh',
+  :git => 'https://github.com/simp/pupmod-simp-ssh',
+  :ref => 'master'
+
+mod 'simp-sssd',
+  :git => 'https://github.com/simp/pupmod-simp-sssd',
+  :ref => 'master'
+
+mod 'simp-stdlib',
+  :git => 'https://github.com/simp/puppetlabs-stdlib',
+  :ref => 'simp-master'
+
 mod 'simp-stunnel',
-  :git => 'git://github.com/simp/pupmod-simp-stunnel',
+  :git => 'https://github.com/simp/pupmod-simp-stunnel',
   :ref => 'master'
+
 mod 'simp-sudo',
-  :git => 'git://github.com/simp/pupmod-simp-sudo',
+  :git => 'https://github.com/simp/pupmod-simp-sudo',
   :ref => 'master'
+
 mod 'simp-sudosh',
-  :git => 'git://github.com/simp/pupmod-simp-sudosh',
+  :git => 'https://github.com/simp/pupmod-simp-sudosh',
   :ref => 'master'
+
 mod 'simp-svckill',
-  :git => 'git://github.com/simp/pupmod-simp-svckill',
+  :git => 'https://github.com/simp/pupmod-simp-svckill',
   :ref => 'master'
+
 mod 'simp-sysctl',
-  :git => 'git://github.com/simp/pupmod-simp-sysctl',
+  :git => 'https://github.com/simp/pupmod-simp-sysctl',
   :ref => 'master'
+
 mod 'simp-tcpwrappers',
-  :git => 'git://github.com/simp/pupmod-simp-tcpwrappers',
+  :git => 'https://github.com/simp/pupmod-simp-tcpwrappers',
   :ref => 'master'
+
 mod 'simp-tftpboot',
-  :git => 'git://github.com/simp/pupmod-simp-tftpboot',
+  :git => 'https://github.com/simp/pupmod-simp-tftpboot',
   :ref => 'master'
+
 mod 'simp-tpm',
-  :git => 'git://github.com/simp/pupmod-simp-tpm',
+  :git => 'https://github.com/simp/pupmod-simp-tpm',
   :ref => 'master'
+
 mod 'simp-upstart',
-  :git => 'git://github.com/simp/pupmod-simp-upstart',
+  :git => 'https://github.com/simp/pupmod-simp-upstart',
   :ref => 'master'
+
 mod 'simp-vnc',
-  :git => 'git://github.com/simp/pupmod-simp-vnc',
+  :git => 'https://github.com/simp/pupmod-simp-vnc',
   :ref => 'master'
+
 mod 'simp-vsftpd',
-  :git => 'git://github.com/simp/pupmod-simp-vsftpd',
+  :git => 'https://github.com/simp/pupmod-simp-vsftpd',
   :ref => 'master'
+
 mod 'simp-windowmanager',
-  :git => 'git://github.com/simp/pupmod-simp-windowmanager',
+  :git => 'https://github.com/simp/pupmod-simp-windowmanager',
   :ref => 'master'
+
 mod 'simp-xinetd',
-  :git => 'git://github.com/simp/pupmod-simp-xinetd',
+  :git => 'https://github.com/simp/pupmod-simp-xinetd',
   :ref => 'master'
+
 mod 'simp-xwindows',
-  :git => 'git://github.com/simp/pupmod-simp-xwindows',
+  :git => 'https://github.com/simp/pupmod-simp-xwindows',
   :ref => 'master'
-mod 'onyxpoint-compliance_mapper',
+
+mod 'onyxpoint-compliance',
   :git => 'https://github.com/trevor-vaughan/pupmod-compliance',
   :ref => 'master'


### PR DESCRIPTION
`Puppetfile.tracking` has been migrated, `Puppetfile.stable` has not
until the next release.

SIMP-96 #comment Moved 4.2.X `simp-core` from Librarian to R10k
SIMP-96 #close