### PR TITLE
(SIMP-3376) Updates for RHEL7 build

### DIFF
--- a/build/distributions/CentOS/7/x86_64/DVD/7-simp_pkglist.txt
+++ b/build/distributions/CentOS/7/x86_64/DVD/7-simp_pkglist.txt
@@ -1309,12 +1309,15 @@ python-ldap
 python-libs
 python-linecache2
 python-lxml
+python-magic
 python-memcached
 python-perf
 python-pycurl
 python-pyro
 python-pyudev
 python-redis
+python-rhsm
+python-rhsm-certificates
 python-setuptools
 python-simplejson
 python-six

--- a/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
@@ -118,10 +118,10 @@ puppet-agent:
   :source: http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-agent-1.8.3-1.el7.x86_64.rpm
 puppet-client-tools:
   :rpm_name: puppet-client-tools-1.1.1-1.el7.x86_64.rpm
-  :source: http://yum.puppetlabs.com/el/7Server/PC1/x86_64/puppet-client-tools-1.1.0-1.el7.x86_64.rpm
+  :source: http://yum.puppetlabs.com/el/7Server/PC1/x86_64/puppet-client-tools-1.1.1-1.el7.x86_64.rpm
 puppetdb:
   :rpm_name: puppetdb-4.3.0-1.el7.noarch.rpm
-  :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppetdb-2.3.8-1.el7.noarch.rpm
+  :source: http://yum.puppetlabs.com/el/7/PC1/x86_64/puppetdb-4.3.0-1.el7.noarch.rpm
 puppetdb-termini:
   :rpm_name: puppetdb-termini-4.3.0-1.el7.noarch.rpm
   :source: http://yum.puppetlabs.com/el/7/PC1/x86_64/puppetdb-termini-4.3.0-1.el7.noarch.rpm
@@ -130,7 +130,7 @@ puppetlabs-release-pc1:
   :source: http://yum.puppetlabs.com/el/7/PC1/x86_64/puppetlabs-release-pc1-1.1.0-5.el7.noarch.rpm
 puppetserver:
   :rpm_name: puppetserver-2.7.2-1.el7.noarch.rpm
-  :source: http://yum.puppetlabs.com/el/7/products/x86_64/puppetserver-1.1.3-1.el7.noarch.rpm
+  :source: http://yum.puppetlabs.com/el/7/PC1/x86_64/puppetserver-2.7.2-1.el7.noarch.rpm
 python-elasticsearch:
   :rpm_name: python-elasticsearch-1.2.0-0.el7.centos.noarch.rpm
   :source: https://dl.bintray.com/simp/5.1.X-Ext/python-elasticsearch-1.2.0-0.el7.centos.noarch.rpm
@@ -151,7 +151,7 @@ python-unittest2:
   :source: http://lug.mtu.edu/epel/7/x86_64/p/python-unittest2-1.1.0-4.el7.noarch.rpm
 razor-server:
   :rpm_name: razor-server-1.5.0-1.el7.noarch.rpm
-  :source: http://yum.puppetlabs.com/el/7/products/x86_64/razor-server-1.1.0-1.el7.noarch.rpm
+  :source: http://yum.puppetlabs.com/el/7/PC1/x86_64/razor-server-1.5.0-1.el7.noarch.rpm
 ruby-augeas:
   :rpm_name: ruby-augeas-0.4.1-3.el7.x86_64.rpm
   :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/ruby-augeas-0.4.1-3.el7.x86_64.rpm
@@ -174,11 +174,11 @@ rubygem-highline:
   :rpm_name: rubygem-highline-1.6.11-5.el7.noarch.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/r/rubygem-highline-1.6.11-5.el7.noarch.rpm
 rubygem-net-ldap:
-  :rpm_name: rubygem-net-ldap-0.6.1-2.el7.noarch.rpm
-  :source: https://dl.fedoraproject.org/pub/epel/7/x86_64/r/rubygem-net-ldap-0.6.1-2.el7.noarch.rpm
+  :rpm_name: rubygem-net-ldap-0.16.0-1.el7.noarch.rpm
+  :source: https://dl.fedoraproject.org/pub/epel/7/x86_64/r/rubygem-net-ldap-0.16.0-1.el7.noarch.rpm
 rubygem-net-ldap-doc:
