### PR TITLE
(SIMP-3162) Move to puppet 4.10 and update diskdetect.sh and snmp

### DIFF
--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -165,6 +165,10 @@ mod 'puppetlabs-stdlib',
   :git => 'https://github.com/simp/puppetlabs-stdlib',
   :tag => '4.19.0'
 
+mod 'razorsedge-snmp',
+  :git => 'https://github.com/simp/puppet-snmp',
+  :tag => '3.8.1'
+
 mod 'richardc-datacat',
   :git => 'https://github.com/simp/puppet-datacat',
   :ref => 'master'
@@ -386,6 +390,10 @@ mod 'simp-simp_nfs',
 
 mod 'simp-simp_rsyslog',
   :git => 'https://github.com/simp/pupmod-simp-simp_rsyslog',
+  :ref => 'master'
+
+mod 'simp-simp_snmpd',
+  :git => 'https://github.com/simp/pupmod-simp-simp_snmpd',
   :ref => 'master'
 
 mod 'simp-simplib',

--- a/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
@@ -12,23 +12,23 @@ chkrootkit:
   :rpm_name: chkrootkit-0.49-9.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/chkrootkit-0.49-9.el6.x86_64.rpm
 clamav:
-  :rpm_name: clamav-0.99.2-1.el6.x86_64.rpm
-  :source: http://mirrors.lug.mtu.edu/epel/6/x86_64/clamav-0.99.2-1.el6.x86_64.rpm
+  :rpm_name: clamav-0.99.2-2.el6.x86_64.rpm
+  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/clamav-0.99.2-2.el6.x86_64.rpm
 clamav-db:
-  :rpm_name: clamav-db-0.99.2-1.el6.x86_64.rpm
-  :source: http://mirrors.lug.mtu.edu/epel/6/x86_64/clamav-db-0.99.2-1.el6.x86_64.rpm
+  :rpm_name: clamav-db-0.99.2-2.el6.x86_64.rpm
+  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/clamav-db-0.99.2-2.el6.x86_64.rpm
 clamav-devel:
-  :rpm_name: clamav-devel-0.99.2-1.el6.x86_64.rpm
-  :source: http://mirrors.lug.mtu.edu/epel/6/x86_64/clamav-devel-0.99.2-1.el6.x86_64.rpm
+  :rpm_name: clamav-devel-0.99.2-2.el6.x86_64.rpm
+  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/clamav-devel-0.99.2-2.el6.x86_64.rpm
 clamav-milter:
-  :rpm_name: clamav-milter-0.99.2-1.el6.x86_64.rpm
-  :source: http://mirrors.lug.mtu.edu/epel/6/x86_64/clamav-milter-0.99.2-1.el6.x86_64.rpm
+  :rpm_name: clamav-milter-0.99.2-2.el6.x86_64.rpm
+  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/clamav-milter-0.99.2-2.el6.x86_64.rpm
 clamav-unofficial-sigs:
   :rpm_name: clamav-unofficial-sigs-3.7.1-7.el6.noarch.rpm
   :source: http://mirrors.lug.mtu.edu/epel/6/x86_64/clamav-unofficial-sigs-3.7.1-7.el6.noarch.rpm
 clamd:
-  :rpm_name: clamd-0.99.2-1.el6.x86_64.rpm
-  :source: http://mirrors.lug.mtu.edu/epel/6/x86_64/clamd-0.99.2-1.el6.x86_64.rpm
+  :rpm_name: clamd-0.99.2-2.el6.x86_64.rpm
+  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/clamd-0.99.2-2.el6.x86_64.rpm
 clamsmtp:
   :rpm_name: clamsmtp-1.10-7.el6.x86_64.rpm
   :source: http://mirrors.lug.mtu.edu/epel/6/x86_64/clamsmtp-1.10-7.el6.x86_64.rpm
@@ -36,8 +36,8 @@ elasticsearch:
   :rpm_name: elasticsearch-5.5.2.rpm
   :source: https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.2.rpm
 elasticsearch-curator:
