### PR TITLE
(SIMP-3163) Updates for EL 6.9 and release_mappers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ build/yum_data/*/packages
 log
 spec/fixtures
 src/assets/*/dist
+src/assets/environment
 src/build/autorequires
 src/dist
 src/doc

--- a/Puppetfile.stable
+++ b/Puppetfile.stable
@@ -23,7 +23,7 @@ mod 'binford2k-node_encrypt',
 
 mod 'puppet-grafana',
   :git => 'https://github.com/simp/puppet-grafana.git',
-  :ref => '84267ebe1e4fbe8211a44165d37e690e180fb2fb'
+  :tag => 'v3.0.0'
 
 mod 'camptocamp-kmod',
   :git => 'https://github.com/simp/puppet-kmod.git',
@@ -31,11 +31,11 @@ mod 'camptocamp-kmod',
 
 mod 'elastic-elasticsearch',
   :git => 'https://github.com/simp/puppet-elasticsearch',
-  :ref => '1f5cce28ca0eec9e5bb748dbc91af5e092685f7b'
+  :tag => '5.2.0'
 
 mod 'elastic-logstash',
   :git => 'https://github.com/simp/puppet-logstash',
-  :ref => '8f416a43c6e5b3782b892f9df0830dd816ec57cb'
+  :tag => '5.2.1'
 
 mod 'electrical-file_concat',
   :git => 'https://github.com/simp/puppet-lib-file_concat',

--- a/Puppetfile.stable
+++ b/Puppetfile.stable
@@ -21,9 +21,9 @@ mod 'binford2k-node_encrypt',
   :ref => '3bcae75e8bd89bf2a7eab0ad2fc1aceafe984d48'
   #:tag => 'v0.2.5'
 
-mod 'bfraser-grafana',
-  :git => 'https://github.com/simp/puppet-grafana',
-  :ref => '6d426d5ccc52ff23dbbcfc45290dafd224b5d2bc'
+mod 'puppet-grafana',
+  :git => 'https://github.com/simp/puppet-grafana.git',
+  :ref => '84267ebe1e4fbe8211a44165d37e690e180fb2fb'
 
 mod 'camptocamp-kmod',
   :git => 'https://github.com/simp/puppet-kmod.git',
@@ -31,11 +31,11 @@ mod 'camptocamp-kmod',
 
 mod 'elastic-elasticsearch',
   :git => 'https://github.com/simp/puppet-elasticsearch',
-  :ref => 'dc6d3fab6ace62701aa3de6e4bb868e24fef0553'
+  :ref => '1f5cce28ca0eec9e5bb748dbc91af5e092685f7b'
 
 mod 'elastic-logstash',
   :git => 'https://github.com/simp/puppet-logstash',
-  :ref => 'f475deaeb6120abc4c56c27cd3ab1ce808391517'
+  :ref => '8f416a43c6e5b3782b892f9df0830dd816ec57cb'
 
 mod 'electrical-file_concat',
   :git => 'https://github.com/simp/puppet-lib-file_concat',

--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -27,7 +27,7 @@ moduledir 'src/puppet/modules'
 
 mod 'puppet-grafana',
   :git => 'https://github.com/simp/puppet-grafana.git',
-  :ref => 'master'
+  :tag => 'v3.0.0'
 
 mod 'binford2k-node_encrypt',
   :git => 'https://github.com/simp/binford2k-node_encrypt.git',
@@ -39,11 +39,11 @@ mod 'camptocamp-kmod',
 
 mod 'elastic-elasticsearch',
   :git => 'https://github.com/simp/puppet-elasticsearch',
-  :ref => 'master'
+  :tag => '5.2.0'
 
 mod 'elastic-logstash',
   :git => 'https://github.com/simp/puppet-logstash',
-  :ref => 'master'
+  :tag => '5.2.1'
 
 mod 'electrical-file_concat',
   :git => 'https://github.com/simp/puppet-lib-file_concat',

--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -26,7 +26,7 @@ mod 'rubygem-simp_cli',
 moduledir 'src/puppet/modules'
 
 mod 'bfraser-grafana',
-  :git => 'https://github.com/simp/puppet-grafana',
+  :git => 'https://github.com/bfraser/puppet-grafana',
   :ref => 'master'
 
 mod 'binford2k-node_encrypt',

--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -25,8 +25,8 @@ mod 'rubygem-simp_cli',
 
 moduledir 'src/puppet/modules'
 
-mod 'bfraser-grafana',
-  :git => 'https://github.com/bfraser/puppet-grafana',
+mod 'puppet-grafana',
+  :git => 'https://github.com/simp/puppet-grafana.git',
   :ref => 'master'
 
 mod 'binford2k-node_encrypt',
@@ -39,7 +39,7 @@ mod 'camptocamp-kmod',
 
 mod 'elastic-elasticsearch',
   :git => 'https://github.com/simp/puppet-elasticsearch',
-  :ref => 'simp-master'
+  :ref => 'master'
 
 mod 'elastic-logstash',
   :git => 'https://github.com/simp/puppet-logstash',

--- a/build/distributions/CentOS/6/x86_64/DVD/6-simp_pkglist.txt
+++ b/build/distributions/CentOS/6/x86_64/DVD/6-simp_pkglist.txt
@@ -595,6 +595,9 @@ libjpeg
 libjpeg-devel
 libjpeg-turbo
 libjpeg-turbo-devel
+libkadm5
+libkadm5srv_mit
+libkadm5clnt_mit
 libldb
 libmcpp
 libmng

--- a/build/distributions/CentOS/6/x86_64/release_mappings.yaml
+++ b/build/distributions/CentOS/6/x86_64/release_mappings.yaml
@@ -2,7 +2,7 @@
 # This file houses the *officially supported* SIMP release combinations
 # Other build combinations may work, but unexpected issues may arise.
 simp_releases:
-  6.0.1-RC1:
+  6.X:
     flavors:
       CentOS:
         isos:

--- a/build/distributions/CentOS/6/x86_64/release_mappings.yaml
+++ b/build/distributions/CentOS/6/x86_64/release_mappings.yaml
@@ -17,9 +17,9 @@ simp_releases:
         os_version:   '6.9'
       RedHat:
         isos:
-          - name:     'rhel-server-6.8-x86_64-dvd.iso'
-            size:     3878682624
-            checksum: 'd35fd1af20f6adef9b11b46c2534ae8b6e18de7754889e2b51808b436dff2804'
+          - name:     'rhel-server-6.9-x86_64-dvd.iso'
+            size:     3887071232
+            checksum: '3f961576e9f81ea118566f73f98d7bdf3287671c35436a13787c1ffd5078cf8e'
         build_command: 'bundle exec rake build:auto[/path/to/RedHat/DVDS,6.X]'
         mock:          'epel-6-x86_64'
-        os_version:   '6.8'
+        os_version:   '6.9'

--- a/build/distributions/CentOS/6/x86_64/release_mappings.yaml
+++ b/build/distributions/CentOS/6/x86_64/release_mappings.yaml
@@ -2,7 +2,7 @@
 # This file houses the *officially supported* SIMP release combinations
 # Other build combinations may work, but unexpected issues may arise.
 simp_releases:
-  6.X:
+  6.1.0-RC1:
     flavors:
       CentOS:
         isos:

--- a/build/distributions/CentOS/6/x86_64/release_mappings.yaml
+++ b/build/distributions/CentOS/6/x86_64/release_mappings.yaml
@@ -2,7 +2,7 @@
 # This file houses the *officially supported* SIMP release combinations
 # Other build combinations may work, but unexpected issues may arise.
 simp_releases:
-  6.1.0-RC1:
+  6.0.1-RC1:
     flavors:
       CentOS:
         isos:

--- a/build/distributions/CentOS/6/x86_64/release_mappings.yaml
+++ b/build/distributions/CentOS/6/x86_64/release_mappings.yaml
@@ -6,15 +6,15 @@ simp_releases:
     flavors:
       CentOS:
         isos:
-          - name:     'CentOS-6.8-x86_64-bin-DVD1.iso'
-            size:     3916431360
-            checksum: '1dda55622614a8b43b448a72f87d6cb7f79de1eff49ee8c5881a7d9db28d4e35'
-          - name:     'CentOS-6.8-x86_64-bin-DVD2.iso'
-            size:     2220693504
-            checksum: '0aba869427b4ce04e100d72744daf7fea1f7be2e4be56b658095bd9e99e04e6d'
-        build_command: 'bundle exec rake build:auto[4.2.X,/path/to/CentOS-6.8/DVDs]'
+          - name:     'CentOS-6.9-x86_64-bin-DVD1.iso'
+            size:     3972005888
+            checksum: 'd27cf37a40509c17ad70f37bc743f038c1feba00476fe6b69682aa424c399ea6'
+          - name:     'CentOS-6.9-x86_64-bin-DVD2.iso'
+            size:     2177677312
+            checksum: '631b8640460f46a8139a6a7cbbac5f3594d08c32945449b6bbd65234929ce7a4'
+        build_command: 'bundle exec rake build:auto[4.2.X,/path/to/CentOS-6.9/DVDs]'
         mock:          'epel-6-x86_64'
-        os_version:   '6.8'
+        os_version:   '6.9'
       RedHat:
         isos:
           - name:     'rhel-server-6.8-x86_64-dvd.iso'

--- a/build/distributions/CentOS/6/x86_64/release_mappings.yaml
+++ b/build/distributions/CentOS/6/x86_64/release_mappings.yaml
@@ -23,3 +23,24 @@ simp_releases:
         build_command: 'bundle exec rake build:auto[/path/to/RedHat/DVDS,6.X]'
         mock:          'epel-6-x86_64'
         os_version:   '6.9'
+  6.0.0-0:
+    flavors:
+      CentOS:
+        isos:
+          - name:     'CentOS-6.8-x86_64-bin-DVD1.iso'
+            size:     3916431360
+            checksum: '1dda55622614a8b43b448a72f87d6cb7f79de1eff49ee8c5881a7d9db28d4e35'
+          - name:     'CentOS-6.8-x86_64-bin-DVD2.iso'
+            size:     2220693504
+            checksum: '0aba869427b4ce04e100d72744daf7fea1f7be2e4be56b658095bd9e99e04e6d'
+        build_command: 'bundle exec rake build:auto[4.2.X,/path/to/CentOS-6.8/DVDs]'
+        mock:          'epel-6-x86_64'
+        os_version:   '6.8'
+      RedHat:
+        isos:
+          - name:     'rhel-server-6.8-x86_64-dvd.iso'
+            size:     3878682624
+            checksum: 'd35fd1af20f6adef9b11b46c2534ae8b6e18de7754889e2b51808b436dff2804'
+        build_command: 'bundle exec rake build:auto[4.2.X,rhel-server-6.8-x86_64-dvd.iso]'
+        mock:          'epel-6-x86_64'
+        os_version:   '6.8'

--- a/build/distributions/CentOS/6/x86_64/release_mappings.yaml
+++ b/build/distributions/CentOS/6/x86_64/release_mappings.yaml
@@ -12,7 +12,7 @@ simp_releases:
           - name:     'CentOS-6.9-x86_64-bin-DVD2.iso'
             size:     2177677312
             checksum: '631b8640460f46a8139a6a7cbbac5f3594d08c32945449b6bbd65234929ce7a4'
-        build_command: 'bundle exec rake build:auto[4.2.X,/path/to/CentOS-6.9/DVDs]'
+        build_command: 'bundle exec rake build:auto[/path/to/CentOS-6.9/DVDs,6.X]'
         mock:          'epel-6-x86_64'
         os_version:   '6.9'
       RedHat:
@@ -20,6 +20,6 @@ simp_releases:
           - name:     'rhel-server-6.8-x86_64-dvd.iso'
             size:     3878682624
             checksum: 'd35fd1af20f6adef9b11b46c2534ae8b6e18de7754889e2b51808b436dff2804'
-        build_command: 'bundle exec rake build:auto[4.2.X,rhel-server-6.8-x86_64-dvd.iso]'
+        build_command: 'bundle exec rake build:auto[/path/to/RedHat/DVDS,6.X]'
         mock:          'epel-6-x86_64'
         os_version:   '6.8'

--- a/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
@@ -37,7 +37,7 @@ elasticsearch:
   :source: https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/rpm/elasticsearch/2.3.5/elasticsearch-2.3.5.rpm
 elasticsearch-curator:
   :rpm_name: elasticsearch-curator-1.1.1-0.el6.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/packages/el/7/elasticsearch-curator-1.1.1-0.el6.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/elasticsearch-curator-1.1.1-0.el6.noarch.rpm
 fping:
   :rpm_name: fping-2.4b2-10.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/fping-2.4b2-10.el6.x86_64.rpm
@@ -97,7 +97,7 @@ grafana:
   :source: https://packagecloud.io/grafana/stable/el/6/x86_64/grafana-3.1.1-1470047149.x86_64.rpm
 gweb:
   :rpm_name: gweb-2.1.8-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/packages/el/7/gweb-2.1.8-1.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/gweb-2.1.8-1.noarch.rpm
 haveged:
   :rpm_name: haveged-1.9.1-2.el6.x86_64.rpm
   :source: http://mirror.sfo12.us.leaseweb.net/epel/6/x86_64/haveged-1.9.1-2.el6.x86_64.rpm
@@ -148,10 +148,10 @@ libev:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/libev-4.03-3.el6.x86_64.rpm
 libyaml:
   :rpm_name: libyaml-0.1.4-2.el6.x86_64.rpm
-  :source: https://dl.bintray.com/simp/4.2.X/libyaml-0.1.4-2.el6.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/libyaml-0.1.4-2.el6.x86_64.rpm
 libyaml-devel:
   :rpm_name: libyaml-devel-0.1.4-2.el6.x86_64.rpm
-  :source: https://dl.bintray.com/simp/4.2.X/libyaml-devel-0.1.4-2.el6.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/libyaml-devel-0.1.4-2.el6.x86_64.rpm
 logstash:
   :rpm_name: logstash-2.3.4-1.noarch.rpm
   :source: https://download.elastic.co/logstash/logstash/packages/centos/logstash-2.3.4-1.noarch.rpm
