### PR TITLE
(SIMP-1167) Added NFS requirements for SIMP

### DIFF
--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -146,7 +146,7 @@ mod 'simp-clamav',
   :git => 'https://github.com/simp/pupmod-simp-clamav',
   :ref => 'master'
 
-mod 'simp-concat',
+mod 'simp-simpcat',
   :git => 'https://github.com/simp/pupmod-simp-concat',
   :ref => 'master'
 
@@ -178,8 +178,8 @@ mod 'simp-jenkins',
   :git => 'https://github.com/simp/pupmod-simp-jenkins',
   :ref => 'master'
 
-mod 'simp-kibana',
-  :git => 'https://github.com/simp/pupmod-simp-kibana',
+mod 'simp-krb5',
+  :git => 'https://github.com/simp/pupmod-simp-krb5',
   :ref => 'master'
 
 mod 'simp-libvirt',


### PR DESCRIPTION
* Also removed the kibana module since it is no longer supported

SIMP-1167 #comment Puppetfile update for 5.1.X
SIMP-1263 #close

Change-Id: Ia3166821cbc234818d10e21c50aec7ab8f042b09