### PR TITLE
(SIMP-3828) simp-core: Update Changelog with upgrade info

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -321,10 +321,12 @@ Other Upgrade Notices
    At the console the Puppet compilation will appear to pause at
    ``(/Stage[main]/Aide/Exec[update_aide_db])``.
 
-#. *Guidelines for upgrading and troublehooting possible issues are in the docs
-   under the ``User Guide`` section.  The docs can be found at 
-   `Read The Docs`_ on the internet or under ``/usr/share/doc``
-   when installed from ``simp-doc.noarch`` rpm on the iso.
+#. *Guidelines for upgrading and troublehooting
+  
+   The ``User Guide: Upgrading SIMP`` section of the documentation contains further
+   information and should be read before upgrading your system.
+   The docs can be found at `Read The Docs`_ on the internet or under 
+   ``/usr/share/doc`` when installed from ``simp-doc.noarch`` rpm on the iso.
 
 
 .. _FACT-1732: https://tickets.puppetlabs.com/browse/FACT-1732

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -348,7 +348,7 @@ there are a few details that warrant further discussion.
 
    In order to expose AIDE database configuration errors during a Puppet
    compilation, the database initialization is no longer handled as a
-   background process.  When the AIDE database must be initialized
+   background process.  When the AIDE database must be initialized,
    this can extend the time for a Puppet compilation by several minutes.
    At the console the Puppet compilation will appear to pause at
    ``(/Stage[main]/Aide/Exec[update_aide_db])``.

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -293,6 +293,65 @@ Known Bugs
 * The ``krb5`` module may have issues in some cases, validation pending
 * The graphical ``switch user`` functionality does not work. We are working
   with the vendor to discover a solution
+* The upgrade of the ``simp-gpgkeys-3.0.1-0.noarch`` RPM on a SIMP server
+  fails to set up the keys in ``/var/www/yum/SIMP/GPGKEYS``.   This problem
+  can be worked around by either uninstalling ``simp-gpgkeys-3.0.1-0.noarch``
+  prior to the SIMP 6.1.0 upgrade, or reinstalling the newer ``simp-gpgkeys``
+  RPM after the upgrade.
+* An upgrade of the ``pupmod-saz-timezone-3.3.0-2016.1.noarch`` RPM  to
+  the ``pupmod-simp-timezone-4.0.0-0.noarch`` RPM fails to copy the
+  installed files into ``/etc/puppetlabs/code/environments/simp/modules``,
+  when the ``simp-adapter`` is configured to execute the copy.  This
+  problem can be worked around by either uninstalling
+  ``pupmod-saz-timezone-3.3.0-2016.1.noarch`` prior to the SIMP 6.1.0
+  upgrade, or reinstalling the ``pupmod-simp-timezone-4.0.0-0.noarch`` RPM
+  after the upgrade.
+
+Other Upgrade Notices
+---------------------
+
+The upgrade from SIMP 6.0.0 to SIMP 6.1.0 is largely seamless.  However,
+there are a few details that warrant further discussion.
+
+#. *The PostgreSQL 9.4 server must be stopped prior to the post-upgrade
+   compilation:* 
+
+   SIMP 6.1.0 updates the ``puppetdb`` Puppet module to 6.0.0, which,
+   by default, requires a PostgreSQL upgrade from 9.4 to 9.6.  Although
+   the appropriate PostgreSQL RPMs will be installed via the ``puppetdb``
+   6.0.0 Puppet module, the Puppet compilation after the SIMP 6.1.0
+   upgrade will fail, because the PostgreSQL 9.6 server cannot start
+   while the PostgreSQL 9.4 server is still running.  You must manually
+   stop the PostgreSQL 9.4 server prior to compiling the SIMP 6.1.0
+   Puppet manifests.
+
+   In addition, you may want to
+
+   * Migrate the data contained in the 9.4 database.  This data is *not*
+     automatically imported into the 9.6 database by the ``puppetdb``
+     Puppet module.  See `Upgrading a PostgreSQL Cluster`_ for detailed
+     instructions.
+
+   * Prevent future conflicts between the two PostgreSQL versions by
+     performing one of the following actions:
+ 
+     * Disabling the automatic start of the PostgreSQL 9.4 server at
+       boot time.
+     * Configuring the PostgreSQL 9.4 server to use different ports
+       than the 9.6 server.
+     * Uninstalling the PostgreSQL 9.4 RPMs.
+
+     Unless you need the PostgreSQL 9.4 server for another application
+     running on the PuppetDB server, removing the 9.4 RPMs is advised.
+
+#. *Puppet compiles containing the AIDE database initialization are long*:
+
+   In order to expose AIDE database configuration errors during a Puppet
+   compilation, the database initialization is no longer handled as a
+   background process.  When the AIDE database must be initialized
+   this can extend the time for a Puppet compilation by several minutes.
+   At the console the Puppet compilation will appear to pause at
+   ``(/Stage[main]/Aide/Exec[update_aide_db])``.
 
 .. _FACT-1732: https://tickets.puppetlabs.com/browse/FACT-1732
 .. _Puppet Code Manager: https://docs.puppet.com/pe/latest/code_mgr.html
