### PR TITLE
(SIMP-1035) Add `Defaults !requiretty` for `sudo`

### DIFF
--- a/src/puppet/bootstrap/build/simp-bootstrap.spec
+++ b/src/puppet/bootstrap/build/simp-bootstrap.spec
@@ -203,10 +203,13 @@ if [ -f /etc/security/groupaccess.conf ]; then
     echo "simp" >> /etc/security/groupaccess.conf;
   fi
 fi
+
+# Permit `simp` user full non-tty sudo access before running `simp bootstrap`
 grep -q "^simp" /etc/sudoers;
 if [ $? -ne 0 ]; then
     echo -e 'simp\t\tALL=(ALL)\t/bin/su' >> /etc/sudoers;
 fi
+echo 'Defaults !requiretty' >> /etc/sudoers
 
 getent group wheel | grep -q simp
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
This patch supplements the previous SIMP-1035 commit by adding the line
`Defaults !requiretty` to the `/etc/sudoers` file on a freshy-installed
(pre-`simp config`) ISO.

SIMP-238 #comment Add `Defaults !requiretty` to `simp-bootstrap` 5.1.X
SIMP-1035 #comment Add `Defaults !requiretty` to `simp-bootstrap` 5.1.X