### PR TITLE
(SIMP-1685) Replaced bintray with packagecloud in simp.repo

### DIFF
--- a/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/repos/simp.repo
+++ b/build/yum_data/SIMP5.1.0_CentOS7.0_x86_64/repos/simp.repo
@@ -1,9 +1,21 @@
 [simp-base]
 name=simp-base
-baseurl=https://dl.bintray.com/simp/5.1.X 
+baseurl=https://packagecloud.io/simp-project/5_X/el/7/$basearch
+gpgcheck=1
 enabled=1
+gpgkey=https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
 
 [simp-ext]
 name=simp-ext
-baseurl=https://dl.bintray.com/simp/5.1.X-Ext 
+baseurl=https://packagecloud.io/simp-project/5_X_Dependencies/el/7/$basearch
+gpgcheck=1
 enabled=1
+gpgkey=https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
+       https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs
+       https://getfedora.org/static/352C64E5.txt
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300

--- a/build/yum_data/SIMP5.1.0_RHEL7.2_x86_64/repos/simp.repo
+++ b/build/yum_data/SIMP5.1.0_RHEL7.2_x86_64/repos/simp.repo
@@ -1,9 +1,21 @@
 [simp-base]
 name=simp-base
-baseurl=https://dl.bintray.com/simp/5.1.X 
+baseurl=https://packagecloud.io/simp-project/5_X/el/7/$basearch
+gpgcheck=1
 enabled=1
+gpgkey=https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
 
 [simp-ext]
 name=simp-ext
-baseurl=https://dl.bintray.com/simp/5.1.X-Ext 
+baseurl=https://packagecloud.io/simp-project/5_X_Dependencies/el/7/$basearch
+gpgcheck=1
 enabled=1
+gpgkey=https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
+       https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs
+       https://getfedora.org/static/352C64E5.txt
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300


### PR DESCRIPTION
build/yum_data/SIMP*/repos/simp.repo was updated to use packagecloud,
but packages.yaml was not.  That functionality will be upgraded by
SIMP-1447.

SIMP-1685 #comment Done 5.2.X
