### PR TITLE
(SIMP-3282) Use `#YUMSERVER#` in PXE kickstart files

### DIFF
--- a/build/distributions/CentOS/6/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -35,7 +35,7 @@ skipx
 text
 keyboard us
 lang en_US
-url --url https://#KSSERVER#/yum/#LINUXDIST#/6/x86_64 --noverifyssl
+url --url https://#YUMSERVER#/yum/#LINUXDIST#/6/x86_64 --noverifyssl
 
 %include /tmp/part-include
 

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -35,7 +35,7 @@ skipx
 text
 keyboard us
 lang en_US
-url --noverifyssl --url https://#KSSERVER#/yum/#LINUXDIST#/7/x86_64
+url --noverifyssl --url https://#YUMSERVER#/yum/#LINUXDIST#/7/x86_64
 
 %include /tmp/part-include
 


### PR DESCRIPTION
This commit fixes a bug in the kickstart files by using the string
`#YUMSERVER#` as a substitution-friendly placeholder for the source
tree location in the `url --url` option.

SIMP-3282 #close