### PR TITLE
SIMP-719 IPSEC Tunnel

### DIFF
--- a/Puppetfile.stable
+++ b/Puppetfile.stable
@@ -136,6 +136,10 @@ mod 'simp-inifile',
   :git => 'https://github.com/simp/puppetlabs-inifile',
   :ref => '821bad1cccfac9c9a46917d6b304d6a99878d60e'
 
+mod 'ipsec_tunnel',
+  :git => 'https://github.com/simp/simp-ipsec_tunnel',
+  :ref => 'master'
+
 mod 'simp-iptables',
   :git => 'https://github.com/simp/pupmod-simp-iptables',
   :ref => '893e645994108c18ed2d45fe295ce0d79e25def5'

--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -138,6 +138,10 @@ mod 'simp-inifile',
   :git => 'https://github.com/simp/puppetlabs-inifile',
   :ref => 'simp-master'
 
+mod 'ipsec_tunnel',
+  :git => 'https://github.com/simp/simp-ipsec_tunnel',
+  :ref => 'master'
+
 mod 'simp-iptables',
   :git => 'https://github.com/simp/pupmod-simp-iptables',
   :ref => 'master'

--- a/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/packages.yaml
+++ b/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/packages.yaml
@@ -92,6 +92,9 @@ libconfuse:
 libev:
   :rpm_name: libev-4.15-3.el7.x86_64.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/l/libev-4.15-3.el7.x86_64.rpm
+libreswan:
+  :rpm_name:  libreswan-3.17-1.el7_2.x86_64.rpm
+  :source: http://download.libreswan.org/binaries/rhel/7/x86_64/libreswan-3.17-1.el7_2.x86_64.rpm
 libselinux:
   :rpm_name: libselinux-2.2.2-6.el7.x86_64.rpm
   :source: http://mirror.steadfast.net/centos/7.2.1511/os/x86_64/Packages/libselinux-2.2.2-6.el7.x86_64.rpm

--- a/build/yum_data/SIMP5.1.0_RHEL7.1_x86_64/packages.yaml
+++ b/build/yum_data/SIMP5.1.0_RHEL7.1_x86_64/packages.yaml
@@ -104,6 +104,9 @@ libconfuse:
 libev:
   :rpm_name: libev-4.15-3.el7.x86_64.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/l/libev-4.15-3.el7.x86_64.rpm
+libreswan:
+  :rpm_name:  libreswan-3.17-1.el7_2.x86_64.rpm
+  :source: http://download.libreswan.org/binaries/rhel/7/x86_64/libreswan-3.17-1.el7_2.x86_64.rpm
 libselinux:
   :rpm_name: libselinux-2.2.2-6.el7.x86_64.rpm
   :source: Red Hat Updates Repository


### PR DESCRIPTION
  This adds the new module to the lists in PuppetFile* and
  add the libreswan to the list of packages to download
  when making the installation DVD.

  commit for simp-core V5.1
(SIMP-719)