-  :rpm_name: elasticsearch-curator-5.0.2-1.el6.noarch.rpm
-  :source: https://packages.elastic.co/curator/5/centos/6/Packages/elasticsearch-curator-5.0.2-1.x86_64.rpm
+  :rpm_name: elasticsearch-curator-5.0.2-1.x86_64.rpm
+  :source: http://packages.elastic.co/curator/5/centos/6/Packages/elasticsearch-curator-5.0.2-1.x86_64.rpm
 fping:
   :rpm_name: fping-2.4b2-10.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/fping-2.4b2-10.el6.x86_64.rpm
@@ -87,8 +87,8 @@ globus-gss-assist:
   :rpm_name: globus-gss-assist-10.21-1.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-gss-assist-10.21-1.el6.x86_64.rpm
 globus-gssapi-gsi:
-  :rpm_name: globus-gssapi-gsi-12.13-3.el6.x86_64.rpm
-  :source: https://epel.mirror.constant.com/epel/6/x86_64/globus-gssapi-gsi-12.13-3.el6.x86_64.rpm
+  :rpm_name: globus-gssapi-gsi-12.17-3.el6.x86_64.rpm
+  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-gssapi-gsi-12.17-3.el6.x86_64.rpm
 globus-openssl-module:
   :rpm_name: globus-openssl-module-4.8-1.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/globus-openssl-module-4.8-1.el6.x86_64.rpm
@@ -219,17 +219,17 @@ pssh:
   :rpm_name: pssh-2.3.1-5.el6.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pssh-2.3.1-5.el6.noarch.rpm
 puppet-agent:
-  :rpm_name: puppet-agent-1.8.3-1.el6.x86_64.rpm
-  :source: http://yum.puppetlabs.com/el/6/PC1/x86_64/puppet-agent-1.8.3-1.el6.x86_64.rpm
+  :rpm_name: puppet-agent-1.10.6-1.el6.x86_64.rpm
+  :source: http://yum.puppetlabs.com/el/6/PC1/x86_64/puppet-agent-1.10.6-1.el6.x86_64.rpm
 puppet-client-tools:
-  :rpm_name: puppet-client-tools-1.1.0-1.el6.x86_64.rpm
-  :source: http://yum.puppetlabs.com/el/6/PC1/x86_64/puppet-client-tools-1.1.0-1.el6.x86_64.rpm
+  :rpm_name: puppet-client-tools-1.2.1-1.el6.x86_64.rpm
+  :source: http://yum.puppetlabs.com/el/6/PC1/x86_64/puppet-client-tools-1.2.1-1.el6.x86_64.rpm
 puppetdb:
-  :rpm_name: puppetdb-4.3.0-1.el6.noarch.rpm
-  :source: https://yum.puppetlabs.com/el/6Server/PC1/x86_64/puppetdb-4.3.0-1.el6.noarch.rpm
+  :rpm_name: puppetdb-4.4.0-1.el6.noarch.rpm
+  :source: https://yum.puppetlabs.com/el/6Server/PC1/x86_64/puppetdb-4.4.0-1.el6.noarch.rpm
 puppetdb-termini:
-  :rpm_name: puppetdb-termini-4.3.0-1.el6.noarch.rpm
-  :source: http://yum.puppetlabs.com/el/6/PC1/x86_64/puppetdb-termini-4.3.0-1.el6.noarch.rpm
+  :rpm_name: puppetdb-termini-4.4.0-1.el6.noarch.rpm
+  :source: http://yum.puppetlabs.com/el/6/PC1/x86_64/puppetdb-termini-4.4.0-1.el6.noarch.rpm
 puppetlabs-release-pc1:
   :rpm_name: puppetlabs-release-pc1-1.1.0-4.el6.noarch.rpm
   :source: http://yum.puppetlabs.com/el/6/PC1/x86_64/puppetlabs-release-pc1-1.1.0-4.el6.noarch.rpm
