### PR TITLE
(SIMP-2464) Change keydist location

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>4']
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
@@ -21,11 +20,12 @@ end
 gem 'bundler'
 gem 'rake'
 gem 'coderay'
-gem 'puppet', puppetversion
+gem 'puppet', ENV.fetch('PUPPET_VERSION', '~>4')
 gem 'puppet-lint'
+gem 'puppet-strings'
 gem 'puppetlabs_spec_helper'
-gem 'simp-rake-helpers', '~>3.1'
-gem 'simp-build-helpers', '>=0.1.0'
+gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 3.1')
+gem 'simp-build-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '>=0.1.0')
 gem 'parallel'
 gem 'dotenv'
 gem 'ruby-progressbar'
@@ -34,7 +34,7 @@ gem 'google-api-client', '0.9.4'
 group :system_tests do
   gem 'beaker', :git => 'https://github.com/trevor-vaughan/beaker.git', :branch => 'BKR-931-2.51.0'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', '>= 1.0.5'
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.5')
 end
 
 # nice-to-have gems (for debugging)

--- a/src/assets/simp-environment/build/simp-environment.spec
+++ b/src/assets/simp-environment/build/simp-environment.spec
@@ -187,16 +187,6 @@ else
   fi
 fi
 
-# Need to make sure our keydist stub is here prior to fully porting to the new
-# way of doing things.
-(
-  cd %{prefix}
-
-  if [ ! -d 'keydist' ]; then
-    ln -s modules/pki/files/keydist
-  fi
-)
-
 # Needed for migrating the environment data into the codedir
 /usr/local/sbin/simp_rpm_helper --rpm_dir=%{prefix} --rpm_section='post' --rpm_status=$1 --preserve --target_dir='.'
 
@@ -214,11 +204,16 @@ fi
 /usr/local/sbin/simp_rpm_helper --rpm_dir=%{prefix} --rpm_section='postun' --rpm_status=$1 --preserve --target_dir='.'
 
 %changelog
+* Tue Jan 10 2017 Nick Miller <nick.miller@onyxpoint.com> - 6.0.0-Alpha
+- Moved the default location of keydist from the normal puppet environment and
+  modulepath to /var/simp/environments/simp/site_files/pki_files/files/keydist,
+  which won't be overwritten or deleted when using r10k and a control repo.
+
 * Fri Jan 06 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0-Alpha
 - Eliminated the 'localusers' capability
 - Changed the name to simp-environment
 - Ripped out all of the legacy materials
-- Upated to use the simp-adapter RPM helper
+- Updated to use the simp-adapter RPM helper
 
 * Tue Dec 06 2016 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.0-Alpha
 - Updated nist compliance map to reference new gnome::enable_screensaver

--- a/src/assets/simp-environment/environments/simp/FakeCA/gencerts_common.sh
+++ b/src/assets/simp-environment/environments/simp/FakeCA/gencerts_common.sh
@@ -2,16 +2,21 @@
 
 # Common functions for gencerts items.
 
-keydist='../modules/pki/files/keydist'
+# If production is a symlink to simp, then we should probably send certs to site_files
+if [ -L /etc/puppetlabs/code/environments/production ]; then
+  keydist='/var/simp/environments/simp/site_files/pki_files/files/keydist'
+else
+  keydist='/var/simp/environments/`puppet config print environment`/site_files/pki_files/files/keydist'
+fi
 CA_src='/etc/pki/tls/misc/CA'
 
 export CATOP="`pwd`/demoCA"
 
 check_cacerts () {
-if [ ! -f cacertkey ]; then
-  dd if=/dev/urandom status=none bs=60 count=1 | openssl base64 -e -nopad | tr -d '\n' > cacertkey
-  echo '' >> cacertkey
-fi
+  if [ ! -f cacertkey ]; then
+    dd if=/dev/urandom status=none bs=60 count=1 | openssl base64 -e -nopad | tr -d '\n' > cacertkey
+    echo '' >> cacertkey
+  fi
 }
 
 create_ca () {


### PR DESCRIPTION
- Moved the default location of keydist from the normal puppet
  environment and modulepath to
  /var/simp/environments/simp/site_files/pki_files/files/keydist,
  which won't be overwritten or deleted when using r10k and a
  control repo.