### PR TITLE
(SIMP-2703) Fix RPM PATH post install problems

### DIFF
--- a/build/distributions/CentOS/6/x86_64/GPGKEYS/build/simp-gpgkeys.spec
+++ b/build/distributions/CentOS/6/x86_64/GPGKEYS/build/simp-gpgkeys.spec
@@ -28,9 +28,13 @@ All keys copyright their respective owners.
 mkdir -p %{buildroot}/%{_sysconfdir}/pki/rpm-gpg
 mkdir -p %{buildroot}/%{prefix}
 
-#Now install the files.
+# Now install the files.
 cp RPM-GPG-KEY* %{buildroot}/%{_sysconfdir}/pki/rpm-gpg
 cp RPM-GPG-KEY* %{buildroot}/%{prefix}
+
+# Make sure this doesn't include the development key
+rm -f %{buildroot}/%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-SIMP-Dev
+rm -f %{buildroot}/%{prefix}/RPM-GPG-KEY-SIMP-Dev
 
 %clean
 [ "%{buildroot}" != "/" ] && rm -rf %{buildroot}
@@ -42,6 +46,7 @@ cp RPM-GPG-KEY* %{buildroot}/%{prefix}
 
 %post
 #!/bin/bash
+export PATH=/opt/puppetlabs/bin:$PATH
 
 # If we're a SIMP server, place the keys into the appropriate web directory
 
@@ -101,6 +106,10 @@ if [ -d "${dir}/GPGKEYS" ]; then
 fi
 
 %changelog
+* Thu Feb 16 2016 Liz Nemsick <lnemsick.simp@gmail.com> - 3.0.0-0
+- Ensure facter is in $PATH during post install
+- Ensure SIMP development GPG key is not included in the GPG key set
+
 * Tue Feb 14 2016 Nick Miller <nick.miller@onyxpoint.com> - 3.0.0-0
 - Added new puppet gpg key from http://yum.puppetlabs.com/RPM-GPG-KEY-puppet
 

--- a/build/distributions/CentOS/7/x86_64/GPGKEYS/build/simp-gpgkeys.spec
+++ b/build/distributions/CentOS/7/x86_64/GPGKEYS/build/simp-gpgkeys.spec
@@ -28,9 +28,13 @@ All keys copyright their respective owners.
 mkdir -p %{buildroot}/%{_sysconfdir}/pki/rpm-gpg
 mkdir -p %{buildroot}/%{prefix}
 
-#Now install the files.
+# Now install the files.
 cp RPM-GPG-KEY* %{buildroot}/%{_sysconfdir}/pki/rpm-gpg
 cp RPM-GPG-KEY* %{buildroot}/%{prefix}
+
+# Make sure this doesn't include the development key
+rm -f %{buildroot}/%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-SIMP-Dev
+rm -f %{buildroot}/%{prefix}/RPM-GPG-KEY-SIMP-Dev
 
 %clean
 [ "%{buildroot}" != "/" ] && rm -rf %{buildroot}
@@ -42,6 +46,7 @@ cp RPM-GPG-KEY* %{buildroot}/%{prefix}
 
 %post
 #!/bin/bash
+export PATH=/opt/puppetlabs/bin:$PATH
 
 # If we're a SIMP server, place the keys into the appropriate web directory
 
@@ -107,6 +112,10 @@ for dir in '/srv/www/yum/SIMP' '/var/www/yum/SIMP'; do
 done
 
 %changelog
+* Thu Feb 16 2016 Liz Nemsick <lnemsick.simp@gmail.com> - 3.0.0-0
+- Ensure facter is in $PATH during post install
+- Ensure SIMP development GPG key is not included in the GPG key set
+
 * Tue Feb 14 2016 Nick Miller <nick.miller@onyxpoint.com> - 3.0.0-0
 - Added new puppet gpg key from http://yum.puppetlabs.com/RPM-GPG-KEY-puppet
 