@@ -163,22 +163,22 @@ mysql-connector-python:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/mysql-connector-python-1.1.6-1.el6.noarch.rpm
 pdsh:
   :rpm_name: pdsh-2.28-0.x86_64.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/pdsh-2.28-0.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-2.28-0.x86_64.rpm
 pdsh-mod-dshgroup:
   :rpm_name: pdsh-mod-dshgroup-2.28-0.x86_64.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/pdsh-mod-dshgroup-2.28-0.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-mod-dshgroup-2.28-0.x86_64.rpm
 pdsh-mod-machines:
   :rpm_name: pdsh-mod-machines-2.28-0.x86_64.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/pdsh-mod-machines-2.28-0.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-mod-machines-2.28-0.x86_64.rpm
 pdsh-mod-netgroup:
   :rpm_name: pdsh-mod-netgroup-2.28-0.x86_64.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/pdsh-mod-netgroup-2.28-0.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-mod-netgroup-2.28-0.x86_64.rpm
 pdsh-rcmd-exec:
   :rpm_name: pdsh-rcmd-exec-2.28-0.x86_64.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/pdsh-rcmd-exec-2.28-0.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-rcmd-exec-2.28-0.x86_64.rpm
 pdsh-rcmd-ssh:
   :rpm_name: pdsh-rcmd-ssh-2.28-0.x86_64.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/pdsh-rcmd-ssh-2.28-0.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-rcmd-ssh-2.28-0.x86_64.rpm
 perl-Crypt-DES:
   :rpm_name: perl-Crypt-DES-2.05-9.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/perl-Crypt-DES-2.05-9.el6.x86_64.rpm
@@ -214,7 +214,7 @@ postgresql94-server:
   :source: https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-6.9-x86_64/postgresql94-server-9.4.12-1PGDG.rhel6.x86_64.rpm
 pssh:
   :rpm_name: pssh-2.3.1-5.el6.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/packages/el/7/pssh-2.3.1-5.el6.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pssh-2.3.1-5.el6.noarch.rpm
 puppet-agent:
   :rpm_name: puppet-agent-1.8.3-1.el6.x86_64.rpm
   :source: http://yum.puppetlabs.com/el/6/PC1/x86_64/puppet-agent-1.8.3-1.el6.x86_64.rpm
@@ -238,19 +238,19 @@ python-argparse:
   :source: http://mirror.cogentco.com/pub/linux/centos/6/os/x86_64/Packages/python-argparse-1.2.1-2.1.el6.noarch.rpm
 python-elasticsearch:
   :rpm_name: python-elasticsearch-1.2.0-0.el6.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/packages/el/7/python-elasticsearch-1.2.0-0.el6.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/python-elasticsearch-1.2.0-0.el6.noarch.rpm
 python-redis:
   :rpm_name: python-redis-2.0.0-1.el6.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/packages/el/7/python-redis-2.0.0-1.el6.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/python-redis-2.0.0-1.el6.noarch.rpm
 python-six:
   :rpm_name: python-six-1.9.0-2.el6.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/packages/el/7/python-six-1.9.0-2.el6.noarch.rpm
 python-unittest2:
   :rpm_name: python-unittest2-0.5.1-3.el6.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/packages/el/7/python-unittest2-0.5.1-3.el6.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/python-unittest2-0.5.1-3.el6.noarch.rpm
 qstat:
   :rpm_name: qstat-2.11-9.20080912svn311.el6.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/packages/el/7/qstat-2.11-9.20080912svn311.el6.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/qstat-2.11-9.20080912svn311.el6.x86_64.rpm
 radiusclient-ng:
   :rpm_name: radiusclient-ng-0.5.6-5.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/radiusclient-ng-0.5.6-5.el6.x86_64.rpm
@@ -259,40 +259,40 @@ razor-server:
   :source: https://yum.puppetlabs.com/el/6Server/PC1/x86_64/razor-server-1.5.0-1.el6.noarch.rpm
 rlwrap:
   :rpm_name: rlwrap-0.37-3.el6.x86_64.rpm
-  :source: https://dl.bintray.com/simp/4.2.X/rlwrap-0.37-3.el6.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rlwrap-0.37-3.el6.x86_64.rpm
 rubygem-ffi:
   :rpm_name: rubygem-ffi-1.4.0-2.el6.x86_64.rpm
   :source: http://yum.puppetlabs.com/el/6/dependencies/x86_64/rubygem-ffi-1.4.0-2.el6.x86_64.rpm
 rubygem-highline:
   :rpm_name: rubygem-highline-1.6.11-1.noarch.rpm
-  :source: https://dl.bintray.com/simp/4.2.X/rubygem-highline-1.6.11-1.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-highline-1.6.11-1.noarch.rpm
 rubygem-net-ldap:
   :rpm_name: rubygem-net-ldap-0.6.1-2.el6.1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/packages/el/7/rubygem-net-ldap-0.6.1-2.el6.1.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-net-ldap-0.6.1-2.el6.1.noarch.rpm
 rubygem-net-ldap-doc:
   :rpm_name: rubygem-net-ldap-doc-0.6.1-2.el6.1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/packages/el/7/rubygem-net-ldap-doc-0.6.1-2.el6.1.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-net-ldap-doc-0.6.1-2.el6.1.noarch.rpm
 rubygem-net-ping:
   :rpm_name: rubygem-net-ping-1.6.2-1.el6.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/packages/el/7/rubygem-net-ping-1.6.2-1.el6.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-net-ping-1.6.2-1.el6.noarch.rpm
 rubygem-rake-compiler:
   :rpm_name: rubygem-rake-compiler-0.9.3-2.el6.noarch.rpm
   :source: http://fedora-epel.mirror.lstn.net/6/x86_64/rubygem-rake-compiler-0.9.3-2.el6.noarch.rpm
 rubygem-stomp:
   :rpm_name: rubygem-stomp-1.3.2-1.el6.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/packages/el/7/rubygem-stomp-1.3.2-1.el6.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-stomp-1.3.2-1.el6.noarch.rpm
 rubygem-stomp-doc:
   :rpm_name: rubygem-stomp-doc-1.3.2-1.el6.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/packages/el/7/rubygem-stomp-doc-1.3.2-1.el6.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-stomp-doc-1.3.2-1.el6.noarch.rpm
 simp-lastbind:
   :rpm_name: simp-lastbind-2.4.23-0.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/packages/el/7/simp-lastbind-2.4.23-0.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/simp-lastbind-2.4.23-0.x86_64.rpm
 simp-ppolicy-check-password:
   :rpm_name: simp-ppolicy-check-password-2.4.39-0.el6.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/packages/el/7/simp-ppolicy-check-password-2.4.39-0.el6.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/simp-ppolicy-check-password-2.4.39-0.el6.x86_64.rpm
 sudosh2:
   :rpm_name: sudosh2-1.0.2-2.el6.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/packages/el/7/sudosh2-1.0.2-2.el6.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/sudosh2-1.0.2-2.el6.x86_64.rpm
 tpm-tools-pkcs11:
   :rpm_name: tpm-tools-pkcs11-1.3.4-2.el6.x86_64.rpm
   :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.9/os/x86_64/Packages/tpm-tools-pkcs11-1.3.4-2.el6.x86_64.rpm

--- a/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
@@ -7,7 +7,7 @@ activemq-info-provider:
   :source: http://yum.puppetlabs.com/el/6/dependencies/x86_64/activemq-info-provider-5.9.1-2.el6.noarch.rpm
 apr-util-ldap:
   :rpm_name: apr-util-ldap-1.3.9-3.el6_0.1.x86_64.rpm
