### PR TITLE
(SIMP-1876) Updated trusted data lookup in hiera.yaml

### DIFF
--- a/src/puppet/bootstrap/build/simp-bootstrap.spec
+++ b/src/puppet/bootstrap/build/simp-bootstrap.spec
@@ -357,6 +357,9 @@ if [ $1 -eq 0 ]; then
 fi
 
 %changelog
+* Wed Nov 09 2016 Nick Markowski <nmarkowski@keywcorp.com> - 4.3.4-0
+- Hiera.yaml now uses trusted[certname] in place of trusted[clientcert]
+
 * Thu Oct 13 2016 Lisa Umberger <lisa.umberger@onyxpoint.com> - 4.3.4-0
 - Added NIST 800-171 and ISO/IEC 27001 compliance mappings.
 

--- a/src/puppet/bootstrap/hiera.yaml
+++ b/src/puppet/bootstrap/hiera.yaml
@@ -6,7 +6,7 @@
   - 'yaml'
   - 'json'
 :hierarchy:
-  - 'hosts/%{::trusted["clientcert"]}'
+  - 'hosts/%{::trusted["certname"]}'
   - 'hosts/%{::fqdn}'
   - 'hosts/%{::hostname}'
   - 'domains/%{::domain}'


### PR DESCRIPTION
trusted['clientcert'] changed to trusted['certname'] in hiera.yaml

SIMP-1876 #comment done in 4.X
SIMP-1913 #close