### PR TITLE
(SIMP-1699) Problems kickstarting with FIPS enabled

### DIFF
--- a/src/DVD/ks/pupclient_x86_64.cfg
+++ b/src/DVD/ks/pupclient_x86_64.cfg
@@ -14,7 +14,7 @@
 #        - Current CASE SENSITIVE options: RedHat CentOS
 
 authconfig --enableshadow --passalgo=sha512
-bootloader --location=mbr --append="fips=1 console=ttyS1,57600 console=tty1" --iscrypted --password=#BOOTPASS#
+bootloader --location=mbr --append="console=ttyS1,57600 console=tty1" --iscrypted --password=#BOOTPASS#
 rootpw --iscrypted #ROOTPASS#
 zerombr
 firewall --enabled --ssh
@@ -49,10 +49,10 @@ coolkey
 crontabs
 cryptsetup-luks
 dhclient
-# dracut
-## Uncomment the previous line and comment out the line below to disable
+dracut
+## Uncomment the following line and comment out the line above to enable
 ## checking FIPS compliance at boot.
-dracut-fips
+#dracut-fips
 fipscheck
 git
 gnupg
@@ -197,33 +197,33 @@ ksserver="#KSSERVER#"
 sed -i '/PRELINKING=yes/ c\PRELINKING=no' /etc/sysconfig/prelink
 prelink -u -a
 
-## Comment out/delete the following if you want to disable FIPS compliance. ##
+## uncomment the following if you want to enable FIPS compliance. ##
 # FIPS
-if [ -e /sys/firmware/efi ]; then
-  BOOTDEV=`df /boot/efi | tail -1 | cut -f1 -d' '`
-else
-  BOOTDEV=`df /boot | tail -1 | cut -f1 -d' '`
-fi
+#if [ -e /sys/firmware/efi ]; then
+#  BOOTDEV=`df /boot/efi | tail -1 | cut -f1 -d' '`
+#else
+#  BOOTDEV=`df /boot | tail -1 | cut -f1 -d' '`
+#fi
 # In case you need a working fallback
-DEFAULT_KERNEL_INFO=`/sbin/grubby --default-kernel`
-DEFAULT_INITRD=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep initrd | cut -f2 -d'='`
-DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 title | cut -f2 -d'='`
-/sbin/grubby --copy-default --make-default --add-kernel=`/sbin/grubby --default-kernel` --initrd=${DEFAULT_INITRD} --title="FIPS ${DEFAULT_KERNEL_TITLE}"
+#DEFAULT_KERNEL_INFO=`/sbin/grubby --default-kernel`
+#DEFAULT_INITRD=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep initrd | cut -f2 -d'='`
+#DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 title | cut -f2 -d'='`
+#/sbin/grubby --copy-default --make-default --add-kernel=`/sbin/grubby --default-kernel` --initrd=${DEFAULT_INITRD} --title="FIPS ${DEFAULT_KERNEL_TITLE}"
 # Remove ALL fips= duplicates and force fips=1.
-until [ "$(/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep args | grep -o fips | wc -l)" -eq 0 ]; do
-  $(/sbin/grubby --remove-args="fips" --update-kernel ${DEFAULT_KERNEL_INFO})
-done
-/sbin/grubby --args="boot=${BOOTDEV} fips=1" --update-kernel ${DEFAULT_KERNEL_INFO}
+#until [ "$(/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep args | grep -o fips | wc -l)" -eq 0 ]; do
+#  $(/sbin/grubby --remove-args="fips" --update-kernel ${DEFAULT_KERNEL_INFO})
+#done
+#/sbin/grubby --args="boot=${BOOTDEV} fips=1" --update-kernel ${DEFAULT_KERNEL_INFO}
 
 # For the disk crypto
-if [ -f "/etc/.cryptcreds" ]; then
-  echo 'install_items+="/etc/.cryptcreds"' >> /etc/dracut.conf
-fi
+#if [ -f "/etc/.cryptcreds" ]; then
+#  echo 'install_items+="/etc/.cryptcreds"' >> /etc/dracut.conf
+#fi
 
-for x in `ls -d /lib/modules/*`; do
-  installed_kernel=`basename $x`
-  dracut -f "/boot/initramfs-${installed_kernel}.img" $installed_kernel
-done
+#for x in `ls -d /lib/modules/*`; do
+#  installed_kernel=`basename $x`
+#  dracut -f "/boot/initramfs-${installed_kernel}.img" $installed_kernel
+#done
 ## END FIPS ##
 
 # Notify users that bootstrap will run on firstboot


### PR DESCRIPTION
  Because anaconda has problems running in an
  environemnt where fips is enabled, we are changing
  the default for the kick start file to not have
  fips enabled.  These are the changes for SIMP6

SIMP-1699
