### PR TITLE
Update simp-bootstrap.spec

### DIFF
--- a/src/puppet/bootstrap/build/simp-bootstrap.spec
+++ b/src/puppet/bootstrap/build/simp-bootstrap.spec
@@ -57,7 +57,7 @@ cp puppet.conf %{buildroot}/%{prefix}/puppet.conf.rpmnew
 
 %files
 %defattr(0640,root,puppet,0750)
-%{prefix}/environments
+%{prefix}/environments/simp
 %config(noreplace) %attr(0660,-,-) %{prefix}/environments/simp/localusers
 %attr(0750,puppet,puppet) %{prefix}/environments/simp/simp_autofiles
 %config(noreplace) %{prefix}/auth.conf.simp


### PR DESCRIPTION
Narrowed directory in %files section to just the simp subfolder due to this YUM error:

```
Transaction check error:
  file /etc/puppet/environments from install of simp-bootstrap-5.2.1-4.noarch conflicts with file from package puppet-server-3.8.1-1.el7.noarch
```