### PR TITLE
(SIMP-1063) Fix `%files` conflict in bootstrap

### DIFF
--- a/src/puppet/bootstrap/build/simp-bootstrap.spec
+++ b/src/puppet/bootstrap/build/simp-bootstrap.spec
@@ -57,7 +57,7 @@ cp puppet.conf %{buildroot}/%{prefix}/puppet.conf.rpmnew
 
 %files
 %defattr(0640,root,puppet,0750)
-%{prefix}/environments
+%{prefix}/environments/simp
 %config(noreplace) %attr(0660,-,-) %{prefix}/environments/simp/localusers
 %attr(0750,puppet,puppet) %{prefix}/environments/simp/simp_autofiles
 %config(noreplace) %{prefix}/auth.conf.simp


### PR DESCRIPTION
_(reported & patched in 5.1.X by nicholasmhughes:)_

Narrowed directory in `%files` section to just the simp subfolder due to this
YUM error:

```
Transaction check error:
  file /etc/puppet/environments from install of
  simp-bootstrap-5.2.1-4.noarch conflicts with file from package
  puppet-server-3.8.1-1.el7.noarch
```

SIMP-1063 #comment Fixed `%files` in 5.1.X
SIMP-236 #comment 5.1.X: limit `%files` to `%{prefix}/environments/simp`
