### PR TITLE
(SIMP-2708) Add dist flag to the RPM release

### DIFF
--- a/src/assets/simp-adapter/build/simp-adapter.spec
+++ b/src/assets/simp-adapter/build/simp-adapter.spec
@@ -2,8 +2,8 @@
 
 Summary: SIMP Adapter for the AIO Puppet Installation
 Name: simp-adapter
-Version: 0.0.2
-Release: 0
+Version: 0.0.3
+Release: 0%{?dist}
 License: Apache-2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -252,5 +252,8 @@ EOM
 )
 
 %changelog
+* Tue Feb 28 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.0.3-0
+- Add dist to the release field to account for RPM generation on EL6 vs EL7
+
 * Mon Sep 12 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.0.1-Alpha
-  - First cut at the simp-adapter
+- First cut at the simp-adapter


### PR DESCRIPTION
There is logic in the RPM that requires a release tag on the RPM
release.

SIMP-2708 #close