### PR TITLE
(SIMP-2775) Fix broken simp-adapter Gemfile & tests

### DIFF
--- a/src/assets/simp-adapter/Gemfile
+++ b/src/assets/simp-adapter/Gemfile
@@ -12,13 +12,13 @@ gem_sources.each { |gem_source| source gem_source }
 group :test do
   gem "rake"
   gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~>4')
-  gem "rspec", '< 3.2.0'
+  gem "rspec"
   gem "rspec-puppet"
   gem "hiera-puppet-helper"
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
   gem "simp-rspec-puppet-facts", ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 1.3')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 3')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 3.0')
 end
 
 group :development do
@@ -38,5 +38,5 @@ end
 group :system_tests do
   gem 'beaker', :git => 'https://github.com/trevor-vaughan/beaker.git', :branch => 'BKR-931-2.51.0'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', '>= 1.0.5'
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.5')
 end

--- a/src/assets/simp-adapter/spec/acceptance/suites/default/00_basic_test_spec.rb
+++ b/src/assets/simp-adapter/spec/acceptance/suites/default/00_basic_test_spec.rb
@@ -81,7 +81,9 @@ class site {
 
       it 'should install cleanly' do
         host.install_package('pupmod-simp-beakertest')
+        host.install_package('simp-environment')
         on(host, 'test -d /usr/share/simp/modules/beakertest')
+        on(host, 'test -f /usr/share/simp/environment/simp/test_file')
         host.check_for_package('simp-adapter')
       end
 
@@ -95,13 +97,14 @@ class site {
       it 'should start in a clean state' do
         host.uninstall_package('pupmod-simp-beakertest')
         host.uninstall_package('simp-environment')
+        host.uninstall_package('simp-adapter')
 
         config_yaml =<<-EOM
 ---
 copy_rpm_data : true
 this_should_not_break_things : awwww_yeah
         EOM
-        create_remote_file(host, '/etc/simp/simp_adapter_config.yaml', config_yaml)
+        create_remote_file(host, '/etc/simp/adapter_config.yaml', config_yaml)
       end
 
       it 'should copy the module data into the appropriate location' do
@@ -121,6 +124,7 @@ this_should_not_break_things : awwww_yeah
       it 'should uninstall cleanly' do
         host.uninstall_package('pupmod-simp-beakertest')
         host.uninstall_package('simp-environment')
+        host.uninstall_package('simp-adapter')
         on(host, 'test ! -d /usr/share/simp/modules/beakertest')
         on(host, "test ! -d #{install_target}/environments/simp/modules/beakertest")
         on(host, "test ! -f #{install_target}/environments/simp/test_file")
@@ -140,7 +144,7 @@ this_should_not_break_things : awwww_yeah
       end
 
       it 'should install cleanly' do
-        host.install_package('simp-environment')
+        host.install_package('simp-adapter')
         host.install_package('pupmod-simp-beakertest')
         on(host, 'test -d /usr/share/simp/modules/beakertest')
       end
@@ -159,7 +163,7 @@ this_should_not_break_things : awwww_yeah
 
       it 'should uninstall cleanly' do
         host.uninstall_package('pupmod-simp-beakertest')
-        host.uninstall_package('simp-environment')
+        host.uninstall_package('simp-adapter')
         on(host, 'test ! -d /usr/share/simp/modules/beakertest')
         on(host, 'test ! -f /usr/share/simp/environment/simp/test_file')
       end


### PR DESCRIPTION
NOTE:  Only the default suite works.  There seems to be
a problem with test suites that causes the tests in the
default test suite to be run repeatedly when running
'bundle exec rake beaker'.  Since the tests are not designed
to be rerun, they fail.

SIMP-2775 #close