@@ -300,3 +359,4 @@ Known Bugs
 .. _Puppet Location Reference: https://docs.puppet.com/puppet/4.7/reference/whered_it_go.html
 .. _file bugs: https://simp-project.atlassian.net
 .. _r10k: https://github.com/puppetlabs/r10k
+.. _Upgrading a PostgreSQL Cluster: https://www.postgresql.org/docs/9.6/static/upgrading.html

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -307,44 +307,11 @@ Known Bugs
   ``pupmod-saz-timezone-3.3.0-2016.1.noarch`` prior to the SIMP 6.1.0
   upgrade, or reinstalling the ``pupmod-simp-timezone-4.0.0-0.noarch`` RPM
   after the upgrade.
+* Setting selinux to disabled can cause stunnel daemon fail.  Using
+  the permissive mode of selinux does not cause these issues.
 
 Other Upgrade Notices
 ---------------------
-
-The upgrade from SIMP 6.0.0 to SIMP 6.1.0 is largely seamless.  However,
-there are a few details that warrant further discussion.
-
-#. *The PostgreSQL 9.4 server must be stopped prior to the post-upgrade
-   compilation:* 
-
-   SIMP 6.1.0 updates the ``puppetdb`` Puppet module to 6.0.0, which,
-   by default, requires a PostgreSQL upgrade from 9.4 to 9.6.  Although
-   the appropriate PostgreSQL RPMs will be installed via the ``puppetdb``
-   6.0.0 Puppet module, the Puppet compilation after the SIMP 6.1.0
-   upgrade will fail, because the PostgreSQL 9.6 server cannot start
-   while the PostgreSQL 9.4 server is still running.  You must manually
-   stop the PostgreSQL 9.4 server prior to compiling the SIMP 6.1.0
-   Puppet manifests.
-
-   In addition, you may want to
-
-   * Migrate the data contained in the 9.4 database.  This data is *not*
-     automatically imported into the 9.6 database by the ``puppetdb``
-     Puppet module.  See `Upgrading a PostgreSQL Cluster`_ for detailed
-     instructions.
-
-   * Prevent future conflicts between the two PostgreSQL versions by
-     performing one of the following actions:
- 
-     * Disabling the automatic start of the PostgreSQL 9.4 server at
-       boot time.
-     * Configuring the PostgreSQL 9.4 server to use different ports
-       than the 9.6 server.
-     * Uninstalling the PostgreSQL 9.4 RPMs.
-
-     Unless you need the PostgreSQL 9.4 server for another application
-     running on the PuppetDB server, removing the 9.4 RPMs is advised.
-
 #. *Puppet compiles containing the AIDE database initialization are long*:
 
    In order to expose AIDE database configuration errors during a Puppet
@@ -353,6 +320,11 @@ there are a few details that warrant further discussion.
    this can extend the time for a Puppet compilation by several minutes.
    At the console the Puppet compilation will appear to pause at
    ``(/Stage[main]/Aide/Exec[update_aide_db])``.
+
+#. *More details on the known bugs and issues, and also troubleshooting the
+   upgrade are in the docs located at ``https://readthedocs.org/projects/simp`` on the
+   internet or under ``/usr/share/doc`` when installed from simp-doc rpm on the iso.
+
 
 .. _FACT-1732: https://tickets.puppetlabs.com/browse/FACT-1732
 .. _Puppet Code Manager: https://docs.puppet.com/pe/latest/code_mgr.html

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -65,6 +65,7 @@ we highly recommend updating your DAT files from the authoritative upstream
 sources.
 
 SNMP Support Added
+^^^^^^^^^^^^^^^^^^
 
 We have re-added SNMP support after a thorough re-assessment and update from
 our legacy ``snmp`` module. We now build upon a community module and wrap the

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -321,9 +321,10 @@ Other Upgrade Notices
    At the console the Puppet compilation will appear to pause at
    ``(/Stage[main]/Aide/Exec[update_aide_db])``.
 
-#. *More details on the known bugs and issues, and also troubleshooting the
-   upgrade are in the docs located at ``https://readthedocs.org/projects/simp`` on the
-   internet or under ``/usr/share/doc`` when installed from simp-doc rpm on the iso.
+#. *Guidelines for upgrading and troublehooting possible issues are in the docs
+   under the ``User Guide`` section.  The docs can be found at 
+   `Read The Docs`_ on the internet or under ``/usr/share/doc``
+   when installed from ``simp-doc.noarch`` rpm on the iso.
 
 
 .. _FACT-1732: https://tickets.puppetlabs.com/browse/FACT-1732
@@ -332,4 +333,5 @@ Other Upgrade Notices
 .. _Puppet Location Reference: https://docs.puppet.com/puppet/4.7/reference/whered_it_go.html
 .. _file bugs: https://simp-project.atlassian.net
 .. _r10k: https://github.com/puppetlabs/r10k