-  :source: http://denver.gaminghost.co/6.8/os/x86_64/Packages/apr-util-ldap-1.3.9-3.el6_0.1.x86_64.rpm
+  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.9/os/x86_64/Packages/apr-util-ldap-1.3.9-3.el6_0.1.x86_64.rpm
 chkrootkit:
   :rpm_name: chkrootkit-0.49-9.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/chkrootkit-0.49-9.el6.x86_64.rpm
@@ -60,8 +60,8 @@ globus-callout:
   :rpm_name: globus-callout-3.15-1.el6.x86_64.rpm
   :source: https://dl.fedoraproject.org/pub/epel/6/x86_64/globus-callout-3.15-1.el6.x86_64.rpm
 globus-common:
-  :rpm_name: globus-common-16.9-1.el6.x86_64.rpm
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-common-16.9-1.el6.x86_64.rpm
+  :rpm_name: globus-common-17.1-1.el6.x86_64.rpm
+  :source: https://epel.mirror.constant.com/epel/6/x86_64/globus-common-17.1-1.el6.x86_64.rpm
 globus-gsi-callback:
   :rpm_name: globus-gsi-callback-5.13-1.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-gsi-callback-5.13-1.el6.x86_64.rpm
@@ -87,8 +87,8 @@ globus-gss-assist:
   :rpm_name: globus-gss-assist-10.21-1.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-gss-assist-10.21-1.el6.x86_64.rpm
 globus-gssapi-gsi:
-  :rpm_name: globus-gssapi-gsi-12.13-1.el6.x86_64.rpm
-  :source: https://dl.fedoraproject.org/pub/epel/6/x86_64/globus-gssapi-gsi-12.13-1.el6.x86_64.rpm
+  :rpm_name: globus-gssapi-gsi-12.13-3.el6.x86_64.rpm
+  :source: https://epel.mirror.constant.com/epel/6/x86_64/globus-gssapi-gsi-12.13-3.el6.x86_64.rpm
 globus-openssl-module:
   :rpm_name: globus-openssl-module-4.8-1.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-openssl-module-4.8-1.el6.x86_64.rpm
@@ -105,29 +105,29 @@ incron:
   :rpm_name: incron-0.5.9-1.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/incron-0.5.9-1.el6.x86_64.rpm
 kernel:
-  :rpm_name: kernel-2.6.32-642.1.1.el6.x86_64.rpm
-  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.8/updates/x86_64/Packages/kernel-2.6.32-642.1.1.el6.x86_64.rpm
+  :rpm_name: kernel-2.6.32-696.1.1.el6.x86_64.rpm
+  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.9/updates/x86_64/Packages/kernel-2.6.32-696.1.1.el6.x86_64.rpm
 kernel-abi-whitelists:
-  :rpm_name: kernel-abi-whitelists-2.6.32-642.1.1.el6.noarch.rpm
-  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.8/updates/x86_64/Packages/kernel-abi-whitelists-2.6.32-642.1.1.el6.noarch.rpm
+  :rpm_name: kernel-abi-whitelists-2.6.32-696.1.1.el6.noarch.rpm
+  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.9/updates/x86_64/Packages/kernel-abi-whitelists-2.6.32-696.1.1.el6.noarch.rpm
 kernel-debug:
-  :rpm_name: kernel-debug-2.6.32-642.1.1.el6.x86_64.rpm
-  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.8/updates/x86_64/Packages/kernel-debug-2.6.32-642.1.1.el6.x86_64.rpm
+  :rpm_name: kernel-debug-2.6.32-696.1.1.el6.x86_64.rpm
+  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.9/updates/x86_64/Packages/kernel-debug-2.6.32-696.1.1.el6.x86_64.rpm
 kernel-debug-devel:
-  :rpm_name: kernel-debug-devel-2.6.32-642.1.1.el6.x86_64.rpm
-  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.8/updates/x86_64/Packages/kernel-debug-devel-2.6.32-642.1.1.el6.x86_64.rpm
+  :rpm_name: kernel-debug-devel-2.6.32-696.1.1.el6.x86_64.rpm
+  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.9/updates/x86_64/Packages/kernel-debug-devel-2.6.32-696.1.1.el6.x86_64.rpm
 kernel-devel:
-  :rpm_name: kernel-devel-2.6.32-642.1.1.el6.x86_64.rpm
-  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.8/updates/x86_64/Packages/kernel-devel-2.6.32-642.1.1.el6.x86_64.rpm
+  :rpm_name: kernel-devel-2.6.32-696.1.1.el6.x86_64.rpm
+  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.9/updates/x86_64/Packages/kernel-devel-2.6.32-696.1.1.el6.x86_64.rpm
 kernel-doc:
-  :rpm_name: kernel-doc-2.6.32-642.1.1.el6.noarch.rpm
-  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.8/updates/x86_64/Packages/kernel-doc-2.6.32-642.1.1.el6.noarch.rpm
+  :rpm_name: kernel-doc-2.6.32-696.1.1.el6.noarch.rpm
+  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.9/updates/x86_64/Packages/kernel-doc-2.6.32-696.1.1.el6.noarch.rpm
 kernel-firmware:
-  :rpm_name: kernel-firmware-2.6.32-642.1.1.el6.noarch.rpm
-  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.8/updates/x86_64/Packages/kernel-firmware-2.6.32-642.1.1.el6.noarch.rpm
+  :rpm_name: kernel-firmware-2.6.32-696.1.1.el6.noarch.rpm
+  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.9/updates/x86_64/Packages/kernel-firmware-2.6.32-696.1.1.el6.noarch.rpm
 kernel-headers:
-  :rpm_name: kernel-headers-2.6.32-642.1.1.el6.x86_64.rpm
-  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.8/updates/x86_64/Packages/kernel-headers-2.6.32-642.1.1.el6.x86_64.rpm
+  :rpm_name: kernel-headers-2.6.32-696.1.1.el6.x86_64.rpm
+  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.9/updates/x86_64/Packages/kernel-headers-2.6.32-696.1.1.el6.x86_64.rpm
 lcgdm-libs:
   :rpm_name: lcgdm-libs-1.9.0-1.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/lcgdm-libs-1.9.0-1.el6.x86_64.rpm
@@ -202,16 +202,16 @@ perl-Sort-Versions:
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/perl-Sort-Versions-1.5-12.el6.noarch.rpm
 perl-Time-modules:
   :rpm_name: perl-Time-modules-2006.0814-5.el6.noarch.rpm
-  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.8/os/x86_64/Packages/perl-Time-modules-2006.0814-5.el6.noarch.rpm
+  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.9/os/x86_64/Packages/perl-Time-modules-2006.0814-5.el6.noarch.rpm
 postgresql94:
-  :rpm_name: postgresql94-9.4.10-1PGDG.rhel6.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-6.8-x86_64/postgresql94-9.4.10-1PGDG.rhel6.x86_64.rpm
+  :rpm_name: postgresql94-9.4.12-1PGDG.rhel6.x86_64.rpm
+  :source: https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-6.9-x86_64/postgresql94-9.4.12-1PGDG.rhel6.x86_64.rpm
 postgresql94-libs:
-  :rpm_name: postgresql94-libs-9.4.10-1PGDG.rhel6.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-6.8-x86_64/postgresql94-libs-9.4.10-1PGDG.rhel6.x86_64.rpm
+  :rpm_name: postgresql94-libs-9.4.12-1PGDG.rhel6.x86_64.rpm
+  :source: https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-6.9-x86_64/postgresql94-libs-9.4.12-1PGDG.rhel6.x86_64.rpm
 postgresql94-server:
-  :rpm_name: postgresql94-server-9.4.10-1PGDG.rhel6.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-6.8-x86_64/postgresql94-server-9.4.10-1PGDG.rhel6.x86_64.rpm
+  :rpm_name: postgresql94-server-9.4.12-1PGDG.rhel6.x86_64.rpm
+  :source: https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-6.9-x86_64/postgresql94-server-9.4.12-1PGDG.rhel6.x86_64.rpm
 pssh:
   :rpm_name: pssh-2.3.1-5.el6.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/packages/el/7/pssh-2.3.1-5.el6.noarch.rpm
@@ -295,7 +295,7 @@ sudosh2:
   :source: https://packagecloud.io/simp-project/6_X_Alpha_Dependencies/packages/el/7/sudosh2-1.0.2-2.el6.x86_64.rpm
 tpm-tools-pkcs11:
   :rpm_name: tpm-tools-pkcs11-1.3.4-2.el6.x86_64.rpm
-  :source: http://mirror.steadfast.net/centos/6.8/os/x86_64/Packages/tpm-tools-pkcs11-1.3.4-2.el6.x86_64.rpm
+  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.9/os/x86_64/Packages/tpm-tools-pkcs11-1.3.4-2.el6.x86_64.rpm
 voms:
   :rpm_name: voms-2.0.14-1.el6.x86_64.rpm
   :source: http://dl.fedoraproject.org/pub/epel/6/x86_64/voms-2.0.14-1.el6.x86_64.rpm

--- a/build/distributions/CentOS/6/x86_64/yum_data/repos/sql.repo
+++ b/build/distributions/CentOS/6/x86_64/yum_data/repos/sql.repo
@@ -1,5 +1,5 @@
 [postgresql]
 name=postgresql
-baseurl=https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-6.8-x86_64/
+baseurl=https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-6.9-x86_64/
 enabled=1
 gpgcheck=0

--- a/build/distributions/CentOS/7/x86_64/release_mappings.yaml
+++ b/build/distributions/CentOS/7/x86_64/release_mappings.yaml
@@ -2,7 +2,7 @@
 # This file houses the *officially supported* SIMP release combinations
 # Other build combinations may work, but unexpected issues may arise.
 simp_releases:
-  6.0.1-RC1:
+  6.X:
     flavors:
       CentOS:
         isos:

--- a/build/distributions/CentOS/7/x86_64/release_mappings.yaml
+++ b/build/distributions/CentOS/7/x86_64/release_mappings.yaml
@@ -2,7 +2,7 @@
 # This file houses the *officially supported* SIMP release combinations
 # Other build combinations may work, but unexpected issues may arise.
 simp_releases:
-  6.X:
+  6.1.0-RC1:
     flavors:
       CentOS:
         isos:

--- a/build/distributions/CentOS/7/x86_64/release_mappings.yaml
+++ b/build/distributions/CentOS/7/x86_64/release_mappings.yaml
@@ -2,7 +2,7 @@
 # This file houses the *officially supported* SIMP release combinations
 # Other build combinations may work, but unexpected issues may arise.
 simp_releases:
-  6.1.0-RC1:
+  6.0.1-RC1:
     flavors:
       CentOS:
         isos:

--- a/build/distributions/CentOS/7/x86_64/release_mappings.yaml
+++ b/build/distributions/CentOS/7/x86_64/release_mappings.yaml
@@ -21,3 +21,22 @@ simp_releases:
         build_command: 'bundle exec rake build:auto[RedHat-7-x86_64-DVD-1511.iso,6.X]'
         mock:          'epel-7-x86_64'
         os_version:   '7.3'
+  6.0.0-0:
+    flavors:
+      CentOS:
+        isos:
+          - name:     'CentOS-7-x86_64-DVD-1611.iso'
+            size:     4379901952
+            checksum: 'c455ee948e872ad2194bdddd39045b83634e8613249182b88f549bb2319d97eb'
+        build_command: 'bundle exec rake build:auto[CentOS-7-x86_64-DVD-1611.iso,6.X]'
+        mock:          'epel-7-x86_64'
+        os_version:   '7.0'
+
+      RedHat:
+        isos:
+          - name:     'rhel-server-7.3-x86_64-dvd.iso'
+            size:     3793747968
+            checksum: '120acbca7b3d55465eb9f8ef53ad7365f2997d42d4f83d7cc285bf5c71e1131f'
+        build_command: 'bundle exec rake build:auto[RedHat-7-x86_64-DVD-1511.iso,6.X]'
+        mock:          'epel-7-x86_64'
+        os_version:   '7.3'

--- a/build/distributions/Fedora/24/x86_64/release_mappings.yaml
+++ b/build/distributions/Fedora/24/x86_64/release_mappings.yaml
@@ -2,7 +2,7 @@
 # This file houses the *officially supported* SIMP release combinations
 # Other build combinations may work, but unexpected issues may arise.
 simp_releases:
-  6.0.1-RC1:
+  6.X:
     flavors:
       CentOS:
         isos:

--- a/build/distributions/Fedora/24/x86_64/release_mappings.yaml
+++ b/build/distributions/Fedora/24/x86_64/release_mappings.yaml
@@ -20,3 +20,21 @@ simp_releases:
         build_command: 'bundle exec rake build:auto[6.X,RedHat-7-x86_64-DVD-1511.iso]'
         mock:          'epel-7-x86_64'
         os_version:   '7.2'
+  6.0.0-0:
+    flavors:
+      CentOS:
+        isos:
+          - name:     'CentOS-7-x86_64-DVD-1511.iso'
+            size:     4329570304
+            checksum: '907e5755f824c5848b9c8efbb484f3cd945e93faa024bad6ba875226f9683b16'
+        build_command: 'bundle exec rake build:auto[6.X,CentOS-7-x86_64-DVD-1511.iso]'
+        mock:          'epel-7-x86_64'
+        os_version:   '7.0'
+      RedHat:
+        isos:
+          - name:     'rhel-server-7.2-x86_64-dvd.iso'
+            size:     4043309056
+            checksum: '03f3a0291634335f6995534d829bd21ffaa0d000004dfeb1b2fb81052d64a4d5'
+        build_command: 'bundle exec rake build:auto[6.X,RedHat-7-x86_64-DVD-1511.iso]'
+        mock:          'epel-7-x86_64'
+        os_version:   '7.2'

--- a/build/distributions/Fedora/24/x86_64/release_mappings.yaml
+++ b/build/distributions/Fedora/24/x86_64/release_mappings.yaml
@@ -2,7 +2,7 @@
 # This file houses the *officially supported* SIMP release combinations
 # Other build combinations may work, but unexpected issues may arise.
 simp_releases:
-  6.X:
+  6.1.0-RC1:
     flavors:
       CentOS:
         isos:

--- a/build/distributions/Fedora/24/x86_64/release_mappings.yaml
+++ b/build/distributions/Fedora/24/x86_64/release_mappings.yaml
@@ -2,7 +2,7 @@
 # This file houses the *officially supported* SIMP release combinations
 # Other build combinations may work, but unexpected issues may arise.
 simp_releases:
