### PR TITLE
(SIMP-1035) Add `sudo` as a requirement

### DIFF
--- a/src/puppet/bootstrap/build/simp-bootstrap.spec
+++ b/src/puppet/bootstrap/build/simp-bootstrap.spec
@@ -1,7 +1,7 @@
 Summary: SIMP Bootstrap
 Name: simp-bootstrap
 Version: 5.2.1
-Release: 4
+Release: 5
 License: Apache License 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -14,6 +14,7 @@ Requires: simp-rsync >= 5.0.0-3
 Requires: simp-utils >= 5.0.0-5
 Requires: rubygem(simp-cli) >= 1.0.0-0
 Requires: openssl
+Requires: sudo
 Requires(post): coreutils
 Requires(post): glibc-common
 Requires(post): pam
@@ -294,6 +295,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Mon Apr 25 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 5.2.1-5
+- Required 'sudo' to resolve ordering race that overwrote '/etc/sudoers'.
+
 * Fri Jan 29 2016 Ralph Wright <ralph.wright@onyxpoint.com> - 5.2.1-4
 - Added suppport for compliance module
 


### PR DESCRIPTION
Before this commit, a fresh ISO install might resolve the `sudo` RPM
package to come after the `simp-bootstrap` package.  This would result
in the `simp` user not having sudo access after boot, which will prevent
packer from building vagrant boxes and AMIs.

This patch resolves the issue by adding the `sudo` package as a
requirement for `simp-bootstrap`.

SIMP-1035 #comment Add `sudo` as a simp-bootstrap requirement in 5.1.X