+.. _Read The Docs: https://readthedocs.org/projects/simp
 .. _Upgrading a PostgreSQL Cluster: https://www.postgresql.org/docs/9.6/static/upgrading.html

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -326,7 +326,7 @@ Other Upgrade Notices
    The ``User Guide: Upgrading SIMP`` section of the documentation contains further
    information and should be read before upgrading your system.
    The docs can be found at `Read The Docs`_ on the internet or under
-   ``/usr/share/doc`` when installed from ``simp-doc.noarch`` rpm on the iso.
+   ``/usr/share/doc`` when the ``simp-doc.noarch`` RPM is installed.
 
 
 .. _FACT-1732: https://tickets.puppetlabs.com/browse/FACT-1732

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -321,11 +321,11 @@ Other Upgrade Notices
    At the console the Puppet compilation will appear to pause at
    ``(/Stage[main]/Aide/Exec[update_aide_db])``.
 
-#. *Guidelines for upgrading and troublehooting
-  
+#. *Guidelines for upgrading and troublehooting*:
+
    The ``User Guide: Upgrading SIMP`` section of the documentation contains further
    information and should be read before upgrading your system.
-   The docs can be found at `Read The Docs`_ on the internet or under 
+   The docs can be found at `Read The Docs`_ on the internet or under
    ``/usr/share/doc`` when installed from ``simp-doc.noarch`` rpm on the iso.
 
 

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -24,8 +24,9 @@ Breaking Changes
 ----------------
 
 .. WARNING::
+
    This release of SIMP is **NOT** backwards compatible with the 4.X and 5.X
-   releases.  **Direct upgrades will not work!**
+   releases. **Direct upgrades will not work!**
 
    At this point, do not expect any of our code moving forward to work with
    Puppet 3.
@@ -35,7 +36,16 @@ If you find any issues, please `file bugs`_!
 Breaking Changes Since 6.0.0-0
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We do not expect any breaking changes to be present in 6.1.0-RC1.
+Upgrade Issues
+""""""""""""""
+
+* You **MUST** read the ``User Guide: Upgrading SIMP`` section of the
+  documentation for this upgrade. There were several RPM issues that require
+  manual intervention for a clean upgrade.
+
+  * The docs can be found at `Read The Docs`_ on the internet or under
+    ``/usr/share/doc`` when the ``simp-doc.noarch`` RPM is installed.
+
 
 Significant Updates
 -------------------
@@ -87,6 +97,17 @@ This caused quite a few of the SIMP modules to have version updates with no
 changes other than an update to the ``metadata.json`` file.
 
 In general, this was due to dropping support for Puppet 3.
+
+Long Puppet Compiles with AIDE Database Initialization
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In order to expose ``aide`` database configuration errors during a Puppet
+compilation, the database initialization is no longer handled as a background
+process.
+
+When the AIDE database must be initialized, this can extend the time for a
+Puppet compilation by **several minutes**. At the console the Puppet
+compilation will appear to pause at ``(/Stage[main]/Aide/Exec[update_aide_db])``.
 
 
 Security Announcements
@@ -310,25 +331,6 @@ Known Bugs
 * Setting selinux to disabled can cause stunnel daemon fail.  Using
   the permissive mode of selinux does not cause these issues.
 
-Other Upgrade Notices
----------------------
-#. *Puppet compiles containing the AIDE database initialization are long*:
-
-   In order to expose AIDE database configuration errors during a Puppet
-   compilation, the database initialization is no longer handled as a
-   background process.  When the AIDE database must be initialized,
-   this can extend the time for a Puppet compilation by several minutes.
-   At the console the Puppet compilation will appear to pause at
-   ``(/Stage[main]/Aide/Exec[update_aide_db])``.
-
-#. *Guidelines for upgrading and troublehooting*:
-
-   The ``User Guide: Upgrading SIMP`` section of the documentation contains further
-   information and should be read before upgrading your system.
-   The docs can be found at `Read The Docs`_ on the internet or under
-   ``/usr/share/doc`` when the ``simp-doc.noarch`` RPM is installed.
-
-
 .. _FACT-1732: https://tickets.puppetlabs.com/browse/FACT-1732
 .. _Puppet Code Manager: https://docs.puppet.com/pe/latest/code_mgr.html
 .. _Puppet Data Types: https://docs.puppet.com/puppet/latest/lang_data_type.html
@@ -336,4 +338,3 @@ Other Upgrade Notices
 .. _file bugs: https://simp-project.atlassian.net
 .. _r10k: https://github.com/puppetlabs/r10k
 .. _Read The Docs: https://readthedocs.org/projects/simp
-.. _Upgrading a PostgreSQL Cluster: https://www.postgresql.org/docs/9.6/static/upgrading.html


### PR DESCRIPTION
Update changelog:
* Note 2 SIMP RPMs that don't cleanly upgrade (bugs)
* Describe PostgreSQL upgrade nuances
* Warn user about long AIDE database initialization
  during Puppet compilation

SIMP-3823 #comment simp-core Changelog updates