--- a/build/distributions/Fedora/24/x86_64/GPGKEYS/build/simp-gpgkeys.spec
+++ b/build/distributions/Fedora/24/x86_64/GPGKEYS/build/simp-gpgkeys.spec
@@ -28,9 +28,13 @@ All keys copyright their respective owners.
 mkdir -p %{buildroot}/%{_sysconfdir}/pki/rpm-gpg
 mkdir -p %{buildroot}/%{prefix}
 
-#Now install the files.
+# Now install the files.
 cp RPM-GPG-KEY* %{buildroot}/%{_sysconfdir}/pki/rpm-gpg
 cp RPM-GPG-KEY* %{buildroot}/%{prefix}
+
+# Make sure this doesn't include the development key
+rm -f %{buildroot}/%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-SIMP-Dev
+rm -f %{buildroot}/%{prefix}/RPM-GPG-KEY-SIMP-Dev
 
 %clean
 [ "%{buildroot}" != "/" ] && rm -rf %{buildroot}
@@ -42,6 +46,7 @@ cp RPM-GPG-KEY* %{buildroot}/%{prefix}
 
 %post
 #!/bin/bash
+export PATH=/opt/puppetlabs/bin:$PATH
 
 # If we're a SIMP server, place the keys into the appropriate web directory
 
@@ -107,6 +112,10 @@ for dir in '/srv/www/yum/SIMP' '/var/www/yum/SIMP'; do
 done
 
 %changelog
+* Thu Feb 16 2016 Liz Nemsick <lnemsick.simp@gmail.com> - 3.0.0-0
+- Ensure facter is in $PATH during post install
+- Ensure SIMP development GPG key is not included in the GPG key set
+
 * Tue Feb 14 2016 Nick Miller <nick.miller@onyxpoint.com> - 3.0.0-0
 - Added new puppet gpg key from http://yum.puppetlabs.com/RPM-GPG-KEY-puppet
 

--- a/src/assets/simp-environment/build/simp-environment.spec
+++ b/src/assets/simp-environment/build/simp-environment.spec
@@ -138,9 +138,9 @@ fi
 
 # Switch things over to the new setup.
 arch=`uname -p`;
-version=`/usr/bin/facter lsbdistrelease 2> /dev/null`;
-majversion=`/usr/bin/facter lsbmajdistrelease 2> /dev/null`;
-os=`/usr/bin/facter operatingsystem 2> /dev/null`;
+version=`facter lsbdistrelease 2> /dev/null`;
+majversion=`facter lsbmajdistrelease 2> /dev/null`;
+os=`facter operatingsystem 2> /dev/null`;
 www_dir="/var/www/yum";
 base="${www_dir}/${os}";
 
@@ -205,6 +205,9 @@ fi
 /usr/local/sbin/simp_rpm_helper --rpm_dir=%{prefix} --rpm_section='postun' --rpm_status=$1 --preserve --target_dir='.'
 
 %changelog
+* Thu Feb 16 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.0
+- Fix path to facter in post install
+
 * Tue Jan 10 2017 Nick Miller <nick.miller@onyxpoint.com> - 6.0.0
 - Moved the default location of keydist from the normal puppet environment and
   modulepath to /var/simp/environments/simp/site_files/pki_files/files/keydist,

--- a/src/build/simp.spec
+++ b/src/build/simp.spec
@@ -161,6 +161,7 @@ chmod u=rwX,g=rX,o=rX -R %{buildroot}%{_sysconfdir}/simp
 
 %post
 # Post installation stuff
+export PATH=/opt/puppetlabs/bin:$PATH
 
 if [ -f %{prefix}/autosign.conf ]; then
   chmod 644 %{prefix}/autosign.conf;
@@ -200,6 +201,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Thu Feb 16 2017 Liz Nemsick<lnemsick.simp@gmail.com> - 6.0.0
+- Ensure puppet and facter are in $PATH during post install
+
 * Tue Jan 10 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.0.0
 - Updated to release -0
 - Upgraded to Puppet 4.8.2


### PR DESCRIPTION
- Ensure $PATH contains /opt/puppetlabs/bin for facter and puppet
  command use in RPM post install
- Ensure SIMP development keys are not delivered with in simp-gpgkeys
  RPMS.

SIMP-2703 #close