### PR TITLE
(SIMP-1848) Missed a dependency

### DIFF
--- a/src/DVD/6-simp_pkglist.txt
+++ b/src/DVD/6-simp_pkglist.txt
@@ -761,6 +761,7 @@ openais
 openaislib
 opencrypto-tpmtok
 opencryptoki
+opencryptoki-libs
 openjade
 openjpeg-libs
 openldap


### PR DESCRIPTION
Missed the opencryptoki-libs dependency in the package list

SIMP-1848 #comment Added missing dependency