### PR TITLE
(SIMP-2861) Correct the mock dist version

### DIFF
--- a/build/distributions/CentOS/7/x86_64/mock.cfg
+++ b/build/distributions/CentOS/7/x86_64/mock.cfg
@@ -4,6 +4,7 @@ config_opts['legal_host_arches'] = ('x86_64',)
 config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
 config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
 config_opts['releasever'] = '7'
+config_opts['macros']['%dist'] = '.el7'
 
 config_opts['yum.conf'] = """
 [main]


### PR DESCRIPTION
Without this change, the dist will have 'centos' in it for any EL7
packages.

SIMP-2861 #close