### PR TITLE
(SIMP-3823) Updated augeasproviders_*

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,7 +234,7 @@ GEM
     fog-voxel (0.1.0)
       fog-core
       fog-xml
-    fog-vsphere (1.13.0)
+    fog-vsphere (1.13.1)
       fog-core
       rbvmomi (~> 1.9)
     fog-xenserver (0.3.0)
@@ -321,7 +321,7 @@ GEM
     os (0.9.6)
     pager (1.0.1)
     parallel (1.12.0)
-    parallel_tests (2.16.0)
+    parallel_tests (2.16.1)
       parallel
     pry (0.11.1)
       coderay (~> 1.1.0)
@@ -422,7 +422,7 @@ GEM
       faraday (~> 0.9)
       jwt (~> 1.5)
       multi_json (~> 1.10)
-    simp-beaker-helpers (1.8.6)
+    simp-beaker-helpers (1.8.7)
       beaker (~> 3.14)
       beaker-puppet_install_helper (~> 0.6)
     simp-build-helpers (0.1.1)

--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -73,122 +73,40 @@ mod 'electrical-file_concat',
   :tag => 'simp-1.0.1'
 
 mod 'herculesteam-augeasproviders_apache',
-  #FIXME Next herculesteam release.
-  # This is a bit messy.  This project has 3 tags that are
-  # all version 2.0.1, but slightly different:
-  #   '2.0.1 from the owner
-  #   'simp-2.0.1' from SIMP team for SIMP4/SIMP5
-  #   'simp6.0.0-2.0.1' from SIMP team for SIMP6
-  # We are going to use the last SIMP team release, until
-  # augeasproviders_apache gets updated and we can get out
-  # of this mess.
   :git => 'https://github.com/simp/augeasproviders_apache',
-  :tag => 'simp6.0.0-2.0.1'
-
-mod 'herculesteam-augeasproviders_base',
-  #FIXME Next herculesteam release.
-  # This is a bit messy.  This project has 3 tags that are
-  # all version 2.0.1, but slightly different:
-  #   '2.0.1 from the owner
-  #   'simp-2.0.1' from SIMP team for SIMP4/SIMP5
-  #   'simp6.0.0-2.0.1' from SIMP team for SIMP6
-  # We are going to use the last SIMP team release, until
-  # augeasproviders_base gets updated and we can get out
-  # of this mess.
-  :git => 'https://github.com/simp/augeasproviders_base',
-  :tag => 'simp6.0.0-2.0.1'
+  :tag => '2.0.2'
 
 mod 'herculesteam-augeasproviders_core',
-  #FIXME Next herculesteam release.
-  # This is a bit messy.  This project has 2 tags that are
-  # both version 2.1.3, but slightly different:
-  #   '2.1.3 from the owner
-  #   'simp6.0.0-2.1.3' from SIMP team for SIMP6
-  # We are going to use the last SIMP team release, until
-  # augeasproviders_core gets updated and we can get out
-  # of this mess.
   :git => 'https://github.com/simp/augeasproviders_core',
-  :tag => 'simp6.0.0-2.1.3'
+  :tag => '2.1.4'
 
 mod 'herculesteam-augeasproviders_grub',
   :git => 'https://github.com/simp/augeasproviders_grub',
   :tag => '3.0.0'
 
 mod 'herculesteam-augeasproviders_mounttab',
-  #FIXME Next herculesteam release.
-  # This is a bit messy.  This project has 3 tags that are
-  # all version 2.0.1, but slightly different:
-  #   '2.0.1 from the owner
-  #   'simp-2.0.1' from SIMP team for SIMP4/SIMP5
-  #   'simp6.0.0-2.0.1' from SIMP team for SIMP6
-  # We are going to use the last SIMP team release, until
-  # augeasproviders_mounttab gets updated and we can get out
-  # of this mess.
   :git => 'https://github.com/simp/augeasproviders_mounttab',
-  :tag => 'simp6.0.0-2.0.1'
+  :tag => '2.0.2'
 
 mod 'herculesteam-augeasproviders_nagios',
-  #FIXME Next herculesteam release.
-  # This is a bit messy.  This project has 3 tags that are
-  # all version 2.0.1, but slightly different:
-  #   '2.0.1 from the owner
-  #   'simp-2.0.1' from SIMP team for SIMP4/SIMP5
-  #   'simp6.0.0-2.0.1' from SIMP team for SIMP6
-  # We are going to use the last SIMP team release, until
-  # augeasproviders_nagios gets updated and we can get out
-  # of this mess.
   :git => 'https://github.com/simp/augeasproviders_nagios',
