### PR TITLE
(SIMP-1699) Remove the 'fips=1' from the 'bootloader' line of the def…

### DIFF
--- a/src/DVD/ks/pupclient_x86_64.cfg
+++ b/src/DVD/ks/pupclient_x86_64.cfg
@@ -14,7 +14,9 @@
 #        - Current CASE SENSITIVE options: RedHat CentOS
 
 authconfig --enableshadow --passalgo=sha512
-bootloader --location=mbr --append="fips=1 console=ttyS1,57600 console=tty1" --iscrypted --password=#BOOTPASS#
+# anaconda has known issues when fips is turned on during boot, so it (fips=1)  was remove from bootloader line.
+# see url: https://groups.google.com/forum/?fromgroups#!topic/simp-announce/3pBQDZl1OVc
+bootloader --location=mbr --append="console=ttyS1,57600 console=tty1" --iscrypted --password=#BOOTPASS#
 rootpw --iscrypted #ROOTPASS#
 zerombr
 firewall --enabled --ssh
@@ -22,7 +24,7 @@ firstboot --disable
 logging --level=info
 network --bootproto=dhcp
 reboot
-selinux --permissive
+selinux --enforcing
 timezone --utc GMT
 
 install


### PR DESCRIPTION
…ault kickstart files

  Anaconda has problems in a fips enabled environment so
  by default fips will not be enabled in teh kick start files.
  These are the changes for SIMP 5

SIMP-1699 #comment 1 of 3