### PR TITLE
(SIMP-3801) core: Update to plabs/apache 2.1.0

### DIFF
--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -123,7 +123,7 @@ mod 'onyxpoint-gpasswd',
 
 mod 'puppetlabs-apache',
   :git => 'https://github.com/simp/puppetlabs-apache',
-  :tag => '2.0.0'
+  :tag => '2.1.0'
 
 mod 'puppetlabs-concat',
   :git => 'https://github.com/simp/puppetlabs-concat',


### PR DESCRIPTION
The update to this module contains a fix for CVE-2017-2299, as well as
other improvements which can be found in the module's changelog.

SIMP-3801 #close