### PR TITLE
(SIMP-1172) Replace old 6.7 mirrors w/CentOS Vault

### DIFF
--- a/build/yum_data/SIMP4.2.0_CentOS6.7_x86_64/packages.yaml
+++ b/build/yum_data/SIMP4.2.0_CentOS6.7_x86_64/packages.yaml
@@ -97,31 +97,31 @@ ganglia-gmond-python:
   :rpm_name: ganglia-gmond-python-3.7.2-2.el6.x86_64.rpm
 glibc:
   :rpm_name: glibc-2.12-1.166.el6_7.1.x86_64.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/glibc-2.12-1.166.el6_7.1.x86_64.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/glibc-2.12-1.166.el6_7.1.x86_64.rpm
 glibc-common:
   :rpm_name: glibc-common-2.12-1.166.el6_7.1.x86_64.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/glibc-common-2.12-1.166.el6_7.1.x86_64.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/glibc-common-2.12-1.166.el6_7.1.x86_64.rpm
 glibc-devel:
   :rpm_name: glibc-devel-2.12-1.166.el6_7.1.x86_64.rpm
-  :source: http://centos.mirror.nac.net/6.7/updates/x86_64/Packages/glibc-devel-2.12-1.166.el6_7.1.x86_64.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/glibc-devel-2.12-1.166.el6_7.1.x86_64.rpm
 glibc-devel_i686:
   :rpm_name: glibc-devel-2.12-1.166.el6_7.1.i686.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/glibc-devel-2.12-1.166.el6_7.1.i686.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/glibc-devel-2.12-1.166.el6_7.1.i686.rpm
 glibc-headers:
   :rpm_name: glibc-headers-2.12-1.166.el6_7.1.x86_64.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/glibc-headers-2.12-1.166.el6_7.1.x86_64.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/glibc-headers-2.12-1.166.el6_7.1.x86_64.rpm
 glibc-static:
   :rpm_name: glibc-static-2.12-1.166.el6_7.1.x86_64.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/glibc-static-2.12-1.166.el6_7.1.x86_64.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/glibc-static-2.12-1.166.el6_7.1.x86_64.rpm
 glibc-static_i686:
   :rpm_name: glibc-static-2.12-1.166.el6_7.1.i686.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/glibc-static-2.12-1.166.el6_7.1.i686.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/glibc-static-2.12-1.166.el6_7.1.i686.rpm
 glibc-utils:
   :rpm_name: glibc-utils-2.12-1.166.el6_7.1.x86_64.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/glibc-utils-2.12-1.166.el6_7.1.x86_64.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/glibc-utils-2.12-1.166.el6_7.1.x86_64.rpm
 glibc_i686:
   :rpm_name: glibc-2.12-1.166.el6_7.1.i686.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/glibc-2.12-1.166.el6_7.1.i686.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/glibc-2.12-1.166.el6_7.1.i686.rpm
 globus-callout:
   :rpm_name: globus-callout-3.13-2.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-callout-3.13-2.el6.x86_64.rpm
