### PR TITLE
(SIMP-1016) Added Mediocre Disk Crypto

### DIFF
--- a/src/DVD/EFI/BOOT/grub.cfg
+++ b/src/DVD/EFI/BOOT/grub.cfg
@@ -20,27 +20,39 @@ menuentry 'simp' {
   linuxefi /images/pxeboot/vmlinuz ks=cdrom:/ks/dvd/auto.cfg
   initrdefi /images/pxeboot/initrd.img
 }
-menuentry simp-big {
+menuentry 'simp-disk-crypt' {
+  linuxefi /images/pxeboot/vmlinuz ks=cdrom:/ks/dvd/auto.cfg simp_disk_crypt
+  initrdefi /images/pxeboot/initrd.img
+}
+menuentry 'simp-big' {
   linuxefi /images/pxeboot/vmlinuz ks=cdrom:/ks/dvd/auto.cfg simp_opt=big
   initrdefi /images/pxeboot/initrd.img
 }
-menuentry simp-prompt {
+menuentry 'simp-big-disk-crypt' {
+  linuxefi /images/pxeboot/vmlinuz ks=cdrom:/ks/dvd/auto.cfg simp_opt=big simp_disk_crypt
+  initrdefi /images/pxeboot/initrd.img
+}
+menuentry 'simp-prompt' {
   linuxefi /images/pxeboot/vmlinuz ks=cdrom:/ks/dvd/auto.cfg simp_opt=prompt
   initrdefi /images/pxeboot/initrd.img
 }
-menuentry linux-min {
+menuentry 'linux-min' {
   linuxefi /images/pxeboot/vmlinuz ks=cdrom:/ks/dvd/min.cfg
   initrdefi /images/pxeboot/initrd.img
 }
-menuentry openstack {
+menuentry 'linux-min-disk-crypt' {
+  linuxefi /images/pxeboot/vmlinuz ks=cdrom:/ks/dvd/min.cfg simp_disk_crypt
+  initrdefi /images/pxeboot/initrd.img
+}
+menuentry 'openstack' {
   linuxefi /images/pxeboot/vmlinuz ks=cdrom:/ks/dvd/min.cfg simp_opt=openstack
   initrdefi /images/pxeboot/initrd.img
 }
-menuentry linux {
+menuentry 'linux' {
   linuxefi /images/pxeboot/vmlinuz
   initrdefi /images/pxeboot/initrd.img
 }
-menuentry rescue {
+menuentry 'rescue' {
   linuxefi /images/pxeboot/vmlinuz rescue askmethod
   initrdefi /images/pxeboot/initrd.img
 }

--- a/src/DVD/isolinux/boot.msg
+++ b/src/DVD/isolinux/boot.msg
@@ -4,20 +4,19 @@
  -  To auto-install SIMP, type 0asimp <ENTER>07.
     - This will erase your existing system!
     - You need at least 50GB of disk space for this to succeed.
+    - Add the option 0asimp_disk_crypt07 ot encrypt your disk.
 
  -  To auto-install SIMP with a large /var, type 0asimp-big <ENTER>07.
     - This will erase your existing system!
+    - Add the option 0asimp_disk_crypt07 ot encrypt your disk.
 
  -  To install SIMP with disk prompt, type 0asimp-prompt<ENTER>07.
     - This will erase your existing system!
 
- -  To install a Workstation version of SIMP, type 0asimp-ws<ENTER>07.
-    - This will erase your existing system!
-    - Note: Your system will not be auto-managed after installation.
-
  -  To auto-install a minimized system type 0alinux-min <ENTER>07.
     - This will erase your existing system!
     - You need at least 50GB of disk space for this to succeed.
+    - Add the option 0asimp_disk_crypt07 ot encrypt your disk.
 
  -  Use the function keys listed below for more information.
 

--- a/src/DVD/ks/dvd/auto.cfg
+++ b/src/DVD/ks/dvd/auto.cfg
@@ -25,10 +25,57 @@ chmod +x /tmp/*.sh
 /tmp/diskdetect.sh
 %end
 
-%post --nochroot
+%post --nochroot --erroronfail
 # SOURCE is the DVD; SYSIMAGE is the chroot'd root dir
 SOURCE="/mnt/source"
 SYSIMAGE="/mnt/sysimage"
+
+# If we dropped a LUKS key-file, we need to copy it into place.
+if [ -f /boot/disk_creds ]; then
+  cp /boot/disk_creds $SYSIMAGE/etc/.cryptcreds
+  chown root:root $SYSIMAGE/etc/.cryptcreds
+  chmod 400 $SYSIMAGE/etc/.cryptcreds
+
+  crypt_disk=`cat /boot/crypt_disk`
+  for x in /dev/$crypt_disk*; do
+    if `cryptsetup isLuks $x`; then
+      crypt_partition="$x"
+      break
+    fi
+  done
+
+  if [ -z "$crypt_partition" ]; then
+    echo "Error: Could not find the encrypted partition"
+    exit 1
+  fi
+
+  exec < /dev/tty6 > /dev/tty6 2> /dev/tty6
+  chvt 6
+
+  echo "Updating the LUKS keys, this may take some time...."
+
+  # We need to make sure our keyfile lands in slot 0 and EL6 doesn't have the
+  # luksChangeKey command
+  cryptsetup luksAddKey --key-slot 1 --key-file /boot/disk_creds $crypt_partition /boot/disk_creds
+  cryptsetup luksKillSlot --key-file /boot/disk_creds $crypt_partition 0
+
+  cryptsetup luksAddKey --key-slot 0 --key-file /boot/disk_creds $crypt_partition /boot/disk_creds
+  cryptsetup luksKillSlot --key-file /boot/disk_creds $crypt_partition 1
+
+  # Modify the crypttab file
+  crypt_uuid=`cryptsetup luksDump ${crypt_partition} | grep UUID | sed 's/[[:space:]]\+/ /g' | cut -f2 -d' '`
+
+  chvt 1
+  exec < /dev/tty1 > /dev/tty1 2> /dev/tty1
+
+  # If we got here, and this is blank, fail hard!
+  if [ -z "$crypt_uuid" ]; then
+    echo "Error: Could not find crypt_uuid"
+    exit 1
+  fi
+
+  echo "luks-${crypt_uuid} UUID=${crypt_uuid} /etc/.cryptcreds luks" > $SYSIMAGE/etc/crypttab
+fi
 
 # Some nonsense to try and re-mount the DVD
 if [ -b /dev/cdrom ]; then
@@ -81,7 +128,7 @@ fi
 
 if [ ! -d "${SYSIMAGE}/var/www/yum/${ostype}/${majrhversion}" ]; then
   cd "${SYSIMAGE}/var/www/yum/${ostype}";
-  ln -s $rhversion $majrhversion;
+  ln -sf $rhversion $majrhversion;
   cd -;
 fi
 
@@ -106,7 +153,7 @@ if [ -d "${src_dir}" ]; then
       pushd .
       cd "${rsync_dir}"
       mkdir "${rsync_target}"
-      ln -s "${rsync_target}" "${rsync_link}"
+      ln -sf "${rsync_target}" "${rsync_link}"
       cp -a "${src_dir}/vmlinuz" "${rsync_target}"
       cp -a "${src_dir}/initrd.img" "${rsync_target}"
       chown -R root.nobody "${rsync_target}"
@@ -123,7 +170,8 @@ if [ $tftpboot_setup_success -ne 0 ]; then
   echo -e "Could not add PXE Images from the disc to ${rsync_dir}/${rsync_target}" | tee -a ${SYSIMAGE}/root/postinstall.err
 fi
 
-eject /tmp/cdrom
+# Don't care if this fails.
+eject /tmp/cdrom || true
 %end
 
 %post
@@ -133,12 +181,22 @@ if [ -e /sys/firmware/efi ]; then
 else
   BOOTDEV=`df /boot | tail -1 | cut -f1 -d' '`
 fi
+
 # In case you need a working fallback
 DEFAULT_KERNEL_INFO=`/sbin/grubby --default-kernel`
 DEFAULT_INITRD=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep initrd | cut -f2 -d'='`
 DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 title | cut -f2 -d'='`
 /sbin/grubby --copy-default --make-default --args="boot=${BOOTDEV} fips=1" --add-kernel=`/sbin/grubby --default-kernel` --initrd=${DEFAULT_INITRD} --title="FIPS ${DEFAULT_KERNEL_TITLE}"
-dracut -f
+
+# For the disk crypto
+if [ -f "/etc/.cryptcreds" ]; then
+  echo 'install_items+="/etc/.cryptcreds"' >> /etc/dracut.conf
+fi
+
+for x in `ls -d /lib/modules/*`; do
+  installed_kernel=`basename $x`
+  dracut -f "/boot/initramfs-${installed_kernel}.img" $installed_kernel
+done
 
 sed -i 's/--class os/--class os --unrestricted/g' /boot/grub2/grub.cfg
 

--- a/src/DVD/ks/dvd/min.cfg
+++ b/src/DVD/ks/dvd/min.cfg
@@ -26,6 +26,55 @@ chmod +x /tmp/*.sh
 /tmp/diskdetect.sh
 %end
 
+%post --nochroot --erroronfail
+# If we dropped a LUKS key-file, we need to copy it into place.
+if [ -f /boot/disk_creds ]; then
+  cp /boot/disk_creds $SYSIMAGE/etc/.cryptcreds
+  chown root:root $SYSIMAGE/etc/.cryptcreds
+  chmod 400 $SYSIMAGE/etc/.cryptcreds
+
+  crypt_disk=`cat /boot/crypt_disk`
+  for x in /dev/$crypt_disk*; do
+    if `cryptsetup isLuks $x`; then
+      crypt_partition="$x"
+      break
+    fi
+  done
+
+  if [ -z "$crypt_partition" ]; then
+    echo "Error: Could not find the encrypted partition"
+    exit 1
+  fi
+
+  exec < /dev/tty6 > /dev/tty6 2> /dev/tty6
+  chvt 6
+
+  echo "Updating the LUKS keys, this may take some time...."
+
+  # We need to make sure our keyfile lands in slot 0 and EL6 doesn't have the
+  # luksChangeKey command
+  cryptsetup luksAddKey --key-slot 1 --key-file /boot/disk_creds $crypt_partition /boot/disk_creds
+  cryptsetup luksKillSlot --key-file /boot/disk_creds $crypt_partition 0
+
+  cryptsetup luksAddKey --key-slot 0 --key-file /boot/disk_creds $crypt_partition /boot/disk_creds
+  cryptsetup luksKillSlot --key-file /boot/disk_creds $crypt_partition 1
+
+  # Modify the crypttab file
+  crypt_uuid=`cryptsetup luksDump ${crypt_partition} | grep UUID | sed 's/[[:space:]]\+/ /g' | cut -f2 -d' '`
+
+  chvt 1
+  exec < /dev/tty1 > /dev/tty1 2> /dev/tty1
+
+  # If we got here, and this is blank, fail hard!
+  if [ -z "$crypt_uuid" ]; then
+    echo "Error: Could not find crypt_uuid"
+    exit 1
+  fi
+
+  echo "luks-${crypt_uuid} UUID=${crypt_uuid} /etc/.cryptcreds luks" > $SYSIMAGE/etc/crypttab
+fi
+%end
+
 %post
 # FIPS
 if [ -e /sys/firmware/efi ]; then
@@ -38,7 +87,16 @@ DEFAULT_KERNEL_INFO=`/sbin/grubby --default-kernel`
 DEFAULT_INITRD=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep initrd | cut -f2 -d'='`
 DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 title | cut -f2 -d'='`
 /sbin/grubby --copy-default --make-default --args="boot=${BOOTDEV} fips=1" --add-kernel=`/sbin/grubby --default-kernel` --initrd=${DEFAULT_INITRD} --title="FIPS ${DEFAULT_KERNEL_TITLE}"
-dracut -f
+
+# For the disk crypto
+if [ -f "/etc/.cryptcreds" ]; then
+  echo 'install_items+="/etc/.cryptcreds"' >> /etc/dracut.conf
+fi
+
+for x in `ls -d /lib/modules/*`; do
+  installed_kernel=`basename $x`
+  dracut -f "/boot/initramfs-${installed_kernel}.img" $installed_kernel
+done
 
 /sbin/chkconfig --add network;
 /sbin/chkconfig --level 345 nscd on;

--- a/src/DVD/ks/pupclient_x86_64.cfg
+++ b/src/DVD/ks/pupclient_x86_64.cfg
@@ -134,6 +134,56 @@ chmod 750 /tmp/repodetect.sh;
 /tmp/repodetect.sh '7' $ksserver;
 %end
 
+%post --nochroot --erroronfail
+
+# If we dropped a LUKS key-file, we need to copy it into place.
+if [ -f /boot/disk_creds ]; then
+  cp /boot/disk_creds $SYSIMAGE/etc/.cryptcreds
+  chown root:root $SYSIMAGE/etc/.cryptcreds
+  chmod 400 $SYSIMAGE/etc/.cryptcreds
+
+  crypt_disk=`cat /boot/crypt_disk`
+  for x in /dev/$crypt_disk*; do
+    if `cryptsetup isLuks $x`; then
+      crypt_partition="$x"
+      break
+    fi
+  done
+
+  if [ -z "$crypt_partition" ]; then
+    echo "Error: Could not find the encrypted partition"
+    exit 1
+  fi
+
+  exec < /dev/tty6 > /dev/tty6 2> /dev/tty6
+  chvt 6
+
+  echo "Updating the LUKS keys, this may take some time...."
+
+  # We need to make sure our keyfile lands in slot 0 and EL6 doesn't have the
+  # luksChangeKey command
+  cryptsetup luksAddKey --key-slot 1 --key-file /boot/disk_creds $crypt_partition /boot/disk_creds
+  cryptsetup luksKillSlot --key-file /boot/disk_creds $crypt_partition 0
+
+  cryptsetup luksAddKey --key-slot 0 --key-file /boot/disk_creds $crypt_partition /boot/disk_creds
+  cryptsetup luksKillSlot --key-file /boot/disk_creds $crypt_partition 1
+
+  # Modify the crypttab file
+  crypt_uuid=`cryptsetup luksDump ${crypt_partition} | grep UUID | sed 's/[[:space:]]\+/ /g' | cut -f2 -d' '`
+
+  chvt 1
+  exec < /dev/tty1 > /dev/tty1 2> /dev/tty1
+
+  # If we got here, and this is blank, fail hard!
+  if [ -z "$crypt_uuid" ]; then
+    echo "Error: Could not find crypt_uuid"
+    exit 1
+  fi
+
+  echo "luks-${crypt_uuid} UUID=${crypt_uuid} /etc/.cryptcreds luks" > $SYSIMAGE/etc/crypttab
+fi
+%end
+
 %post
 ostype="#LINUXDIST#"
 if [ $ostype == "CentOS" ]; then
@@ -159,7 +209,16 @@ DEFAULT_KERNEL_INFO=`/sbin/grubby --default-kernel`
 DEFAULT_INITRD=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep initrd | cut -f2 -d'='`
 DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 title | cut -f2 -d'='`
 /sbin/grubby --copy-default --make-default --args="boot=${BOOTDEV} fips=1" --add-kernel=`/sbin/grubby --default-kernel` --initrd=${DEFAULT_INITRD} --title="FIPS ${DEFAULT_KERNEL_TITLE}"
-dracut -f
+
+# For the disk crypto
+if [ -f "/etc/.cryptcreds" ]; then
+  echo 'install_items+="/etc/.cryptcreds"' >> /etc/dracut.conf
+fi
+
+for x in `ls -d /lib/modules/*`; do
+  installed_kernel=`basename $x`
+  dracut -f "/boot/initramfs-${installed_kernel}.img" $installed_kernel
+done
 ## END FIPS ##
 
 # Notify users that bootstrap will run on firstboot


### PR DESCRIPTION
Added default disk encryption. This is not _good_ disk encryption! This
adds a file, /boot/disk_creds, that will decrypt your disk without
requiring a password.

The goal of this is to allow users to update the encryption at a later
time without needing to either rebuild their system or find a method to
copy off their data.

This is _not_ enabled by default but is instead activated by passing the
string simp_disk_crypto at the boot prompt.

If you enable this on a VM, expect it to take a while the first time while the
system builds up entropy for the encryption run.