-  :tag => 'simp6.0.0-2.0.1'
+  :tag => '2.0.2'
 
 mod 'herculesteam-augeasproviders_pam',
-  #FIXME Next herculesteam release.
-  # This is a bit messy.  This project has 2 tags that are
-  # both version 2.1.0, but slightly different:
-  #   '2.1.0 from the owner
-  #   'simp6.0.0-2.1.0' from SIMP team for SIMP6
-  # We are going to use the last SIMP team release, until
-  # augeasproviders_pam gets updated and we can get out
-  # of this mess.
   :git => 'https://github.com/simp/augeasproviders_pam',
-  :tag => 'simp6.0.0-2.1.0'
+  :tag => '2.1.1'
 
 mod 'herculesteam-augeasproviders_postgresql',
-  #FIXME Next herculesteam release.
-  # This is a bit messy.  This project has 3 tags that are
-  # all version 2.0.3, but slightly different:
-  #   '2.0.3 from the owner
-  #   'simp-2.0.3' from SIMP team for SIMP4/SIMP5
-  #   'simp6.0.0-2.0.3' from SIMP team for SIMP6
-  # We are going to use the last SIMP team release, until
-  # augeasproviders_postgresql gets updated and we can get out
-  # of this mess.
   :git => 'https://github.com/simp/augeasproviders_postgresql',
-  :tag => 'simp6.0.0-2.0.3'
+  :tag => '2.0.4'
 
 mod 'herculesteam-augeasproviders_puppet',
-  #FIXME Next herculesteam release.
-  # This is a bit messy.  This project has 2 tags that are
-  # both version 2.1.0, but slightly different:
-  #   '2.1.0 from the owner
-  #   'simp-2.1.0' from SIMP team for SIMP6
-  # We are going to use the last SIMP team release, until
-  # augeasproviders_pam gets updated and we can get out
-  # of this mess.
   :git => 'https://github.com/simp/augeasproviders_puppet',
-  :tag => 'simp-2.1.0'
+  :tag => '2.1.1'
 
 mod 'herculesteam-augeasproviders_shellvar',
-  #FIXME Next herculesteam release.
-  # This is a bit messy.  This project has 3 tags that are
-  # all version 2.2.1, but slightly different:
-  #   '2.2.1 from the owner
-  #   'simp-2.2.1' from SIMP team for SIMP4/SIMP5
-  #   'simp6.0.0-2.2.1' from SIMP team for SIMP6
-  # We are going to use the last SIMP team release, until
-  # augeasproviders_postgresql gets updated and we can get out
-  # of this mess.
   :git => 'https://github.com/simp/augeasproviders_shellvar',
-  :tag => 'simp6.0.0-2.2.1'
+  :tag => '2.2.2'
 
 mod 'herculesteam-augeasproviders_ssh',
   :git => 'https://github.com/simp/augeasproviders_ssh',

--- a/src/assets/simp/build/simp.spec
+++ b/src/assets/simp/build/simp.spec
@@ -16,7 +16,6 @@ Obsoletes: simp-hiera < 3.0.2
 # Core SIMP Requirements
 Requires: pupmod-camptocamp-kmod >= 2.1.0, pupmod-camptocamp-kmod < 3.0.0
 Requires: pupmod-herculesteam-augeasproviders_apache >= 2.0.1-2016, pupmod-herculesteam-augeasproviders_apache < 3.0.0
-Requires: pupmod-herculesteam-augeasproviders_base >= 2.0.1-2016, pupmod-herculesteam-augeasproviders_base < 3.0.0
 Requires: pupmod-herculesteam-augeasproviders_core >= 2.1.1-2016, pupmod-herculesteam-augeasproviders_core < 3.0.0
 Requires: pupmod-herculesteam-augeasproviders_grub >= 2.3.1-2016, pupmod-herculesteam-augeasproviders_grub < 4.0.0
 Requires: pupmod-herculesteam-augeasproviders_postgresql >= 2.0.3-2016, pupmod-herculesteam-augeasproviders_postgresql < 3.0.0
@@ -205,6 +204,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Mon Oct 02 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.0-0
+- Removed pupmod-herculesteam-augeasproviders_base as a SIMP dependency
+
 * Tue Sep 26 2017 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.1.0-0
 - update puppetserver to 2.8.0-1
 - updated packages.yaml to pull puppet 4.10.6 rpms.


### PR DESCRIPTION
Updated the Puppetfile.tracking to reference the new augeasproviders_*
repositories.

augeasproviders_base is currently broken in testing so we will need to
wait for that to be fixed and a new version released.

SIMP-3823 #comment Updated augeasproviders_*