### PR TITLE
(SIMP-3436) Dependancy Error

### DIFF
--- a/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
@@ -10,7 +10,7 @@ apr-util-ldap:
   :source: http://mirrors.advancedhosters.com/centos/7.3.1611/os/x86_64/Packages/apr-util-ldap-1.5.2-6.el7.x86_64.rpm
 chkrootkit:
   :rpm_name: chkrootkit-0.50-4el7.x86_64.rpm
-  :source: https://dl.bintray.com/simp/5.1.X-Ext/chkrootkit-0.50-4el7.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/chkrootkit-0.50-4el7.x86_64.rpm
 clamav:
   :rpm_name: clamav-0.99.2-1.el7.x86_64.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/c/clamav-0.99.2-1.el7.x86_64.rpm
@@ -55,13 +55,13 @@ elasticsearch:
   :source: https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/rpm/elasticsearch/2.3.5/elasticsearch-2.3.5.rpm
 elasticsearch-curator:
   :rpm_name: elasticsearch-curator-1.1.1-0el7.noarch.rpm
-  :source: https://dl.bintray.com/simp/5.1.X-Ext/elasticsearch-curator-1.1.1-0el7.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/elasticsearch-curator-1.1.1-0el7.noarch.rpm
 grafana:
   :rpm_name: grafana-3.1.1-1470047149.x86_64.rpm
   :source: https://packagecloud.io/grafana/stable/el/7/x86_64/grafana-3.1.1-1470047149.x86_64.rpm
 gweb:
   :rpm_name: gweb-2.1.8-1.noarch.rpm
-  :source: https://dl.bintray.com/simp/5.1.X-Ext/gweb-2.1.8-1.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/gweb-2.1.8-1.noarch.rpm
 haveged:
   :rpm_name: haveged-1.9.1-1.el7.x86_64.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/h/haveged-1.9.1-1.el7.x86_64.rpm
@@ -70,7 +70,7 @@ incron:
   :source: http://lug.mtu.edu/epel/7/x86_64/i/incron-0.5.10-8.el7.x86_64.rpm
 libarchive-devel:
   :rpm_name: libarchive-devel-3.1.2-10.el7_2.x86_64.rpm
-  :source: http://mirror.supremebytes.com/centos/7.3.1611/os/x86_64/Packages/libarchive-devel-3.1.2-10.el7_2.x86_64.rpm
+  :source: http://repos.dfw.quadranet.com/centos/7.3.1611/os/x86_64/Packages/libarchive-devel-3.1.2-10.el7_2.x86_64.rpm
 libconfuse:
   :rpm_name: libconfuse-2.7-7.el7.x86_64.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/l/libconfuse-2.7-7.el7.x86_64.rpm
@@ -82,25 +82,25 @@ logstash:
   :source: https://download.elastic.co/logstash/logstash/packages/centos/logstash-2.3.4-1.noarch.rpm
 pdsh:
   :rpm_name: pdsh-2.29-1el7.x86_64.rpm
-  :source: https://dl.bintray.com/simp/5.1.X-Ext/pdsh-2.29-1el7.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-2.29-1el7.x86_64.rpm
 pdsh-debuginfo:
   :rpm_name: pdsh-debuginfo-2.29-1el7.x86_64.rpm
-  :source: https://dl.bintray.com/simp/5.1.X-Ext/pdsh-debuginfo-2.29-1el7.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-debuginfo-2.29-1el7.x86_64.rpm
 pdsh-mod-dshgroup:
   :rpm_name: pdsh-mod-dshgroup-2.29-1el7.x86_64.rpm
-  :source: https://dl.bintray.com/simp/5.1.X-Ext/pdsh-mod-dshgroup-2.29-1el7.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-mod-dshgroup-2.29-1el7.x86_64.rpm
 pdsh-mod-machines:
   :rpm_name: pdsh-mod-machines-2.29-1el7.x86_64.rpm
-  :source: https://dl.bintray.com/simp/5.1.X-Ext/pdsh-mod-machines-2.29-1el7.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-mod-machines-2.29-1el7.x86_64.rpm
 pdsh-mod-netgroup:
   :rpm_name: pdsh-mod-netgroup-2.29-1el7.x86_64.rpm
-  :source: https://dl.bintray.com/simp/5.1.X-Ext/pdsh-mod-netgroup-2.29-1el7.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-mod-netgroup-2.29-1el7.x86_64.rpm
 pdsh-rcmd-exec:
   :rpm_name: pdsh-rcmd-exec-2.29-1el7.x86_64.rpm
