### PR TITLE
(SIMP-2151) Move stdlib from simp-master to master

### DIFF
--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -120,7 +120,7 @@ mod 'puppetlabs-apache',
 
 mod 'puppetlabs-stdlib',
   :git => 'https://github.com/simp/puppetlabs-stdlib',
-  :ref => 'simp-master'
+  :ref => 'master'
 
 mod 'richardc-datacat',
   :git => 'https://github.com/simp/puppet-datacat',


### PR DESCRIPTION
There are no changes we need to make to stdlib, so we can include the
master branch now.

SIMP-2151 #close
SIMP-2048 #comment Updated puppetfile to track master