### PR TITLE
(SIMP-1877) Added dirtycow to the puppetfiles

### DIFF
--- a/Puppetfile.stable
+++ b/Puppetfile.stable
@@ -164,6 +164,10 @@ mod 'simp-dhcp',
   :git => 'https://github.com/simp/pupmod-simp-dhcp',
   :ref => '7e0f9dc0b5e1114ab39efca1ee082f138226c7cb'
 
+mod 'simp-dirtycow',
+  :git => 'https://github.com/simp/pupmod-simp-dirtycow.git',
+  :ref => '4b7c61777486554ca02b003e67133a2e629245bc'
+
 mod 'simp-foreman',
   :git => 'https://github.com/simp/pupmod-simp-foreman',
   :ref => 'a42210f237d7e68af1a740a46d38119cd13ff6e8'

--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -4,7 +4,7 @@ moduledir 'src'
 
 mod 'simp-doc',
   :git => 'https://github.com/simp/simp-doc',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-rsync',
   :git => 'https://github.com/simp/simp-rsync',
@@ -14,137 +14,137 @@ moduledir 'src/rubygems'
 
 mod 'rubygem-simp_cli',
   :git => 'https://github.com/simp/rubygem-simp-cli',
-  :ref => 'master'
+  :ref => '5.X'
 
 moduledir 'src/puppet/modules'
 
 mod 'bfraser-grafana',
   :git => 'https://github.com/simp/puppet-grafana',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'elasticsearch-elasticsearch',
   :git => 'https://github.com/simp/puppet-elasticsearch',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'elasticsearch-logstash',
   :git => 'https://github.com/simp/puppet-logstash',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'electrical-file_concat',
   :git => 'https://github.com/simp/puppet-lib-file_concat',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'herculesteam-augeasproviders',
   :git => 'https://github.com/simp/augeasproviders',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'herculesteam-augeasproviders_apache',
   :git => 'https://github.com/simp/augeasproviders_apache',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'herculesteam-augeasproviders_base',
   :git => 'https://github.com/simp/augeasproviders_base',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'herculesteam-augeasproviders_core',
   :git => 'https://github.com/simp/augeasproviders_core',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'herculesteam-augeasproviders_grub',
   :git => 'https://github.com/simp/augeasproviders_grub',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'herculesteam-augeasproviders_mounttab',
   :git => 'https://github.com/simp/augeasproviders_mounttab',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'herculesteam-augeasproviders_nagios',
   :git => 'https://github.com/simp/augeasproviders_nagios',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'herculesteam-augeasproviders_pam',
   :git => 'https://github.com/simp/augeasproviders_pam',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'herculesteam-augeasproviders_postgresql',
   :git => 'https://github.com/simp/augeasproviders_postgresql',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'herculesteam-augeasproviders_puppet',
   :git => 'https://github.com/simp/augeasproviders_puppet',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'herculesteam-augeasproviders_shellvar',
   :git => 'https://github.com/simp/augeasproviders_shellvar',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'herculesteam-augeasproviders_ssh',
   :git => 'https://github.com/simp/augeasproviders_ssh',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'herculesteam-augeasproviders_sysctl',
   :git => 'https://github.com/simp/augeasproviders_sysctl',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'onyxpoint-gpasswd',
   :git => 'https://github.com/simp/puppet-gpasswd',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'puppetlabs-inifile',
   :git => 'https://github.com/simp/puppetlabs-inifile',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'puppetlabs-java',
   :git => 'https://github.com/simp/puppetlabs-java',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'puppetlabs-java_ks',
   :git => 'https://github.com/simp/puppetlabs-java_ks',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'puppetlabs-mysql',
   :git => 'https://github.com/simp/puppetlabs-mysql',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'puppetlabs-postgresql',
   :git => 'https://github.com/simp/puppetlabs-postgresql',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'puppetlabs-puppetlabs_apache',
   :git => 'https://github.com/simp/puppetlabs-apache',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'puppetlabs-stdlib',
   :git => 'https://github.com/simp/puppetlabs-stdlib',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'richardc-datacat',
   :git => 'https://github.com/simp/puppet-datacat',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'simp-acpid',
   :git => 'https://github.com/simp/pupmod-simp-acpid',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-activemq',
   :git => 'https://github.com/simp/pupmod-simp-activemq',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-aide',
   :git => 'https://github.com/simp/pupmod-simp-aide',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-apache',
   :git => 'https://github.com/simp/pupmod-simp-apache',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-auditd',
   :git => 'https://github.com/simp/pupmod-simp-auditd',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-autofs',
   :git => 'https://github.com/simp/pupmod-simp-autofs',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-backuppc',
   :git => 'https://github.com/simp/pupmod-simp-backuppc',
@@ -156,27 +156,31 @@ mod 'simp-cgroups',
 
 mod 'simp-clamav',
   :git => 'https://github.com/simp/pupmod-simp-clamav',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-simpcat',
   :git => 'https://github.com/simp/pupmod-simp-concat',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-dhcp',
   :git => 'https://github.com/simp/pupmod-simp-dhcp',
+  :ref => '5.X'
+
+mod 'simp-dirtycow',
+  :git => 'https://github.com/simp/pupmod-simp-dirtycow.git',
   :ref => 'master'
 
 mod 'simp-foreman',
   :git => 'https://github.com/simp/pupmod-simp-foreman',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-freeradius',
   :git => 'https://github.com/simp/pupmod-simp-freeradius',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-ganglia',
   :git => 'https://github.com/simp/pupmod-simp-ganglia',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-gfs2',
   :git => 'https://github.com/simp/pupmod-simp-gfs2',