-  :source: https://dl.bintray.com/simp/5.1.X-Ext/pdsh-rcmd-exec-2.29-1el7.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-rcmd-exec-2.29-1el7.x86_64.rpm
 pdsh-rcmd-ssh:
   :rpm_name: pdsh-rcmd-ssh-2.29-1el7.x86_64.rpm
-  :source: https://dl.bintray.com/simp/5.1.X-Ext/pdsh-rcmd-ssh-2.29-1el7.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-rcmd-ssh-2.29-1el7.x86_64.rpm
 postgresql94:
   :rpm_name: postgresql94-9.4.11-2PGDG.rhel7.x86_64.rpm
   :source: https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-7-x86_64/postgresql94-9.4.11-2PGDG.rhel7.x86_64.rpm
@@ -112,7 +112,7 @@ postgresql94-server:
   :source: https://download.postgresql.org/pub/repos/yum/9.4/redhat/rhel-7-x86_64/postgresql94-server-9.4.11-2PGDG.rhel7.x86_64.rpm
 pssh:
   :rpm_name: pssh-2.3.1.SIMP-5.el7.noarch.rpm
-  :source: https://dl.bintray.com/simp/5.1.X-Ext/pssh-2.3.1.SIMP-5.el7.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pssh-2.3.1.SIMP-5.el7.noarch.rpm
 puppet-agent:
   :rpm_name: puppet-agent-1.8.3-1.el7.x86_64.rpm
   :source: http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-agent-1.8.3-1.el7.x86_64.rpm
@@ -133,7 +133,7 @@ puppetserver:
   :source: http://yum.puppetlabs.com/el/7/PC1/x86_64/puppetserver-2.7.2-1.el7.noarch.rpm
 python-elasticsearch:
   :rpm_name: python-elasticsearch-1.2.0-0.el7.centos.noarch.rpm
-  :source: https://dl.bintray.com/simp/5.1.X-Ext/python-elasticsearch-1.2.0-0.el7.centos.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/python-elasticsearch-1.2.0-0.el7.centos.noarch.rpm
 python-linecache2:
   :rpm_name: python-linecache2-1.0.0-1.el7.noarch.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/p/python-linecache2-1.0.0-1.el7.noarch.rpm
@@ -145,7 +145,7 @@ python-simplejson:
   :source: http://lug.mtu.edu/epel/7/x86_64/p/python-simplejson-3.3.3-1.el7.x86_64.rpm
 python-traceback2:
   :rpm_name: python-traceback2-1.4.0-2.el7.noarch.rpm
-  :source: https://dl.bintray.com/simp/5.1.X/python-traceback2-1.4.0-2.el7.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/python-traceback2-1.4.0-2.el7.noarch.rpm
 python-unittest2:
   :rpm_name: python-unittest2-1.1.0-4.el7.noarch.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/p/python-unittest2-1.1.0-4.el7.noarch.rpm
@@ -157,7 +157,7 @@ ruby-augeas:
   :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/ruby-augeas-0.4.1-3.el7.x86_64.rpm
 ruby-ldap:
   :rpm_name: ruby-ldap-0.9.16-1.el7.x86_64.rpm
-  :source: https://dl.bintray.com/simp/5.1.X/ruby-ldap-0.9.16-1.el7.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/ruby-ldap-0.9.16-1.el7.x86_64.rpm
 ruby-rgen:
   :rpm_name: ruby-rgen-0.6.5-2.el7.noarch.rpm
   :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/ruby-rgen-0.6.5-2.el7.noarch.rpm
@@ -186,8 +186,8 @@ rubygem-puppet-lint:
   :rpm_name: rubygem-puppet-lint-1.1.0-1.el7.noarch.rpm
   :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-puppet-lint-1.1.0-1.el7.noarch.rpm
 rubygem-rake:
-  :rpm_name: rubygem-rake-0.9.6-29.el7.noarch.rpm
-  :source: http://mirrors.advancedhosters.com/centos/7.3.1611/os/x86_64/Packages/rubygem-rake-0.9.6-29.el7.noarch.rpm
+  :rpm_name: rubygem-rake-0.9.6-25.el7_1.noarch.rpm
+  :source: ftp://ftp.icm.edu.pl/vol/rzm6/linux-slc/centos/7.2.1511/os/x86_64/Packages/rubygem-rake-0.9.6-25.el7_1.noarch.rpm
 rubygem-rake-compiler:
   :rpm_name: rubygem-rake-compiler-0.9.3-1.el7.noarch.rpm
   :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-rake-compiler-0.9.3-1.el7.noarch.rpm