-  6.1.0-RC1:
+  6.0.1-RC1:
     flavors:
       CentOS:
         isos:

--- a/build/distributions/RedHat/6/x86_64/release_mappings.yaml
+++ b/build/distributions/RedHat/6/x86_64/release_mappings.yaml
@@ -2,7 +2,7 @@
 # This file houses the *officially supported* SIMP release combinations
 # Other build combinations may work, but unexpected issues may arise.
 simp_releases:
-  6.0.1-RC1:
+  6.X:
     flavors:
       CentOS:
         isos:

--- a/build/distributions/RedHat/6/x86_64/release_mappings.yaml
+++ b/build/distributions/RedHat/6/x86_64/release_mappings.yaml
@@ -2,24 +2,24 @@
 # This file houses the *officially supported* SIMP release combinations
 # Other build combinations may work, but unexpected issues may arise.
 simp_releases:
-  6.X:
+  6.1.0-RC1:
     flavors:
       CentOS:
         isos:
-          - name:     'CentOS-6.8-x86_64-bin-DVD1.iso'
-            size:     3916431360
-            checksum: '1dda55622614a8b43b448a72f87d6cb7f79de1eff49ee8c5881a7d9db28d4e35'
-          - name:     'CentOS-6.8-x86_64-bin-DVD2.iso'
-            size:     2220693504
-            checksum: '0aba869427b4ce04e100d72744daf7fea1f7be2e4be56b658095bd9e99e04e6d'
-        build_command: 'bundle exec rake build:auto[4.2.X,/path/to/CentOS-6.8/DVDs]'
+          - name:     'CentOS-6.9-x86_64-bin-DVD1.iso'
+            size:     3972005888
+            checksum: 'd27cf37a40509c17ad70f37bc743f038c1feba00476fe6b69682aa424c399ea6'
+          - name:     'CentOS-6.9-x86_64-bin-DVD2.iso'
+            size:     2177677312
+            checksum: '631b8640460f46a8139a6a7cbbac5f3594d08c32945449b6bbd65234929ce7a4'
+        build_command: 'bundle exec rake build:auto[/path/to/CentOS-6.9/DVDs,6.X]'
         mock:          'epel-6-x86_64'
-        os_version:   '6.8'
+        os_version:   '6.9'
       RedHat:
         isos:
           - name:     'rhel-server-6.8-x86_64-dvd.iso'
             size:     3878682624
             checksum: 'd35fd1af20f6adef9b11b46c2534ae8b6e18de7754889e2b51808b436dff2804'
-        build_command: 'bundle exec rake build:auto[4.2.X,rhel-server-6.8-x86_64-dvd.iso]'
+        build_command: 'bundle exec rake build:auto[/path/to/RedHat/DVDS,6.X]'
         mock:          'epel-6-x86_64'
         os_version:   '6.8'

--- a/build/distributions/RedHat/6/x86_64/release_mappings.yaml
+++ b/build/distributions/RedHat/6/x86_64/release_mappings.yaml
@@ -17,9 +17,9 @@ simp_releases:
         os_version:   '6.9'
       RedHat:
         isos:
-          - name:     'rhel-server-6.8-x86_64-dvd.iso'
-            size:     3878682624
-            checksum: 'd35fd1af20f6adef9b11b46c2534ae8b6e18de7754889e2b51808b436dff2804'
+          - name:     'rhel-server-6.9-x86_64-dvd.iso'
+            size:     3887071232
+            checksum: '3f961576e9f81ea118566f73f98d7bdf3287671c35436a13787c1ffd5078cf8e'
         build_command: 'bundle exec rake build:auto[/path/to/RedHat/DVDS,6.X]'
         mock:          'epel-6-x86_64'
-        os_version:   '6.8'
+        os_version:   '6.9'

--- a/build/distributions/RedHat/6/x86_64/release_mappings.yaml
+++ b/build/distributions/RedHat/6/x86_64/release_mappings.yaml
@@ -2,7 +2,7 @@
 # This file houses the *officially supported* SIMP release combinations
 # Other build combinations may work, but unexpected issues may arise.
 simp_releases:
-  6.1.0-RC1:
+  6.0.1-RC1:
     flavors:
       CentOS:
         isos:

--- a/build/distributions/RedHat/6/x86_64/release_mappings.yaml
+++ b/build/distributions/RedHat/6/x86_64/release_mappings.yaml
@@ -23,3 +23,24 @@ simp_releases:
         build_command: 'bundle exec rake build:auto[/path/to/RedHat/DVDS,6.X]'
         mock:          'epel-6-x86_64'
         os_version:   '6.9'
+  6.0.0-0:
+    flavors:
+      CentOS:
+        isos:
+          - name:     'CentOS-6.8-x86_64-bin-DVD1.iso'
+            size:     3916431360
+            checksum: '1dda55622614a8b43b448a72f87d6cb7f79de1eff49ee8c5881a7d9db28d4e35'
+          - name:     'CentOS-6.8-x86_64-bin-DVD2.iso'
+            size:     2220693504
+            checksum: '0aba869427b4ce04e100d72744daf7fea1f7be2e4be56b658095bd9e99e04e6d'
+        build_command: 'bundle exec rake build:auto[4.2.X,/path/to/CentOS-6.8/DVDs]'
+        mock:          'epel-6-x86_64'
+        os_version:   '6.8'
+      RedHat:
+        isos:
+          - name:     'rhel-server-6.8-x86_64-dvd.iso'
+            size:     3878682624
+            checksum: 'd35fd1af20f6adef9b11b46c2534ae8b6e18de7754889e2b51808b436dff2804'
+        build_command: 'bundle exec rake build:auto[4.2.X,rhel-server-6.8-x86_64-dvd.iso]'
+        mock:          'epel-6-x86_64'
+        os_version:   '6.8'

--- a/build/distributions/RedHat/6/x86_64/yum_data/packages.yaml
+++ b/build/distributions/RedHat/6/x86_64/yum_data/packages.yaml
@@ -7,7 +7,7 @@ activemq-info-provider:
   :source: http://yum.puppetlabs.com/el/6/dependencies/x86_64/activemq-info-provider-5.9.1-2.el6.noarch.rpm
 apr-util-ldap:
   :rpm_name: apr-util-ldap-1.3.9-3.el6_0.1.x86_64.rpm
-  :source: http://denver.gaminghost.co/6.8/os/x86_64/Packages/apr-util-ldap-1.3.9-3.el6_0.1.x86_64.rpm
+  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.9/os/x86_64/Packages/apr-util-ldap-1.3.9-3.el6_0.1.x86_64.rpm
 chkrootkit:
   :rpm_name: chkrootkit-0.49-9.el6.x86_64.rpm
   :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/chkrootkit-0.49-9.el6.x86_64.rpm
@@ -60,8 +60,8 @@ globus-callout:
   :rpm_name: globus-callout-3.15-1.el6.x86_64.rpm
   :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/globus-callout-3.13-2.el6.x86_64.rpm
 globus-common:
