### PR TITLE
(SIMP-1149) Disable ISO auto-boot

### DIFF
--- a/src/DVD/isolinux/isolinux.cfg
+++ b/src/DVD/isolinux/isolinux.cfg
@@ -1,6 +1,5 @@
 default simp
 prompt 1
-timeout 600
 display boot.msg
 F1 boot.msg
 F2 options.msg


### PR DESCRIPTION
This disables auto-boot in the isolinux config file.  Previously
isolinux would timeout and boot the first menu entry.  Because that
first entry auto-installs SIMP, wiping out all local storage, it was
perilous to boot the DVD unattended.  This new behavior requires manual
intervention before the bootstrap process will proceed.

SIMP-1149 #testing
