### PR TITLE
(SIMP-918) Remove nscd chkconfig from CentOS 6 cfg

### DIFF
--- a/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/min.cfg
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/min.cfg
@@ -104,7 +104,6 @@ fi
 dracut -f
 
 /sbin/chkconfig --add network;
-/sbin/chkconfig --level 345 nscd on;
 /sbin/chkconfig --level 2345 rsyslog on;
 
 pass_hash='$6$1tkixqzp$iihri50cUBpvDcIfq1ieftkj6ToRBrlQutpzP2sdGo5/h6dDfdXvFkmVtODwEJD0W2XYScmKrnkqRnnMEkaRi.'


### PR DESCRIPTION
While installing CentOS 6, there is a console error about attempting to
start `nscd` (which is no longer installed by default).  This patch
removes the leftover code that produces that error.

SIMP-918 #close #comment Leftover fix for CentOS 6