### PR TITLE
(SIMP-1249) Provide disabling FIPS on ISO

### DIFF
--- a/src/DVD/isolinux/boot.msg
+++ b/src/DVD/isolinux/boot.msg
@@ -1,6 +1,8 @@
  
 
 
+ -  0aNOTE:07 To disable FIPS, add 0afips=007 to any option.
+
  -  To auto-install SIMP, type 0asimp <ENTER>07.
     - This will erase your existing system!
     - You need at least 50GB of disk space for this to succeed.

--- a/src/DVD/ks/dvd/auto.cfg
+++ b/src/DVD/ks/dvd/auto.cfg
@@ -23,6 +23,15 @@ chmod +x /tmp/*.sh
 
 /tmp/repodetect.sh `python -c "import ConfigParser; config = ConfigParser.ConfigParser(); config.read('/mnt/stage2/.treeinfo'); print config.get('general','version')"`
 /tmp/diskdetect.sh
+
+# Prep for selecting the correct dracut to install
+use_fips=`awk -F "fips=" '{print $2}' /proc/cmdline | cut -f1 -d' '`
+
+if [ $use_fips == "0" ]; then
+  echo 'dracut' > /tmp/dracut_packages
+else
+  echo 'dracut-fips' > /tmp/dracut_packages
+fi
 %end
 
 %post --nochroot --erroronfail
@@ -192,17 +201,21 @@ sed -i '/PRELINKING=yes/ c\PRELINKING=no' /etc/sysconfig/prelink
 prelink -u -a
 
 # FIPS
-if [ -e /sys/firmware/efi ]; then
-  BOOTDEV=`df /boot/efi | tail -1 | cut -f1 -d' '`
-else
-  BOOTDEV=`df /boot | tail -1 | cut -f1 -d' '`
-fi
+use_fips=`awk -F "fips=" '{print $2}' /proc/cmdline | cut -f1 -d' '`
 
-# In case you need a working fallback
-DEFAULT_KERNEL_INFO=`/sbin/grubby --default-kernel`
-DEFAULT_INITRD=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep initrd | cut -f2 -d'='`
-DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 title | cut -f2 -d'='`
-/sbin/grubby --copy-default --make-default --args="boot=${BOOTDEV} fips=1" --add-kernel=`/sbin/grubby --default-kernel` --initrd=${DEFAULT_INITRD} --title="FIPS ${DEFAULT_KERNEL_TITLE}"
+if [ $use_fips != "0" ]; then
+  if [ -e /sys/firmware/efi ]; then
+    BOOTDEV=`df /boot/efi | tail -1 | cut -f1 -d' '`
+  else
+    BOOTDEV=`df /boot | tail -1 | cut -f1 -d' '`
+  fi
+
+  # In case you need a working fallback
+  DEFAULT_KERNEL_INFO=`/sbin/grubby --default-kernel`
+  DEFAULT_INITRD=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep initrd | cut -f2 -d'='`
+  DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 title | cut -f2 -d'='`
+  /sbin/grubby --copy-default --make-default --args="boot=${BOOTDEV} fips=1" --add-kernel=`/sbin/grubby --default-kernel` --initrd=${DEFAULT_INITRD} --title="FIPS ${DEFAULT_KERNEL_TITLE}"
+fi
 
 # For the disk crypto
 if [ -f "/etc/.cryptcreds" ]; then

--- a/src/DVD/ks/dvd/include/common_ks_base
+++ b/src/DVD/ks/dvd/include/common_ks_base
@@ -2,7 +2,7 @@ authconfig --enableshadow --passalgo=sha512 --enablemd5
 network --nodns --hostname=puppet.change.me
 skipx
 rootpw --iscrypted $6$80gio95q$anOG/VG/cs0vNfYblxQKnH7J3z9omZbxe3Gpa2VojlNf8CbWmtZWXbd/O.4HdlGbGFTRLmvtVe8.jEjQpbxDl/
-bootloader --location=mbr --driveorder=sda,hda --append="fips=1 console=ttyS1,57600 console=tty0" --iscrypted --password=$6$EiDpY9dX.blbssNm$9KxoNaquKc1HEAjO.uH1EqFO.PpC.uJyfvjoIAvgojAKoio7MXHCwxm4vwBW4TNlKQxkZaNRJ9cxDmmStDe9H.
+bootloader --location=mbr --driveorder=sda,hda --append="console=ttyS1,57600 console=tty0" --iscrypted --password=$6$EiDpY9dX.blbssNm$9KxoNaquKc1HEAjO.uH1EqFO.PpC.uJyfvjoIAvgojAKoio7MXHCwxm4vwBW4TNlKQxkZaNRJ9cxDmmStDe9H.
 zerombr
 key --skip
 firewall --enabled --ssh
@@ -38,8 +38,7 @@ coolkey
 cpuspeed
 cryptsetup-luks
 dhclient
-# dracut
-dracut-fips
+%include /tmp/dracut_packages
 fipscheck
 git
 gnupg

--- a/src/DVD/ks/dvd/include/min_ks_base
+++ b/src/DVD/ks/dvd/include/min_ks_base
@@ -2,7 +2,7 @@ authconfig --enableshadow --passalgo=sha512 --enablemd5
 network --bootproto=dhcp --nodns --hostname=puppet.change.me
 skipx
 rootpw --iscrypted $6$cKH4tleUAthZBrFM$ZnXngjlvHTDCJOJWZOcOWXH5UHR9v75XbkGzshrBaR8LC30Jkxf/KP4kIFrSFOMgxDmha/SuXv9I8N2C0RPV1.
-bootloader --location=mbr --driveorder=sda,hda --append="fips=1 console=ttyS1,57600 console=tty0" --iscrypted --password=$6$Y3AnAvsj52K3HOvh$s.BH/N1MzeTTk/5U/6C55FsG0839vCIj0RPmEaGMM4Sqz5i.VtW.RNPND1nXJKbthvUw9AKMRcNL/fucnSn/L1
+bootloader --location=mbr --driveorder=sda,hda --append="console=ttyS1,57600 console=tty0" --iscrypted --password=$6$Y3AnAvsj52K3HOvh$s.BH/N1MzeTTk/5U/6C55FsG0839vCIj0RPmEaGMM4Sqz5i.VtW.RNPND1nXJKbthvUw9AKMRcNL/fucnSn/L1
 zerombr
 key --skip
 firewall --enabled --ssh
@@ -38,8 +38,7 @@ coolkey
 cpuspeed
 cryptsetup-luks
 dhclient
-# dracut
-dracut-fips
+%include /tmp/dracut_packages
 fipscheck
 gnupg
 irqbalance

--- a/src/DVD/ks/dvd/min.cfg
+++ b/src/DVD/ks/dvd/min.cfg
@@ -81,16 +81,20 @@ sed -i '/PRELINKING=yes/ c\PRELINKING=no' /etc/sysconfig/prelink
 prelink -u -a
 
 # FIPS
-if [ -e /sys/firmware/efi ]; then
-  BOOTDEV=`df /boot/efi | tail -1 | cut -f1 -d' '`
-else
-  BOOTDEV=`df /boot | tail -1 | cut -f1 -d' '`
+use_fips=`awk -F "fips=" '{print $2}' /proc/cmdline | cut -f1 -d' '`
+
+if [ $use_fips != "0" ]; then
+  if [ -e /sys/firmware/efi ]; then
+    BOOTDEV=`df /boot/efi | tail -1 | cut -f1 -d' '`
+  else
+    BOOTDEV=`df /boot | tail -1 | cut -f1 -d' '`
+  fi
+  # In case you need a working fallback
+  DEFAULT_KERNEL_INFO=`/sbin/grubby --default-kernel`
+  DEFAULT_INITRD=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep initrd | cut -f2 -d'='`
+  DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 title | cut -f2 -d'='`
+  /sbin/grubby --copy-default --make-default --args="boot=${BOOTDEV} fips=1" --add-kernel=`/sbin/grubby --default-kernel` --initrd=${DEFAULT_INITRD} --title="FIPS ${DEFAULT_KERNEL_TITLE}"
 fi
-# In case you need a working fallback
-DEFAULT_KERNEL_INFO=`/sbin/grubby --default-kernel`
-DEFAULT_INITRD=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep initrd | cut -f2 -d'='`
-DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 title | cut -f2 -d'='`
-/sbin/grubby --copy-default --make-default --args="boot=${BOOTDEV} fips=1" --add-kernel=`/sbin/grubby --default-kernel` --initrd=${DEFAULT_INITRD} --title="FIPS ${DEFAULT_KERNEL_TITLE}"
 
 # For the disk crypto
 if [ -f "/etc/.cryptcreds" ]; then


### PR DESCRIPTION
This provides the ability to disable FIPS on the ISO at initial boot
time.

SIMP-1249 #close Fix for 4.2.X

Change-Id: I75bb288bc064c9fcdedeb6dba63ed192805c415f
