### PR TITLE
(SIMP-1132) Add the 'site_files' module path

### DIFF
--- a/src/puppet/bootstrap/auth.conf
+++ b/src/puppet/bootstrap/auth.conf
@@ -84,10 +84,20 @@ allow $1
 path ~ ^/file_(metadata|content)/modules/pki/keydist/(cacerts|mcollective)
 allow *
 
+path ~ ^/file_(metadata|content)/site_files/pki_files/files/keydist(cacerts|mcollective)
+allow *
+
+# SIMP site_files materials
 
 # Allow access to the keydist space for only the nodes that match via
 # certificate name
 path ~ ^/file_(metadata|content)/modules/pki/keydist/([^/]+)
+allow $2
+
+path ~ ^/file_(metadata|content)/site_files/pki_files/files/keytabs/([^/]+)
+allow $2
+
+path ~ ^/file_(metadata|content)/site_files/krb5_files/files/keytabs/([^/]+)
 allow $2
 
 # Allow all nodes to access all file services; this is necessary for

--- a/src/puppet/bootstrap/build/simp-bootstrap.spec
+++ b/src/puppet/bootstrap/build/simp-bootstrap.spec
@@ -1,7 +1,7 @@
 Summary: SIMP Bootstrap
 Name: simp-bootstrap
-Version: 5.2.1
-Release: 5
+Version: 5.3.0
+Release: 0
 License: Apache License 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -58,11 +58,13 @@ cp puppet.conf %{buildroot}/%{prefix}/puppet.conf.rpmnew
 %files
 %defattr(0640,root,puppet,0750)
 %{prefix}/environments/simp
+%dir %{prefix}/environments/simp/site_files
 %config(noreplace) %attr(0660,-,-) %{prefix}/environments/simp/localusers
 %attr(0750,puppet,puppet) %{prefix}/environments/simp/simp_autofiles
 %config(noreplace) %{prefix}/auth.conf.simp
 %config(noreplace) %{prefix}/autosign.conf
 %config(noreplace) %{prefix}/hiera.yaml
+%config(noreplace) %{prefix}/environments/environment.conf
 %config(noreplace) %{prefix}/environments/simp/hieradata/RedHat/6.yaml
 %config(noreplace) %{prefix}/environments/simp/hieradata/hosts/puppet.your.domain.yaml
 %config(noreplace) %{prefix}/environments/simp/hieradata/simp/logstash/default.yaml
@@ -298,6 +300,12 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Thu Jul 07 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.3.0-0
+- Moved to semantic versioning
+- Added support for a 'site_files' module path in the primary 'simp'
+  environment for modules like krb5 and pki that have files in them that should
+  not be managed by r10k or code manager.
+
 * Mon Apr 25 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 5.2.1-5
 - Required 'sudo' to resolve ordering race that overwrote '/etc/sudoers'.
 

--- a/src/puppet/bootstrap/environments/simp/environment.conf
+++ b/src/puppet/bootstrap/environments/simp/environment.conf
@@ -1,0 +1,19 @@
+# Add support for external and/or site-specific file locations that should not
+# be touched by code manager or r10k under a 'site_files' directory.
+#
+# This is used by the SIMP stack and certain features may not work if you don't
+# have this module path in place.
+#
+# While each module in here is a valid module in your path, ideally there
+# should only be modules of the form
+# <primary_module_name>_files/files/<yourfiles here>.
+#
+# For example, if you were supporting the 'foo' module:
+#
+#   site_files/foo_files/files/foo.conf
+#
+# Do *not* remove basemodulepath from this!
+
+
+modulepath = modules:site_files:$basemodulepath
+environment_timeout = 0

--- a/src/puppet/bootstrap/environments/simp/site_files/README
+++ b/src/puppet/bootstrap/environments/simp/site_files/README
@@ -1,0 +1,8 @@
+# This directory houses SIMP-specific files that may be auto-generated at
+# runtime.
+#
+# Please take care when modifying anything in this directory as it may severely
+# impact your system!
+#
+# The purpose of this is to eliminate all dynamic materials from the main SIMP
+# repo so that users can easily manage their systems with r10k.


### PR DESCRIPTION
This adds a 'site_files' directory to the environment modulepath so
that we can avoid issues with generated materials and code-manager/r10k.

SIMP-1132 #comment 5.1.X
SIMP-1212 #close

Change-Id: If35b03798a6a69f52341abf0b69684e7e37c299f