@@ -184,35 +188,35 @@ mod 'simp-gfs2',
 
 mod 'simp-haveged',
   :git => 'https://github.com/simp/puppet-haveged',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'simp-iptables',
   :git => 'https://github.com/simp/pupmod-simp-iptables',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-jenkins',
   :git => 'https://github.com/simp/pupmod-simp-jenkins',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-krb5',
   :git => 'https://github.com/simp/pupmod-simp-krb5',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-libvirt',
   :git => 'https://github.com/simp/pupmod-simp-libvirt',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-logrotate',
   :git => 'https://github.com/simp/pupmod-simp-logrotate',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-mcafee',
   :git => 'https://github.com/simp/pupmod-simp-mcafee',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-mcollective',
   :git => 'https://github.com/simp/pupmod-simp-mcollective',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'simp-memcached',
   :git => 'https://github.com/simp/puppet-memcached',
@@ -220,7 +224,7 @@ mod 'simp-memcached',
 
 mod 'simp-mozilla',
   :git => 'https://github.com/simp/pupmod-simp-mozilla',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-multipathd',
   :git => 'https://github.com/simp/pupmod-simp-multipathd',
@@ -228,164 +232,164 @@ mod 'simp-multipathd',
 
 mod 'simp-named',
   :git => 'https://github.com/simp/pupmod-simp-named',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-network',
   :git => 'https://github.com/simp/pupmod-simp-network',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-nfs',
   :git => 'https://github.com/simp/pupmod-simp-nfs',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-nscd',
   :git => 'https://github.com/simp/pupmod-simp-nscd',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-ntpd',
   :git => 'https://github.com/simp/pupmod-simp-ntpd',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-oddjob',
   :git => 'https://github.com/simp/pupmod-simp-oddjob',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-openldap',
   :git => 'https://github.com/simp/pupmod-simp-openldap',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-openscap',
   :git => 'https://github.com/simp/pupmod-simp-openscap',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-pam',
   :git => 'https://github.com/simp/pupmod-simp-pam',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-pki',
   :git => 'https://github.com/simp/pupmod-simp-pki',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-polkit',
   :git => 'https://github.com/simp/pupmod-simp-polkit',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-postfix',
   :git => 'https://github.com/simp/pupmod-simp-postfix',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-pupmod',
   :git => 'https://github.com/simp/pupmod-simp-pupmod',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-puppetdb',
   :git => 'https://github.com/simp/puppetlabs-puppetdb',
-  :ref => 'simp-master'
+  :ref => '5.X'
 
 mod 'simp-rsync',
   :git => 'https://github.com/simp/pupmod-simp-rsync',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-rsyslog',
   :git => 'https://github.com/simp/pupmod-simp-rsyslog',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-selinux',
   :git => 'https://github.com/simp/pupmod-simp-selinux',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-simp',
   :git => 'https://github.com/simp/pupmod-simp-simp',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-simp_elasticsearch',
   :git => 'https://github.com/simp/pupmod-simp-simp_elasticsearch',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-simp_grafana',
   :git => 'https://github.com/simp/pupmod-simp-simp_grafana',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-simp_logstash',
   :git => 'https://github.com/simp/pupmod-simp-simp_logstash',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-simplib',
   :git => 'https://github.com/simp/pupmod-simp-simplib',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-site',
   :git => 'https://github.com/simp/pupmod-simp-site',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-snmpd',
   :git => 'https://github.com/simp/pupmod-simp-snmpd',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-ssh',
   :git => 'https://github.com/simp/pupmod-simp-ssh',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-sssd',
   :git => 'https://github.com/simp/pupmod-simp-sssd',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-stunnel',
   :git => 'https://github.com/simp/pupmod-simp-stunnel',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-sudo',
   :git => 'https://github.com/simp/pupmod-simp-sudo',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-sudosh',
   :git => 'https://github.com/simp/pupmod-simp-sudosh',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-svckill',
   :git => 'https://github.com/simp/pupmod-simp-svckill',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-sysctl',
   :git => 'https://github.com/simp/pupmod-simp-sysctl',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-tcpwrappers',
   :git => 'https://github.com/simp/pupmod-simp-tcpwrappers',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-tftpboot',
   :git => 'https://github.com/simp/pupmod-simp-tftpboot',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-tpm',
   :git => 'https://github.com/simp/pupmod-simp-tpm',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-upstart',
   :git => 'https://github.com/simp/pupmod-simp-upstart',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-vnc',
   :git => 'https://github.com/simp/pupmod-simp-vnc',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-vsftpd',
   :git => 'https://github.com/simp/pupmod-simp-vsftpd',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-windowmanager',
   :git => 'https://github.com/simp/pupmod-simp-windowmanager',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-xinetd',
   :git => 'https://github.com/simp/pupmod-simp-xinetd',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-xwindows',
   :git => 'https://github.com/simp/pupmod-simp-xwindows',
-  :ref => 'master'
+  :ref => '5.X'
 
 mod 'simp-compliance_markup',
   :git => 'https://github.com/simp/pupmod-simp-compliance_markup',
-  :ref => 'master'
+  :ref => '5.X'


### PR DESCRIPTION
     The 4.2 files were pointing to the wrong branches
     so this also updates the branches to point to 5.X.

SIMP-1877 #done in 4.X

Change-Id:  Ie2cc7aa2b9d2aab3ade80955a535a289c2070f1b