@@ -258,8 +258,8 @@ radiusclient-ng:
   :rpm_name: radiusclient-ng-0.5.6-5.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/radiusclient-ng-0.5.6-5.el6.x86_64.rpm
 razor-server:
-  :rpm_name: razor-server-1.5.0-1.el6.noarch.rpm
-  :source: https://yum.puppetlabs.com/el/6Server/PC1/x86_64/razor-server-1.5.0-1.el6.noarch.rpm
+  :rpm_name: razor-server-1.6.1-1.el6.noarch.rpm
+  :source: https://yum.puppetlabs.com/el/6Server/PC1/x86_64/razor-server-1.6.1-1.el6.noarch.rpm
 rlwrap:
   :rpm_name: rlwrap-0.37-3.el6.x86_64.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rlwrap-0.37-3.el6.x86_64.rpm
@@ -280,7 +280,7 @@ rubygem-net-ping:
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-net-ping-1.6.2-1.el6.noarch.rpm
 rubygem-rake-compiler:
   :rpm_name: rubygem-rake-compiler-0.9.3-2.el6.noarch.rpm
-  :source: http://fedora-epel.mirror.lstn.net/6/x86_64/rubygem-rake-compiler-0.9.3-2.el6.noarch.rpm
+  :source: http://http://yum.puppetlabs.com/el/6/dependencies/x86_64/rubygem-rake-compiler-0.9.3-2.el6.noarch.rpm
 rubygem-stomp:
   :rpm_name: rubygem-stomp-1.3.2-1.el6.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-stomp-1.3.2-1.el6.noarch.rpm

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/diskdetect.sh
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/diskdetect.sh
@@ -86,11 +86,11 @@ if [ "$simp_opt" != "prompt" ]; then
   cat << EOF >> /tmp/part-include
 volgroup VolGroup00 pv.01
 logvol swap --fstype=swap --name=SwapVol --vgname=VolGroup00 --size=1024
-logvol / --fstype=xfs --name=RootVol --vgname=VolGroup00 --size=10240 --fsoptions=iversion
-logvol /tmp --fstype=xfs --name=TmpVol --vgname=VolGroup00 --size=2048 --fsoptions=nosuid,noexec,nodev
-logvol /home --fstype=xfs --name=HomeVol --vgname=VolGroup00 --size=1024 --fsoptions=nosuid,noexec,nodev,iversion
+logvol / --fstype=ext4 --name=RootVol --vgname=VolGroup00 --size=10240 --fsoptions=iversion
+logvol /tmp --fstype=ext4 --name=TmpVol --vgname=VolGroup00 --size=2048 --fsoptions=nosuid,noexec,nodev
+logvol /home --fstype=ext4 --name=HomeVol --vgname=VolGroup00 --size=1024 --fsoptions=nosuid,noexec,nodev,iversion
 logvol /var --fstype=ext4 --name=VarVol --vgname=VolGroup00 --size=1024 --grow
-logvol /var/log --fstype=xfs --name=VarLogVol --vgname=VolGroup00 --size=4096 --fsoptions=nosuid,noexec,nodev
-logvol /var/log/audit --fstype=xfs --name=VarLogAuditVol --vgname=VolGroup00 --size=1024 --fsoptions=nosuid,noexec,nodev
+logvol /var/log --fstype=ext4 --name=VarLogVol --vgname=VolGroup00 --size=4096 --fsoptions=nosuid,noexec,nodev
+logvol /var/log/audit --fstype=ext4 --name=VarLogAuditVol --vgname=VolGroup00 --size=1024 --fsoptions=nosuid,noexec,nodev
 EOF
 fi

--- a/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
@@ -117,17 +117,17 @@ pssh:
   :rpm_name: pssh-2.3.1.SIMP-5.el7.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pssh-2.3.1.SIMP-5.el7.noarch.rpm
 puppet-agent:
-  :rpm_name: puppet-agent-1.8.3-1.el7.x86_64.rpm
-  :source: http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-agent-1.8.3-1.el7.x86_64.rpm
+  :rpm_name: puppet-agent-1.10.6-1.el7.x86_64.rpm
+  :source: http://yum.puppetlabs.com/el/7/PC1/x86_64/puppet-agent-1.10.6-1.el7.x86_64.rpm
 puppet-client-tools:
-  :rpm_name: puppet-client-tools-1.1.1-1.el7.x86_64.rpm
-  :source: http://yum.puppetlabs.com/el/7Server/PC1/x86_64/puppet-client-tools-1.1.1-1.el7.x86_64.rpm
+  :rpm_name: puppet-client-tools-1.2.1-1.el7.x86_64.rpm
+  :source: http://yum.puppetlabs.com/el/7Server/PC1/x86_64/puppet-client-tools-1.2.1-1.el7.x86_64.rpm
 puppetdb:
-  :rpm_name: puppetdb-4.3.0-1.el7.noarch.rpm
-  :source: http://yum.puppetlabs.com/el/7/PC1/x86_64/puppetdb-4.3.0-1.el7.noarch.rpm
+  :rpm_name: puppetdb-4.4.0-1.el7.noarch.rpm
+  :source: http://yum.puppetlabs.com/el/7/PC1/x86_64/puppetdb-4.4.0-1.el7.noarch.rpm
 puppetdb-termini:
-  :rpm_name: puppetdb-termini-4.3.0-1.el7.noarch.rpm
-  :source: http://yum.puppetlabs.com/el/7/PC1/x86_64/puppetdb-termini-4.3.0-1.el7.noarch.rpm
+  :rpm_name: puppetdb-termini-4.4.0-1.el7.noarch.rpm
+  :source: http://yum.puppetlabs.com/el/7/PC1/x86_64/puppetdb-termini-4.4.0-1.el7.noarch.rpm
 puppetlabs-release-pc1:
   :rpm_name: puppetlabs-release-pc1-1.1.0-5.el7.noarch.rpm
   :source: http://yum.puppetlabs.com/el/7/PC1/x86_64/puppetlabs-release-pc1-1.1.0-5.el7.noarch.rpm
@@ -153,8 +153,8 @@ python-unittest2:
   :rpm_name: python-unittest2-1.1.0-4.el7.noarch.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/p/python-unittest2-1.1.0-4.el7.noarch.rpm
 razor-server:
-  :rpm_name: razor-server-1.5.0-1.el7.noarch.rpm
-  :source: https://yum.puppetlabs.com/el/7/PC1/x86_64/razor-server-1.5.0-1.el7.noarch.rpm
+  :rpm_name: razor-server-1.6.1-1.el7.noarch.rpm
+  :source: https://yum.puppetlabs.com/el/7/PC1/x86_64/razor-server-1.6.1-1.el7.noarch.rpm
 ruby-augeas:
   :rpm_name: ruby-augeas-0.4.1-3.el7.x86_64.rpm
   :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/ruby-augeas-0.4.1-3.el7.x86_64.rpm

--- a/src/build/simp.spec
+++ b/src/build/simp.spec
@@ -202,6 +202,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Thu Aug 31 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.1.0
+- updated packages.yaml to pull puppet 4.10.6 rpms.
+
 * Wed Aug 23 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.0-0
 - 6.1.0-RC1 prep
 

--- a/src/build/simp.spec
+++ b/src/build/simp.spec
@@ -20,7 +20,7 @@ Requires: pupmod-herculesteam-augeasproviders >= 2.1.3, pupmod-herculesteam-auge
 Requires: pupmod-herculesteam-augeasproviders_apache >= 2.0.1, pupmod-herculesteam-augeasproviders_apache < 3.0.0
 Requires: pupmod-herculesteam-augeasproviders_base >= 2.0.1, pupmod-herculesteam-augeasproviders_base < 3.0.0
 Requires: pupmod-herculesteam-augeasproviders_core >= 2.1.1, pupmod-herculesteam-augeasproviders_core < 3.0.0
