### PR TITLE
(SIMP-1250) Provide disabling FIPS on ISO

### DIFF
--- a/src/DVD/isolinux/boot.msg
+++ b/src/DVD/isolinux/boot.msg
@@ -1,6 +1,8 @@
  
 
 
+ -  0aNOTE:07 To disable FIPS, add 0afips=007 to any option.
+
  -  To auto-install SIMP, type 0asimp <ENTER>07.
     - This will erase your existing system!
     - You need at least 50GB of disk space for this to succeed.

--- a/src/DVD/ks/dvd/auto.cfg
+++ b/src/DVD/ks/dvd/auto.cfg
@@ -23,6 +23,15 @@ chmod +x /tmp/*.sh
 
 /tmp/repodetect.sh `python -c "import ConfigParser; config = ConfigParser.ConfigParser(); config.read('/mnt/install/repo/.treeinfo'); print config.get('general','version')"`
 /tmp/diskdetect.sh
+
+# Prep for selecting the correct dracut to install
+use_fips=`awk -F "fips=" '{print $2}' /proc/cmdline | cut -f1 -d' '`
+
+if [ $use_fips == "0" ]; then
+  echo 'dracut' > /tmp/dracut_packages
+else
+  echo 'dracut-fips' > /tmp/dracut_packages
+fi
 %end
 
 %post --nochroot --erroronfail
@@ -176,17 +185,21 @@ eject /tmp/cdrom || true
 
 %post
 # FIPS
-if [ -e /sys/firmware/efi ]; then
-  BOOTDEV=`df /boot/efi | tail -1 | cut -f1 -d' '`
-else
-  BOOTDEV=`df /boot | tail -1 | cut -f1 -d' '`
-fi
+use_fips=`awk -F "fips=" '{print $2}' /proc/cmdline | cut -f1 -d' '`
 
-# In case you need a working fallback
-DEFAULT_KERNEL_INFO=`/sbin/grubby --default-kernel`
-DEFAULT_INITRD=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep initrd | cut -f2 -d'='`
-DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 title | cut -f2 -d'='`
-/sbin/grubby --copy-default --make-default --args="boot=${BOOTDEV} fips=1" --add-kernel=`/sbin/grubby --default-kernel` --initrd=${DEFAULT_INITRD} --title="FIPS ${DEFAULT_KERNEL_TITLE}"
+if [ $use_fips != "0" ]; then
+  if [ -e /sys/firmware/efi ]; then
+    BOOTDEV=`df /boot/efi | tail -1 | cut -f1 -d' '`
+  else
+    BOOTDEV=`df /boot | tail -1 | cut -f1 -d' '`
+  fi
+
+  # In case you need a working fallback
+  DEFAULT_KERNEL_INFO=`/sbin/grubby --default-kernel`
+  DEFAULT_INITRD=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep initrd | cut -f2 -d'='`
+  DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 title | cut -f2 -d'='`
+  /sbin/grubby --copy-default --make-default --args="boot=${BOOTDEV} fips=1" --add-kernel=`/sbin/grubby --default-kernel` --initrd=${DEFAULT_INITRD} --title="FIPS ${DEFAULT_KERNEL_TITLE}"
+fi
 
 # For the disk crypto
 if [ -f "/etc/.cryptcreds" ]; then

--- a/src/DVD/ks/dvd/include/common_ks_base
+++ b/src/DVD/ks/dvd/include/common_ks_base
@@ -2,7 +2,7 @@ authconfig --enableshadow --passalgo=sha512 --enablemd5
 network --nodns --hostname=puppet.change.me
 skipx
 rootpw --iscrypted $6$3iLC5g2j9z/UvuAX$wKQy4.T92omIx7aEQ6iVunQHSG0l2eVd7be47kUKC2nWFoJhoARx68h8x.jcR99TZZRrFf8SKzVlvK3JdhKkf0
-bootloader --location=mbr --driveorder=sda,hda --append="fips=1 console=ttyS1,57600 console=tty0" --iscrypted --password=grub.pbkdf2.sha512.10000.38F6446B9655E8E98CEA82F10EFE4DA30A963932FE415EC72B744FB04EB3636384BD968004B64E5A900CF7D08C9064725A6F2E8246F5874BC4954F9B489D72BA.EE006A76847C20D226064CB77FEC9C697229DE22C5149331425AB3EEBCB99504F712ACBE101D332B35D8A277C7D7E74D8A905C474533A3C7B0428D3BD416382C
+bootloader --location=mbr --driveorder=sda,hda --append="console=ttyS1,57600 console=tty0" --iscrypted --password=grub.pbkdf2.sha512.10000.38F6446B9655E8E98CEA82F10EFE4DA30A963932FE415EC72B744FB04EB3636384BD968004B64E5A900CF7D08C9064725A6F2E8246F5874BC4954F9B489D72BA.EE006A76847C20D226064CB77FEC9C697229DE22C5149331425AB3EEBCB99504F712ACBE101D332B35D8A277C7D7E74D8A905C474533A3C7B0428D3BD416382C
 zerombr
 firewall --enabled --ssh
 firstboot --disable
@@ -29,9 +29,7 @@ coolkey
 crontabs
 cryptsetup-luks
 dhclient
-# dracut
-dracut-fips
-dracut-fips-aesni
+%include /tmp/dracut_packages
 fipscheck
 git
 gnupg

--- a/src/DVD/ks/dvd/include/min_ks_base
+++ b/src/DVD/ks/dvd/include/min_ks_base
@@ -28,9 +28,7 @@ coolkey
 crontabs
 cryptsetup-luks
 dhclient
-# dracut
-dracut-fips
-dracut-fips-aesni
+%include /tmp/dracut_packages
 fipscheck
 git
 gnupg

--- a/src/DVD/ks/dvd/min.cfg
+++ b/src/DVD/ks/dvd/min.cfg
@@ -77,16 +77,20 @@ fi
 
 %post
 # FIPS
-if [ -e /sys/firmware/efi ]; then
-  BOOTDEV=`df /boot/efi | tail -1 | cut -f1 -d' '`
-else
-  BOOTDEV=`df /boot | tail -1 | cut -f1 -d' '`
+use_fips=`awk -F "fips=" '{print $2}' /proc/cmdline | cut -f1 -d' '`
+
+if [ $use_fips != "0" ]; then
+  if [ -e /sys/firmware/efi ]; then
+    BOOTDEV=`df /boot/efi | tail -1 | cut -f1 -d' '`
+  else
+    BOOTDEV=`df /boot | tail -1 | cut -f1 -d' '`
+  fi
+  # In case you need a working fallback
+  DEFAULT_KERNEL_INFO=`/sbin/grubby --default-kernel`
+  DEFAULT_INITRD=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep initrd | cut -f2 -d'='`
+  DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 title | cut -f2 -d'='`
+  /sbin/grubby --copy-default --make-default --args="boot=${BOOTDEV} fips=1" --add-kernel=`/sbin/grubby --default-kernel` --initrd=${DEFAULT_INITRD} --title="FIPS ${DEFAULT_KERNEL_TITLE}"
 fi
-# In case you need a working fallback
-DEFAULT_KERNEL_INFO=`/sbin/grubby --default-kernel`
-DEFAULT_INITRD=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep initrd | cut -f2 -d'='`
-DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 title | cut -f2 -d'='`
-/sbin/grubby --copy-default --make-default --args="boot=${BOOTDEV} fips=1" --add-kernel=`/sbin/grubby --default-kernel` --initrd=${DEFAULT_INITRD} --title="FIPS ${DEFAULT_KERNEL_TITLE}"
 
 # For the disk crypto
 if [ -f "/etc/.cryptcreds" ]; then


### PR DESCRIPTION
This provides the ability to disable FIPS on the ISO at initial boot
time.

SIMP-1250 #close Fix for 5.1.X

Change-Id: I781a76d3d677ce64809cc50956a440afa2814c42