### PR TITLE
(SIMP-1156) Enable SSL for kickstarting

### DIFF
--- a/src/DVD/ks/pupclient_x86_64.cfg
+++ b/src/DVD/ks/pupclient_x86_64.cfg
@@ -33,7 +33,7 @@ skipx
 text
 keyboard us
 lang en_US
-url --url https://#KSSERVER#/yum/#LINUXDIST#/6/x86_64
+url --url https://#KSSERVER#/yum/#LINUXDIST#/6/x86_64 --noverifyssl
 
 %include /tmp/part-include
 

--- a/src/DVD/ks/repodetect.sh
+++ b/src/DVD/ks/repodetect.sh
@@ -51,16 +51,16 @@ fi
 
 if [ "$type" == 'RedHat' ]; then
   cat << EOF > /tmp/repo-include
-repo --name="HighAvailability" --baseurl="$uri_header/HighAvailability"
-repo --name="LoadBalancer" --baseurl="$uri_header/LoadBalancer"
-repo --name="ResilientStorage" --baseurl="$uri_header/ResilientStorage"
-repo --name="ScalableFileSystme" --baseurl="$uri_header/ScalableFileSystem"
-repo --name="Server" --baseurl="$uri_header/Server"
-repo --name="Local" --baseurl="$local_header"
+repo --name="HighAvailability" --baseurl="$uri_header/HighAvailability" --noverifyssl
+repo --name="LoadBalancer" --baseurl="$uri_header/LoadBalancer" --noverifyssl
+repo --name="ResilientStorage" --baseurl="$uri_header/ResilientStorage" --noverifyssl
+repo --name="ScalableFileSystme" --baseurl="$uri_header/ScalableFileSystem" --noverifyssl
+repo --name="Server" --baseurl="$uri_header/Server" --noverifyssl
+repo --name="Local" --baseurl="$local_header" --noverifyssl
 EOF
 elif [ "$type" == 'CentOS' ]; then
   cat << EOF > /tmp/repo-include
-repo --name="Server" --baseurl="$uri_header"
-repo --name="Local" --baseurl="$local_header"
+repo --name="Server" --baseurl="$uri_header" --noverifyssl
+repo --name="Local" --baseurl="$local_header" --noverifyssl
 EOF
 fi


### PR DESCRIPTION
Problems remained with 4.2 access to yum repositories after
SSL was enabled for kickstarting.  This fix updates
repodetect.sh and pup-client kickstart files for 4.2
by adding --noverifyssl to the repo and url commands used by anaconda.

SIMP-1156 #close