-  :rpm_name: globus-common-16.9-1.el6.x86_64.rpm
-  :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/globus-common-15.30-1.el6.x86_64.rpm
+  :rpm_name: globus-common-17.1-1.el6.x86_64.rpm
+  :source: https://epel.mirror.constant.com/epel/6/x86_64/globus-common-17.1-1.el6.x86_64.rpm
 globus-gsi-callback:
   :rpm_name: globus-gsi-callback-5.13-1.el6.x86_64.rpm
   :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/globus-gsi-callback-5.8-1.el6.x86_64.rpm
@@ -87,8 +87,8 @@ globus-gss-assist:
   :rpm_name: globus-gss-assist-10.21-1.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-gss-assist-10.15-1.el6.x86_64.rpm
 globus-gssapi-gsi:
-  :rpm_name: globus-gssapi-gsi-12.13-1.el6.x86_64.rpm
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-gssapi-gsi-11.26-1.el6.x86_64.rpm
+  :rpm_name: globus-gssapi-gsi-12.13-3.el6.x86_64.rpm
+  :source: https://epel.mirror.constant.com/epel/6/x86_64/globus-gssapi-gsi-12.13-3.el6.x86_64.rpm
 globus-openssl-module:
   :rpm_name: globus-openssl-module-4.8-1.el6.x86_64.rpm
   :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/globus-openssl-module-4.6-2.el6.x86_64.rpm
@@ -204,14 +204,14 @@ perl-Time-modules:
   :rpm_name: perl-Time-modules-2006.0814-5.el6.noarch.rpm
   :source: Red Hat Base Repository
 postgresql94:
-  :rpm_name: postgresql94-9.4.10-1PGDG.rhel6.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-6.8-x86_64/postgresql94-9.4.10-1PGDG.rhel6.x86_64.rpm
+  :rpm_name: postgresql94-9.4.12-1PGDG.rhel6.x86_64.rpm
+  :source: https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-6.9-x86_64/postgresql94-9.4.12-1PGDG.rhel6.x86_64.rpm
 postgresql94-libs:
-  :rpm_name: postgresql94-libs-9.4.10-1PGDG.rhel6.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-6.8-x86_64/postgresql94-libs-9.4.10-1PGDG.rhel6.x86_64.rpm
+  :rpm_name: postgresql94-libs-9.4.12-1PGDG.rhel6.x86_64.rpm
+  :source: https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-6.9-x86_64/postgresql94-libs-9.4.12-1PGDG.rhel6.x86_64.rpm
 postgresql94-server:
-  :rpm_name: postgresql94-server-9.4.10-1PGDG.rhel6.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-6.8-x86_64/postgresql94-server-9.4.10-1PGDG.rhel6.x86_64.rpm
+  :rpm_name: postgresql94-server-9.4.12-1PGDG.rhel6.x86_64.rpm
+  :source: https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-6.9-x86_64/postgresql94-server-9.4.12-1PGDG.rhel6.x86_64.rpm
 pssh:
   :rpm_name: pssh-2.3.1-5.el6.noarch.rpm
   :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/pssh-2.3.1-5.el6.noarch.rpm
@@ -295,7 +295,7 @@ sudosh2:
   :source: https://dl.bintray.com/simp/4.2.X-Ext/sudosh2-1.0.2-2.el6.x86_64.rpm
 tpm-tools-pkcs11:
   :rpm_name: tpm-tools-pkcs11-1.3.4-2.el6.x86_64.rpm
-  :source: http://mirror.steadfast.net/centos/6.8/os/x86_64/Packages/tpm-tools-pkcs11-1.3.4-2.el6.x86_64.rpm
+  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.9/os/x86_64/Packages/tpm-tools-pkcs11-1.3.4-2.el6.x86_64.rpm
 voms:
   :rpm_name: voms-2.0.14-1.el6.x86_64.rpm
   :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/voms-2.0.12-3.el6.x86_64.rpm

--- a/build/distributions/RedHat/6/x86_64/yum_data/packages.yaml
+++ b/build/distributions/RedHat/6/x86_64/yum_data/packages.yaml
@@ -37,7 +37,7 @@ elasticsearch:
   :source: https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/rpm/elasticsearch/2.3.5/elasticsearch-2.3.5.rpm
 elasticsearch-curator:
   :rpm_name: elasticsearch-curator-1.1.1-0.el6.noarch.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/elasticsearch-curator-1.1.1-0.el6.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/elasticsearch-curator-1.1.1-0.el6.noarch.rpm
 fping:
   :rpm_name: fping-2.4b2-10.el6.x86_64.rpm
   :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/fping-2.4b2-10.el6.x86_64.rpm
@@ -97,7 +97,7 @@ grafana:
   :source: https://packagecloud.io/grafana/stable/packages/el/6/grafana-3.1.1-1470047149.x86_64.rpm
 gweb:
   :rpm_name: gweb-2.1.8-1.noarch.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/gweb-2.1.8-1.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/gweb-2.1.8-1.noarch.rpm
 haveged:
   :rpm_name: haveged-1.9.1-2.el6.x86_64.rpm
   :source: http://mirror.sfo12.us.leaseweb.net/epel/6/x86_64/haveged-1.9.1-2.el6.x86_64.rpm
@@ -148,10 +148,10 @@ libev:
   :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/libev-4.03-3.el6.x86_64.rpm
 libyaml:
   :rpm_name: libyaml-0.1.4-2.el6.x86_64.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/libyaml-0.1.4-2.el6.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/libyaml-0.1.4-2.el6.x86_64.rpm
 libyaml-devel:
   :rpm_name: libyaml-devel-0.1.4-2.el6.x86_64.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/libyaml-devel-0.1.4-2.el6.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/libyaml-devel-0.1.4-2.el6.x86_64.rpm
 logstash:
   :rpm_name: logstash-2.3.4-1.noarch.rpm
   :source: https://download.elastic.co/logstash/logstash/packages/centos/logstash-2.3.4-1.noarch.rpm
@@ -163,22 +163,22 @@ mysql-connector-python:
   :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/mysql-connector-python-1.1.6-1.el6.noarch.rpm
 pdsh:
   :rpm_name: pdsh-2.28-0.x86_64.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/pdsh-2.28-0.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-2.28-0.x86_64.rpm
 pdsh-mod-dshgroup:
   :rpm_name: pdsh-mod-dshgroup-2.28-0.x86_64.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/pdsh-mod-dshgroup-2.28-0.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-mod-dshgroup-2.28-0.x86_64.rpm
 pdsh-mod-machines:
   :rpm_name: pdsh-mod-machines-2.28-0.x86_64.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/pdsh-mod-machines-2.28-0.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-mod-machines-2.28-0.x86_64.rpm
 pdsh-mod-netgroup:
   :rpm_name: pdsh-mod-netgroup-2.28-0.x86_64.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/pdsh-mod-netgroup-2.28-0.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-mod-netgroup-2.28-0.x86_64.rpm
 pdsh-rcmd-exec:
   :rpm_name: pdsh-rcmd-exec-2.28-0.x86_64.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/pdsh-rcmd-exec-2.28-0.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-rcmd-exec-2.28-0.x86_64.rpm
 pdsh-rcmd-ssh:
   :rpm_name: pdsh-rcmd-ssh-2.28-0.x86_64.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/pdsh-rcmd-ssh-2.28-0.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-rcmd-ssh-2.28-0.x86_64.rpm
 perl-Crypt-DES:
   :rpm_name: perl-Crypt-DES-2.05-9.el6.x86_64.rpm
   :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/perl-Crypt-DES-2.05-9.el6.x86_64.rpm
