### PR TITLE
(SIMP-1043) Default to non-validated HTTPS conns

### DIFF
--- a/src/DVD/ks/pupclient_x86_64.cfg
+++ b/src/DVD/ks/pupclient_x86_64.cfg
@@ -125,10 +125,10 @@ udftools
 
 %pre
 ksserver="#KSSERVER#"
-wget -O /tmp/diskdetect.sh https://$ksserver/ks/diskdetect.sh;
+wget --no-check-certificate -O /tmp/diskdetect.sh https://$ksserver/ks/diskdetect.sh;
 chmod 750 /tmp/diskdetect.sh;
 /tmp/diskdetect.sh;
-wget -O /tmp/repodetect.sh https://$ksserver/ks/repodetect.sh;
+wget --no-check-certificate -O /tmp/repodetect.sh https://$ksserver/ks/repodetect.sh;
 chmod 750 /tmp/repodetect.sh;
 /tmp/repodetect.sh '6' $ksserver;
 %end

--- a/src/puppet/bootstrap/environments/simp/hieradata/hosts/puppet.your.domain.yaml
+++ b/src/puppet/bootstrap/environments/simp/hieradata/hosts/puppet.your.domain.yaml
@@ -1,10 +1,18 @@
 ---
 # This must be a copy of at least 'client_nets' from simp_def.yaml if
 # you want this to cover your base YUM repo services.
-# The fact that you can't include other arrays from Hiera is
-# registered in the Puppet Labs JIRA as HI-183.
+
+# We don't enable non-TLS connections by default. All SIMP services should now
+# be able to use TLS for all connections.
+apache::conf::ssl::client_nets: "%{alias('client_nets')}"
+
+# We disable the SSL client validation for the Kickstart server. There is no
+# way to validate a default image without embedding a certificate in the image
+# and we are not going to modify the core kickstart image from the vendor.
 #
-apache::conf::allowroot : "%{alias('client_nets')}"
+# Since this system is, by default, only a kickstart/YUM server with Apache,
+# this will not adversely affect the security posture of the system.
+apache::conf::ssl::sslverifyclient: 'none'
 
 rsync::server : '127.0.0.1'
 


### PR DESCRIPTION
The kickstart process cannot contain client certificates without
modifying the vendor initrd.

We are not going to do this by default, therefore we need to ensure that
apache does not block our connections by requiring a client validation
at kickstart time.

This is safe in this case since all of our packages are signed and we
aren't using this system for anything other that kickstart and YUM.

Additionally, we now gain the ability to use TLS for all kickstart and
YUM connections!

SIMP-1043 #close #comment For 4.2.X