-Requires: pupmod-herculesteam-augeasproviders_grub >= 2.3.1, pupmod-herculesteam-augeasproviders_grub < 3.0.0
+Requires: pupmod-herculesteam-augeasproviders_grub >= 2.3.1, pupmod-herculesteam-augeasproviders_grub < 4.0.0
 Requires: pupmod-herculesteam-augeasproviders_postgresql >= 2.0.3, pupmod-herculesteam-augeasproviders_postgresql < 3.0.0
 Requires: pupmod-herculesteam-augeasproviders_puppet >= 2.1.0, pupmod-herculesteam-augeasproviders_puppet < 3.0.0
 Requires: pupmod-herculesteam-augeasproviders_shellvar >= 2.1.1, pupmod-herculesteam-augeasproviders_shellvar < 3.0.0
@@ -112,18 +112,20 @@ Prefix: %{_sysconfdir}/puppet
 %package extras
 Summary: Extra Packages for SIMP
 License: Apache-2.0
-Requires: pupmod-puppet-grafana >= 3.0.0
+Requires: pupmod-cristifalcas-journald >= 0.5.0
 Requires: pupmod-elastic-elasticsearch >= 5.2.0
 Requires: pupmod-elastic-logstash >= 5.2.1
 Requires: pupmod-electrical-file_concat >= 1.0.1
 Requires: pupmod-herculesteam-augeasproviders_mounttab >= 2.0.1
 Requires: pupmod-herculesteam-augeasproviders_nagios >= 2.0.1
 Requires: pupmod-herculesteam-augeasproviders_pam >= 2.0.3
+Requires: pupmod-puppet-grafana >= 3.0.0
+Requires: pupmod-puppet-yum >= 2.0.0
 Requires: pupmod-puppetlabs-mysql >= 2.2.3
+Requires: pupmod-razorsedge-snmp >= 3.8.1
 Requires: pupmod-simp-gdm >= 6.0.0
 Requires: pupmod-simp-gnome >= 6.0.0
 Requires: pupmod-simp-jenkins >= 6.0.0
-Requires: pupmod-cristifalcas-journald >= 0.5.0
 Requires: pupmod-simp-libreswan >= 3.0.0
 Requires: pupmod-simp-libvirt >= 5.0.1
 Requires: pupmod-simp-mcafee >= 6.0.0
@@ -132,6 +134,8 @@ Requires: pupmod-simp-openscap >= 6.0.0
 Requires: pupmod-simp-simp_elasticsearch >= 4.0.0
 Requires: pupmod-simp-simp_grafana >= 1.0.1
 Requires: pupmod-simp-simp_logstash >= 3.0.1
+Requires: pupmod-simp-simp_nfs >= 0.0.3
+Requires: pupmod-simp-simp_snmpd >= 0.0.1
 Requires: pupmod-simp-vnc >= 6.0.0
 Requires: pupmod-simp-vsftpd >= 7.0.0
 
@@ -204,6 +208,8 @@ fi
 %changelog
 * Thu Aug 31 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.1.0
 - updated packages.yaml to pull puppet 4.10.6 rpms.
+- change diskdetect.sh kickstart file to use ext4 instead of xfs
+- add simp_snmp, simp_nfs and update augeasproviders_grub
 
 * Wed Aug 23 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.0-0
 - 6.1.0-RC1 prep


### PR DESCRIPTION
- updated the packages.yaml files in CentOS 6 and 7  to download the 4.10.6 RPMs
- change file system used in kickstart files  to ext4 from xfs
   on Centos 7 because of intermittent problems kickstarting
- added puppet-snmp and simp_snmpd to the spec and tracking
        files
- add voxpupuli-yum module to simp.spec because it was missing
- added simp_nfs profile module to simp.spec because it was missing
- updated augeasproviders_grub version to bounds to be < 4.0
         
SIMP-3723  #close
SIMP-3724  #close
SIMP-3669  #close
SIMP-3706  #close
SIMP-3162  #close
SIMP-3715  #close
SIMP-3714  #close
   