@@ -199,13 +199,13 @@ rubygem-stomp-doc:
   :source: http://lug.mtu.edu/epel/7/x86_64/r/rubygem-stomp-doc-1.3.5-1.el7.noarch.rpm
 simp-lastbind:
   :rpm_name: simp-lastbind-2.4.23-0.x86_64.rpm
-  :source: https://dl.bintray.com/simp/5.1.X-Ext/simp-lastbind-2.4.23-0.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/simp-lastbind-2.4.23-0.x86_64.rpm
 simp-ppolicy-check-password:
   :rpm_name: simp-ppolicy-check-password-2.4.39-0el7.x86_64.rpm
-  :source: https://dl.bintray.com/simp/5.1.X-Ext/simp-ppolicy-check-password-2.4.39-0el7.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/simp-ppolicy-check-password-2.4.39-0el7.x86_64.rpm
 sudosh2:
   :rpm_name: sudosh2-1.0.2-2el7.x86_64.rpm
-  :source: https://dl.bintray.com/simp/5.1.X-Ext/sudosh2-1.0.2-2el7.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/sudosh2-1.0.2-2el7.x86_64.rpm
 syslinux-tftpboot:
   :rpm_name: syslinux-tftpboot-4.05-13.el7.x86_64.rpm
   :source: http://mirror.steadfast.net/centos/7.3.1611/os/x86_64/Packages/syslinux-tftpboot-4.05-13.el7.x86_64.rpm

--- a/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
@@ -187,7 +187,7 @@ rubygem-puppet-lint:
   :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-puppet-lint-1.1.0-1.el7.noarch.rpm
 rubygem-rake:
   :rpm_name: rubygem-rake-0.9.6-25.el7_1.noarch.rpm
-  :source: ftp://ftp.icm.edu.pl/vol/rzm6/linux-slc/centos/7.2.1511/os/x86_64/Packages/rubygem-rake-0.9.6-25.el7_1.noarch.rpm
+  :source: http://mirrors.advancedhosters.com/centos/7.3.1611/os/x86_64/Packages/rubygem-rake-0.9.6-29.el7.noarch.rpm
 rubygem-rake-compiler:
   :rpm_name: rubygem-rake-compiler-0.9.3-1.el7.noarch.rpm
   :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-rake-compiler-0.9.3-1.el7.noarch.rpm

--- a/build/distributions/CentOS/7/x86_64/yum_data/repos/simp.repo
+++ b/build/distributions/CentOS/7/x86_64/yum_data/repos/simp.repo
@@ -1,25 +1,27 @@
-[simp-project_5_X]
-name=simp-project_5_X
-baseurl=https://packagecloud.io/simp-project/5_X/el/7/$basearch
+[simp-project_6_X]
+name=simp-project_6_X
+baseurl=https://packagecloud.io/simp-project/6_X/el/7/$basearch
 gpgcheck=1
 enabled=1
 gpgkey=https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
 
-[simp-project_5_X_dependencies]
-name=simp-project_5_1_X_dependencies
-baseurl=https://packagecloud.io/simp-project/5_X_Dependencies/el/7/$basearch
+[simp-project_6_X_dependencies]
+name=simp-project_6_X_dependencies
+baseurl=https://packagecloud.io/simp-project/6_X_Dependencies/el/7/$basearch
 gpgcheck=1
 enabled=1
 gpgkey=https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
        https://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs
+       https://yum.puppetlabs.com/RPM-GPG-KEY-puppet
+       https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-94
        https://getfedora.org/static/352C64E5.txt
 
 [simp-legacy]
 name=simp-base
 baseurl=https://dl.bintray.com/simp/5.1.X
-enabled=1
+enabled=0
 
 [simp-ext-legacy]
 name=simp-ext
 baseurl=https://dl.bintray.com/simp/5.1.X-Ext
-enabled=1
+enabled=0


### PR DESCRIPTION
  -in Centos 7.3 the version of libarchive was updated so the version of
   libarchive-devel that is downloaded by packages.yaml needed to be updated to
   match
  -changed bintray downloads to packages  and disable bintray it in the repos

SIMP-3436 #close