@@ -181,40 +181,40 @@ incron:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/incron-0.5.9-1.el6.x86_64.rpm
 java-1.7.0-openjdk:
   :rpm_name: java-1.7.0-openjdk-1.7.0.85-2.6.1.3.el6_7.x86_64.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/java-1.7.0-openjdk-1.7.0.85-2.6.1.3.el6_7.x86_64.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/java-1.7.0-openjdk-1.7.0.85-2.6.1.3.el6_7.x86_64.rpm
 java-1.7.0-openjdk-demo:
   :rpm_name: java-1.7.0-openjdk-demo-1.7.0.85-2.6.1.3.el6_7.x86_64.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/java-1.7.0-openjdk-demo-1.7.0.85-2.6.1.3.el6_7.x86_64.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/java-1.7.0-openjdk-demo-1.7.0.85-2.6.1.3.el6_7.x86_64.rpm
 java-1.7.0-openjdk-devel:
   :rpm_name: java-1.7.0-openjdk-devel-1.7.0.85-2.6.1.3.el6_7.x86_64.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/java-1.7.0-openjdk-devel-1.7.0.85-2.6.1.3.el6_7.x86_64.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/java-1.7.0-openjdk-devel-1.7.0.85-2.6.1.3.el6_7.x86_64.rpm
 java-1.7.0-openjdk-src:
   :rpm_name: java-1.7.0-openjdk-src-1.7.0.85-2.6.1.3.el6_7.x86_64.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/java-1.7.0-openjdk-src-1.7.0.85-2.6.1.3.el6_7.x86_64.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/java-1.7.0-openjdk-src-1.7.0.85-2.6.1.3.el6_7.x86_64.rpm
 kernel:
   :rpm_name: kernel-2.6.32-573.3.1.el6.x86_64.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/kernel-2.6.32-573.3.1.el6.x86_64.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/kernel-2.6.32-573.3.1.el6.x86_64.rpm
 kernel-abi-whitelists:
   :rpm_name: kernel-abi-whitelists-2.6.32-573.3.1.el6.noarch.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/kernel-abi-whitelists-2.6.32-573.3.1.el6.noarch.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/kernel-abi-whitelists-2.6.32-573.3.1.el6.noarch.rpm
 kernel-debug:
   :rpm_name: kernel-debug-2.6.32-573.3.1.el6.x86_64.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/kernel-debug-2.6.32-573.3.1.el6.x86_64.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/kernel-debug-2.6.32-573.3.1.el6.x86_64.rpm
 kernel-debug-devel:
   :rpm_name: kernel-debug-devel-2.6.32-573.3.1.el6.x86_64.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/kernel-debug-devel-2.6.32-573.3.1.el6.x86_64.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/kernel-debug-devel-2.6.32-573.3.1.el6.x86_64.rpm
 kernel-devel:
   :rpm_name: kernel-devel-2.6.32-573.3.1.el6.x86_64.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/kernel-devel-2.6.32-573.3.1.el6.x86_64.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/kernel-devel-2.6.32-573.3.1.el6.x86_64.rpm
 kernel-doc:
   :rpm_name: kernel-doc-2.6.32-573.3.1.el6.noarch.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/kernel-doc-2.6.32-573.3.1.el6.noarch.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/kernel-doc-2.6.32-573.3.1.el6.noarch.rpm
 kernel-firmware:
   :rpm_name: kernel-firmware-2.6.32-573.3.1.el6.noarch.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/kernel-firmware-2.6.32-573.3.1.el6.noarch.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/kernel-firmware-2.6.32-573.3.1.el6.noarch.rpm
 kernel-headers:
   :rpm_name: kernel-headers-2.6.32-573.3.1.el6.x86_64.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/kernel-headers-2.6.32-573.3.1.el6.x86_64.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/kernel-headers-2.6.32-573.3.1.el6.x86_64.rpm
 kibana:
   :rpm_name: kibana-3.1.0.SIMP-0.noarch.rpm
   :source: https://dl.bintray.com/simp/4.2.X-Ext/kibana-3.1.0.SIMP-0.noarch.rpm
@@ -334,13 +334,13 @@ mysql-connector-python:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/mysql-connector-python-1.1.6-1.el6.noarch.rpm
 nscd:
   :rpm_name: nscd-2.12-1.166.el6_7.1.x86_64.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/nscd-2.12-1.166.el6_7.1.x86_64.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/nscd-2.12-1.166.el6_7.1.x86_64.rpm
 nspr:
   :rpm_name: nspr-4.10.8-1.el6_6.x86_64.rpm
   :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.7/os/x86_64/Packages/nspr-4.10.8-1.el6_6.x86_64.rpm
 nss:
   :rpm_name: nss-3.19.1-3.el6_6.x86_64.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/nss-3.19.1-3.el6_6.x86_64.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/nss-3.19.1-3.el6_6.x86_64.rpm
 nss-softokn:
   :rpm_name: nss-softokn-3.14.3-22.el6_6.x86_64.rpm
   :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.7/os/x86_64/Packages/nss-softokn-3.14.3-22.el6_6.x86_64.rpm
@@ -349,13 +349,13 @@ nss-softokn-freebl:
   :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.7/os/x86_64/Packages/nss-softokn-freebl-3.14.3-22.el6_6.x86_64.rpm
 nss-sysinit:
   :rpm_name: nss-sysinit-3.19.1-3.el6_6.x86_64.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/nss-sysinit-3.19.1-3.el6_6.x86_64.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/nss-sysinit-3.19.1-3.el6_6.x86_64.rpm
 nss-tools:
   :rpm_name: nss-tools-3.19.1-3.el6_6.x86_64.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/nss-tools-3.19.1-3.el6_6.x86_64.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/nss-tools-3.19.1-3.el6_6.x86_64.rpm
 nss-util:
   :rpm_name: nss-util-3.19.1-1.el6_6.x86_64.rpm
-  :source: http://mirror.cs.vt.edu/pub/CentOS/6.7/updates/x86_64/Packages/nss-util-3.19.1-1.el6_6.x86_64.rpm
+  :source: http://bay.uchicago.edu/centos-vault/6.7/updates/x86_64/Packages/nss-util-3.19.1-1.el6_6.x86_64.rpm
 openssl:
   :rpm_name: openssl-1.0.1e-42.el6.x86_64.rpm
   :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.7/os/x86_64/Packages/openssl-1.0.1e-42.el6.x86_64.rpm


### PR DESCRIPTION
Following the release of CentOS 6.8, The CentOS mirrors have begun
retiring old 6.7 packages.  This causes problems during repoclosure for
4.2.X simp-core.

This patch replaces the repositories for some packages with CentOS
long-term "vault" archive repositories.

SIMP-1172 #close