### PR TITLE
(SIMP-2469) Update mock configs for selinux

### DIFF
--- a/build/distributions/CentOS/6/x86_64/mock.cfg
+++ b/build/distributions/CentOS/6/x86_64/mock.cfg
@@ -29,6 +29,14 @@ failovermethod=priority
 gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-CentOS-6
 gpgcheck=1
 
+# For SELinux policies
+[legacy]
+name=Legacy
+enabled=1
+baseurl=http://vault.centos.org/6.0/os/x86_64
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-6
+gpgcheck=1
+
 [updates]
 name=updates
 enabled=1

--- a/build/distributions/CentOS/7/x86_64/mock.cfg
+++ b/build/distributions/CentOS/7/x86_64/mock.cfg
@@ -49,6 +49,13 @@ failovermethod=priority
 gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-CentOS-7
 gpgcheck=1
 
+# For SELinux builds
+[legacy]
+name=Legacy
+baseurl=http://vault.centos.org/7.0.1406/os/x86_64
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-7
+gpgcheck=1
+
 [updates]
 name=updates
 enabled=1


### PR DESCRIPTION
Added 'legacy' repos to the CentOS 6 and 7 builds so that packages can
be built with the oldest valid versions of the policies and guarantee
compatibility

SIMP-2469 #comment update mock configs for oldest selinux