### PR TITLE
(SIMP-1832) Remove foreman from puppetfile

### DIFF
--- a/Puppetfile.stable
+++ b/Puppetfile.stable
@@ -156,10 +156,6 @@ mod 'pupmod-simp-dhcp',
   :git => 'https://github.com/simp/pupmod-simp-dhcp'},
   :ref => '7e0f9dc0b5e1114ab39efca1ee082f138226c7cb'}
 
-mod 'pupmod-simp-foreman',
-  :git => 'https://github.com/simp/pupmod-simp-foreman'},
-  :ref => 'a42210f237d7e68af1a740a46d38119cd13ff6e8'}
-
 mod 'pupmod-simp-freeradius',
   :git => 'https://github.com/simp/pupmod-simp-freeradius'},
   :ref => 'd6e0e3bc28742f58f15b3276d972529dd5db76e0'}

--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -13,8 +13,8 @@ mod 'simp-rsync',
 moduledir 'src/rubygems'
 
 mod 'rubygem-simp_cli',
-  :git => 'https://github.com/trevor-vaughan/rubygem-simp-cli',
-  :ref => 'SIMP-1542'
+  :git => 'https://github.com/simp/rubygem-simp-cli',
+  :ref => 'master'
 
 moduledir 'src/puppet/modules'
 
@@ -160,10 +160,6 @@ mod 'simp-simpcat',
 
 mod 'simp-dhcp',
   :git => 'https://github.com/simp/pupmod-simp-dhcp',
-  :ref => 'master'
-
-mod 'simp-foreman',
-  :git => 'https://github.com/simp/pupmod-simp-foreman',
   :ref => 'master'
 
 mod 'simp-freeradius',

--- a/src/assets/simp-utils/build/simp-utils.spec
+++ b/src/assets/simp-utils/build/simp-utils.spec
@@ -1,13 +1,12 @@
 Summary: SIMP Utils
 Name: simp-utils
 Version: 5.0.1
-Release: 1
+Release: 2
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
-Requires: puppet >= 2.6.4-1
-Requires: pssh >= 2.1.1-0
+Requires: puppet >= 4.0.0
 Requires: mkisofs
 Requires: yum-utils
 Provides: simp_utils
@@ -62,8 +61,12 @@ chmod -R u=rwX,g=rX,o=rX %{buildroot}/usr/share/man
 # Post uninstall stuff
 
 %changelog
+* Wed Oct 26 2016 Nick Miller <nick.millre@onyxpoint.com> - 5.0.1-2
+- Removed the pssh dependency.
+- Updated the Puppet dependency to require Puppet 4.
+
 * Thu Aug 25 2016 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.1-1
-  Removed man pages for simp utility, as simp command line provides
+- Removed man pages for simp utility, as simp command line provides
   up-to-date usage.
 
 * Thu Nov 05 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-8


### PR DESCRIPTION
- Removes Foreman from SIMP 6. The modules needs a rewrite for
  Puppet 4 and it may not need to be done.
- Removes PSSH dependency from simp-utils
- Updates Puppet dependency in simp-utils to Puppet 4

SIMP-1832 #close
SIMP-1536 #comment removed in SIMP 6
