### PR TITLE
(SIMP-1132) Add the 'site_files' module path

### DIFF
--- a/src/puppet/bootstrap/auth.conf
+++ b/src/puppet/bootstrap/auth.conf
@@ -84,10 +84,20 @@ allow $1
 path ~ ^/file_(metadata|content)/modules/pki/keydist/(cacerts|mcollective)
 allow *
 
+path ~ ^/file_(metadata|content)/site_files/pki_files/files/keydist(cacerts|mcollective)
+allow *
+
+# SIMP site_files materials
 
 # Allow access to the keydist space for only the nodes that match via
 # certificate name
 path ~ ^/file_(metadata|content)/modules/pki/keydist/([^/]+)
+allow $2
+
+path ~ ^/file_(metadata|content)/site_files/pki_files/files/keytabs/([^/]+)
+allow $2
+
+path ~ ^/file_(metadata|content)/site_files/krb5_files/files/keytabs/([^/]+)
 allow $2
 
 # Allow all nodes to access all file services; this is necessary for

--- a/src/puppet/bootstrap/environments/simp/environment.conf
+++ b/src/puppet/bootstrap/environments/simp/environment.conf
@@ -1,0 +1,19 @@
+# Add support for external and/or site-specific file locations that should not
+# be touched by code manager or r10k under a 'site_files' directory.
+#
+# This is used by the SIMP stack and certain features may not work if you don't
+# have this module path in place.
+#
+# While each module in here is a valid module in your path, ideally there
+# should only be modules of the form
+# <primary_module_name>_files/files/<yourfiles here>.
+#
+# For example, if you were supporting the 'foo' module:
+#
+#   site_files/foo_files/files/foo.conf
+#
+# Do *not* remove basemodulepath from this!
+
+
+modulepath = modules:site_files:$basemodulepath
+environment_timeout = 0

--- a/src/puppet/bootstrap/environments/simp/site_files/README
+++ b/src/puppet/bootstrap/environments/simp/site_files/README
@@ -1,0 +1,8 @@
+# This directory houses SIMP-specific files that may be auto-generated at
+# runtime.
+#
+# Please take care when modifying anything in this directory as it may severely
+# impact your system!
+#
+# The purpose of this is to eliminate all dynamic materials from the main SIMP
+# repo so that users can easily manage their systems with r10k.


### PR DESCRIPTION
This adds a 'site_files' directory to the environment modulepath so
that we can avoid issues with generated materials and code-manager/r10k.

SIMP-1132 #comment 4.2.X
SIMP-1213 #close

Change-Id: I091b3e1c09a9c2b2fccceef301a758954c32ea3c