-  :rpm_name: rubygem-net-ldap-doc-0.6.1-2.el7.noarch.rpm
-  :source: https://dl.fedoraproject.org/pub/epel/7/x86_64/r/rubygem-net-ldap-doc-0.6.1-2.el7.noarch.rpm
+  :rpm_name: rubygem-net-ldap-doc-0.16.0-1.el7.noarch.rpm
+  :source: https://dl.fedoraproject.org/pub/epel/7/x86_64/r/rubygem-net-ldap-doc-0.16.0-1.el7.noarch.rpm
 rubygem-net-ping:
   :rpm_name: rubygem-net-ping-1.6.2-1.el7.noarch.rpm
   :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-net-ping-1.6.2-1.el7.noarch.rpm

--- a/build/distributions/RedHat/7/x86_64/yum_data/repos/postgres.repo
+++ b/build/distributions/RedHat/7/x86_64/yum_data/repos/postgres.repo
@@ -1,0 +1,6 @@
+[pgdg94]
+name=PostgreSQL 9.4 7 - x86_64
+baseurl=https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-7-x86_64
+enabled=1
+gpgcheck=1
+gpgkey=https://raw.githubusercontent.com/postgres/pgweb/master/keys/RPM-GPG-KEY-PGDG

--- a/build/distributions/RedHat/7/x86_64/yum_data/repos/puppet.repo
+++ b/build/distributions/RedHat/7/x86_64/yum_data/repos/puppet.repo
@@ -1,7 +1,7 @@
 [puppet]
 name=puppet
-baseurl=http://yum.puppetlabs.com/el/7/products/x86_64/
+baseurl=https://yum.puppetlabs.com/el/7/PC1/x86_64/
 
 [puppet-dependencies]
 name=puppet-dependencies
-baseurl=http://yum.puppetlabs.com/el/7/dependencies/x86_64/
+baseurl=https://yum.puppetlabs.com/el/7/dependencies/x86_64/

--- a/build/distributions/RedHat/7/x86_64/yum_data/repos/simp.repo
+++ b/build/distributions/RedHat/7/x86_64/yum_data/repos/simp.repo
@@ -1,9 +1,25 @@
-[simp-base]
+[simp-project_5_X]
+name=simp-project_5_X
+baseurl=https://packagecloud.io/simp-project/5_X/el/7/$basearch
+gpgcheck=1
+enabled=1
+gpgkey=https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
+
+[simp-project_5_X_dependencies]
+name=simp-project_5_1_X_dependencies
+baseurl=https://packagecloud.io/simp-project/5_X_Dependencies/el/7/$basearch
+gpgcheck=1
+enabled=1
+gpgkey=https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
+       https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs
+       https://getfedora.org/static/352C64E5.txt
+
+[simp-legacy]
 name=simp-base
-baseurl=https://dl.bintray.com/simp/5.1.X 
+baseurl=https://dl.bintray.com/simp/5.1.X
 enabled=1
 
-[simp-ext]
+[simp-ext-legacy]
 name=simp-ext
-baseurl=https://dl.bintray.com/simp/5.1.X-Ext 
+baseurl=https://dl.bintray.com/simp/5.1.X-Ext
 enabled=1

--- a/build/distributions/RedHat/7/x86_64/yum_data/repos/simp.repo
+++ b/build/distributions/RedHat/7/x86_64/yum_data/repos/simp.repo
@@ -1,17 +1,19 @@
-[simp-project_5_X]
-name=simp-project_5_X
-baseurl=https://packagecloud.io/simp-project/5_X/el/7/$basearch
+[simp-project_6_X]
+name=simp-project_6_X
+baseurl=https://packagecloud.io/simp-project/6_X/el/$releasever/$basearch
 gpgcheck=1
 enabled=1
 gpgkey=https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
 
-[simp-project_5_X_dependencies]
-name=simp-project_5_1_X_dependencies
-baseurl=https://packagecloud.io/simp-project/5_X_Dependencies/el/7/$basearch
+[simp-project_6_X_dependencies]
+name=simp-project_6_1_X_dependencies
+baseurl=https://packagecloud.io/simp-project/6_X_Dependencies/el/$releasever/$basearch
 gpgcheck=1
 enabled=1
 gpgkey=https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
        https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs
+       https://yum.puppetlabs.com/RPM-GPG-KEY-puppet
+       https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-94
        https://getfedora.org/static/352C64E5.txt
 
 [simp-legacy]


### PR DESCRIPTION
These updates are required to build SIMP for RHEL7.

You will also still need to ensure that a copy of all of your RHEL
repos are available in the 'repos' directory for downloading
dependencies at build time.

SIMP-3376 #close
SIMP-3386 #close