### PR TITLE
(SIMP-1064) Properly enable FIPS in kickstart

### DIFF
--- a/src/DVD/ks/netpuppet.cfg
+++ b/src/DVD/ks/netpuppet.cfg
@@ -22,9 +22,9 @@ KS_SERVER=1.2.3.4
 # Kickstart base directory for pulling scripts and files.
 KS_BASE='some/directory'
 
-wget -nv -a /tmp/pre.log -O /tmp/common_ks_base https://$KS_SERVER/$KS_BASE/ks/dvd/include/common_ks_base
-wget -nv -a /tmp/pre.log -O /tmp/repodetect.sh https://$KS_SERVER/$KS_BASE/ks/repodetect.sh
-wget -nv -a /tmp/pre.log -O /tmp/diskdetect.sh https://$KS_SERVER/$KS_BASE/ks/diskdetect.sh
+wget --no-check-certificate -nv -a /tmp/pre.log -O /tmp/common_ks_base https://$KS_SERVER/$KS_BASE/ks/dvd/include/common_ks_base
+wget --no-check-certificate -nv -a /tmp/pre.log -O /tmp/repodetect.sh https://$KS_SERVER/$KS_BASE/ks/repodetect.sh
+wget --no-check-certificate -nv -a /tmp/pre.log -O /tmp/diskdetect.sh https://$KS_SERVER/$KS_BASE/ks/diskdetect.sh
 
 chmod +x /tmp/repodetect.sh /tmp/diskdetect.sh
 

--- a/src/DVD/ks/pupclient_x86_64.cfg
+++ b/src/DVD/ks/pupclient_x86_64.cfg
@@ -33,7 +33,7 @@ skipx
 text
 keyboard us
 lang en_US
-url --url https://#KSSERVER#/yum/#LINUXDIST#/7/x86_64
+url --noverifyssl --url https://#KSSERVER#/yum/#LINUXDIST#/7/x86_64
 
 %include /tmp/part-include
 
@@ -126,10 +126,10 @@ udftools
 
 %pre
 ksserver="#KSSERVER#"
-wget -O /tmp/diskdetect.sh https://$ksserver/ks/diskdetect.sh;
+wget --no-check-certificate -O /tmp/diskdetect.sh https://$ksserver/ks/diskdetect.sh;
 chmod 750 /tmp/diskdetect.sh;
 /tmp/diskdetect.sh;
-wget -O /tmp/repodetect.sh https://$ksserver/ks/repodetect.sh;
+wget --no-check-certificate -O /tmp/repodetect.sh https://$ksserver/ks/repodetect.sh;
 chmod 750 /tmp/repodetect.sh;
 /tmp/repodetect.sh '7' $ksserver;
 %end
@@ -158,8 +158,15 @@ fi
 DEFAULT_KERNEL_INFO=`/sbin/grubby --default-kernel`
 DEFAULT_INITRD=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep initrd | cut -f2 -d'='`
 DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 title | cut -f2 -d'='`
-/sbin/grubby --copy-default --make-default --args="boot=${BOOTDEV} fips=1" --add-kernel=`/sbin/grubby --default-kernel` --initrd=${DEFAULT_INITRD} --title="FIPS ${DEFAULT_KERNEL_TITLE}"
+/sbin/grubby --copy-default --make-default --add-kernel=`/sbin/grubby --default-kernel` --initrd=${DEFAULT_INITRD} --title="FIPS ${DEFAULT_KERNEL_TITLE}"
+# Remove ALL fips= duplicates and force fips=1.
+until [ "$(/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep args | grep -o fips | wc -l)" -eq 0 ]; do
+  $(/sbin/grubby --remove-args="fips" --update-kernel ${DEFAULT_KERNEL_INFO})
+done
+/sbin/grubby --args="boot=${BOOTDEV} fips=1" --update-kernel ${DEFAULT_KERNEL_INFO}
+
 dracut -f
+
 ## END FIPS ##
 
 # Notify users that bootstrap will run on firstboot


### PR DESCRIPTION
- Removed all kickstart client certificate verification.
- Ensured FIPS is enabled in kickstart %post section.

SIMP-1064 #comment closed in 5.1.X
SIMP-1043 #comment noverifyssl in kickstart.