### PR TITLE
(SIMP-1167) Added NFS requirements for SIMP

### DIFF
--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -154,7 +154,7 @@ mod 'simp-clamav',
   :git => 'https://github.com/simp/pupmod-simp-clamav',
   :ref => 'master'
 
-mod 'simp-concat',
+mod 'simp-simpcat',
   :git => 'https://github.com/simp/pupmod-simp-concat',
   :ref => 'master'
 
@@ -190,8 +190,8 @@ mod 'simp-jenkins',
   :git => 'https://github.com/simp/pupmod-simp-jenkins',
   :ref => 'master'
 
-mod 'simp-kibana',
-  :git => 'https://github.com/simp/pupmod-simp-kibana',
+mod 'simp-krb5',
+  :git => 'https://github.com/simp/pupmod-simp-krb5',
   :ref => 'master'
 
 mod 'simp-libvirt',


### PR DESCRIPTION
* Also removed the kibana module since it is no longer supported

SIMP-1167 #comment Puppetfile update for 4.2.X
SIMP-1262 #close

Change-Id: Ic1e305935841e82850a3c8e5091cc77b7fb521da