### PR TITLE
(SIMP-1523) Bash redirect does not squash STDERR

### DIFF
--- a/src/utils/scripts/bin/unpack_dvd
+++ b/src/utils/scripts/bin/unpack_dvd
@@ -104,7 +104,7 @@ def update_yum_repo(repo)
     begin
       if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('1.9')
         # Use Puppet to hack around the lack of symbolic modes in Ruby < 1.9
-        system(%{puppet resource file #{repo} recurse=true mode='g+srX' 2>&1 > /dev/null})
+        system(%{puppet resource file #{repo} recurse=true mode='g+srX' > /dev/null 2>&1})
       else
         FileUtils.chmod_R('g+srX',repo)
       end

--- a/src/utils/share/upgrade_scripts/migrate_to_environments
+++ b/src/utils/share/upgrade_scripts/migrate_to_environments
@@ -73,21 +73,21 @@ begin
   Dir.chdir(backup_target) do
     FileUtils.mkdir('git_repo')
     Dir.chdir('git_repo') do
-      system(%{git init --bare 2>&1 > /dev/null})
+      system(%{git init --bare > /dev/null 2>&1})
     end
 
     Dir.chdir(puppet_dir) do
       if File.exist?('.git')
         FileUtils.mv('.git','.git.simpbak')
-        system(%{git add .git.simpbak 2>&1 > /dev/null})
+        system(%{git add .git.simpbak > /dev/null 2>&1})
         made_git_backup = true
       end
 
       system(%{getfacl -R . > #{backup_target}/etc_puppet.facl})
 
-      system(%{git init 2>&1 > /dev/null})
-      system(%{git add * 2>&1 > /dev/null})
-      system(%{git commit -m 'SIMP Migration Backup at #{Time.now}' 2>&1 >/dev/null})
+      system(%{git init > /dev/null 2>&1})
+      system(%{git add * > /dev/null 2>&1})
+      system(%{git commit -m 'SIMP Migration Backup at #{Time.now}' > /dev/null 2>&1})
       system(%{git remote add origin #{backup_target}/git_repo})
       system(%{git push origin master})
     end


### PR DESCRIPTION
Several bash redirects in unpack_dvd and migrate_to_environments do not
work as intended. STDERR is still sent to the console.