### PR TITLE
(SIMP-1867) Duplicate entries causing build issues

### DIFF
--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -206,10 +206,6 @@ mod 'simp-logrotate',
   :git => 'https://github.com/simp/pupmod-simp-logrotate',
   :ref => 'master'
 
-mod 'simp-logstash',
-  :git => 'https://github.com/simp/puppet-logstash',
-  :ref => 'simp-master'
-
 mod 'simp-mcafee',
   :git => 'https://github.com/simp/pupmod-simp-mcafee',
   :ref => 'master'


### PR DESCRIPTION
Duplicate entries in the Puppetfile are causing issues with parallel
builds since the mock space will be locked.

SIMP-1867 #close