@@ -238,7 +238,7 @@ python-argparse:
   :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/python-argparse-1.2.1-2.el6.noarch.rpm
 python-elasticsearch:
   :rpm_name: python-elasticsearch-1.2.0-0.el6.noarch.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/python-elasticsearch-1.2.0-0.el6.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/python-elasticsearch-1.2.0-0.el6.noarch.rpm
 python-redis:
   :rpm_name: python-redis-2.0.0-1.el6.noarch.rpm
   :source: http://mirror.symnds.com/distributions/fedora-epel/6/x86_64/python-redis-2.0.0-1.el6.noarch.rpm
@@ -265,7 +265,7 @@ rubygem-ffi:
   :source: http://yum.puppetlabs.com/el/6/dependencies/x86_64/rubygem-ffi-1.4.0-2.el6.x86_64.rpm
 rubygem-highline:
   :rpm_name: rubygem-highline-1.6.11-1.noarch.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/rubygem-highline-1.6.11-1.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-highline-1.6.11-1.noarch.rpm
 rubygem-net-ldap:
   :rpm_name: rubygem-net-ldap-0.6.1-2.el6.1.noarch.rpm
   :source: https://dl.fedoraproject.org/pub/epel/6/x86_64/rubygem-net-ldap-0.6.1-2.el6.1.noarch.rpm
@@ -286,13 +286,13 @@ rubygem-stomp-doc:
   :source: http://yum.puppetlabs.com/el/6/dependencies/x86_64/rubygem-stomp-doc-1.3.2-1.el6.noarch.rpm
 simp-lastbind:
   :rpm_name: simp-lastbind-2.4.23-0.x86_64.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/simp-lastbind-2.4.23-0.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/simp-lastbind-2.4.23-0.x86_64.rpm
 simp-ppolicy-check-password:
   :rpm_name: simp-ppolicy-check-password-2.4.39-0.el6.x86_64.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/simp-ppolicy-check-password-2.4.39-0.el6.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/simp-ppolicy-check-password-2.4.39-0.el6.x86_64.rpm
 sudosh2:
   :rpm_name: sudosh2-1.0.2-2.el6.x86_64.rpm
-  :source: https://dl.bintray.com/simp/4.2.X-Ext/sudosh2-1.0.2-2.el6.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/sudosh2-1.0.2-2.el6.x86_64.rpm
 tpm-tools-pkcs11:
   :rpm_name: tpm-tools-pkcs11-1.3.4-2.el6.x86_64.rpm
   :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.9/os/x86_64/Packages/tpm-tools-pkcs11-1.3.4-2.el6.x86_64.rpm

--- a/build/distributions/RedHat/7/x86_64/release_mappings.yaml
+++ b/build/distributions/RedHat/7/x86_64/release_mappings.yaml
@@ -2,7 +2,7 @@
 # This file houses the *officially supported* SIMP release combinations
 # Other build combinations may work, but unexpected issues may arise.
 simp_releases:
-  6.0.1-RC1:
+  6.X:
     flavors:
       CentOS:
         isos:

--- a/build/distributions/RedHat/7/x86_64/release_mappings.yaml
+++ b/build/distributions/RedHat/7/x86_64/release_mappings.yaml
@@ -2,7 +2,7 @@
 # This file houses the *officially supported* SIMP release combinations
 # Other build combinations may work, but unexpected issues may arise.
 simp_releases:
-  6.X:
+  6.1.0-RC1:
     flavors:
       CentOS:
         isos:

--- a/build/distributions/RedHat/7/x86_64/release_mappings.yaml
+++ b/build/distributions/RedHat/7/x86_64/release_mappings.yaml
@@ -2,7 +2,7 @@
 # This file houses the *officially supported* SIMP release combinations
 # Other build combinations may work, but unexpected issues may arise.
 simp_releases:
-  6.1.0-RC1:
+  6.0.1-RC1:
     flavors:
       CentOS:
         isos:

--- a/build/distributions/RedHat/7/x86_64/release_mappings.yaml
+++ b/build/distributions/RedHat/7/x86_64/release_mappings.yaml
@@ -21,3 +21,22 @@ simp_releases:
         build_command: 'bundle exec rake build:auto[RedHat-7-x86_64-DVD-1511.iso,6.X]'
         mock:          'epel-7-x86_64'
         os_version:   '7.3'
+  6.0.0-0:
+    flavors:
+      CentOS:
+        isos:
+          - name:     'CentOS-7-x86_64-DVD-1611.iso'
+            size:     4379901952
+            checksum: 'c455ee948e872ad2194bdddd39045b83634e8613249182b88f549bb2319d97eb'
+        build_command: 'bundle exec rake build:auto[CentOS-7-x86_64-DVD-1611.iso,6.X]'
+        mock:          'epel-7-x86_64'
+        os_version:   '7.0'
+
+      RedHat:
+        isos:
+          - name:     'rhel-server-7.3-x86_64-dvd.iso'
+            size:     3793747968
+            checksum: '120acbca7b3d55465eb9f8ef53ad7365f2997d42d4f83d7cc285bf5c71e1131f'
+        build_command: 'bundle exec rake build:auto[RedHat-7-x86_64-DVD-1511.iso,6.X]'
+        mock:          'epel-7-x86_64'
+        os_version:   '7.3'

--- a/src/build/simp.spec
+++ b/src/build/simp.spec
@@ -111,9 +111,9 @@ Prefix: %{_sysconfdir}/puppet
 %package extras
 Summary: Extra Packages for SIMP
 License: Apache-2.0
-Requires: pupmod-bfraser-grafana >= 2.5.0-2016
-Requires: pupmod-elasticsearch-elasticsearch >= 0.11.0-2016
-Requires: pupmod-elasticsearch-logstash >= 0.6.4-2016
+Requires: pupmod-puppet-grafana >= 3.0.0-2016
+Requires: pupmod-elastic-elasticsearch >= 5.2.0-2016
+Requires: pupmod-elastic-logstash >= 5.2.1-2016
 Requires: pupmod-electrical-file_concat >= 1.0.1-2016
 Requires: pupmod-herculesteam-augeasproviders_mounttab >= 2.0.1-2016
 Requires: pupmod-herculesteam-augeasproviders_nagios >= 2.0.1-2016

--- a/src/build/simp.spec
+++ b/src/build/simp.spec
@@ -119,7 +119,6 @@ Requires: pupmod-herculesteam-augeasproviders_mounttab >= 2.0.1-2016
 Requires: pupmod-herculesteam-augeasproviders_nagios >= 2.0.1-2016
 Requires: pupmod-herculesteam-augeasproviders_pam >= 2.0.3-2016
 Requires: pupmod-puppetlabs-mysql >= 2.2.3-2016
-Requires: pupmod-simp-foreman >= 1.0.0
 Requires: pupmod-simp-gdm >= 6.0.0-2016
 Requires: pupmod-simp-gnome >= 6.0.0-2016
 Requires: pupmod-simp-jenkins >= 6.0.0-2016


### PR DESCRIPTION
- Updated packages.yaml and ISO prune list
- Updated release mapper (NOTE RHEL 6.9 Not updated)
- Updated gitignore to include src/assets/environment, it is
  managed by the simp-environment-skeleton project

SIMP-3170 #close
SIMP-3171 #close