### PR TITLE
(SIMP-3282) Fix CentOS repo edge cases & comments

### DIFF
--- a/build/distributions/CentOS/6/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -1,3 +1,4 @@
+#
 # Replace the following strings in this file
 # #BOOTPASS# - Your SHA-512 hashed bootloader password
 # #ROOTPASS# - Your SHA-512 hashed root password
@@ -6,10 +7,10 @@
 # #LINUXDIST# - The LINUX Distribution you are kickstarting
 #        - Current CASE SENSITIVE options: RedHat CentOS
 #
-# BOOTLOADER hash generation:
+# To generate the BOOTLOADER hash:
 #  > grub-crypt
 #
-# ROOTPASS hash generation:
+# To generate the ROOTPASS hash:
 #  > ruby -r 'digest/sha2' -e 'puts "password".crypt("$6$" + rand(36**8).to_s(36))'
 
 authconfig --enableshadow --passalgo=sha512
@@ -192,12 +193,13 @@ if [ $ostype == "CentOS" ]; then
 fi
 ksserver="#KSSERVER#"
 
+## Comment out/delete the following if you want to disable FIPS compliance. ##
+# FIPS
+
 # Turn off prelinking and remove all previous linking
 sed -i '/PRELINKING=yes/ c\PRELINKING=no' /etc/sysconfig/prelink
 prelink -u -a
 
-### Comment out/remove this section to disable FIPS ###
-# FIPS
 if [ -e /sys/firmware/efi ]; then
   BOOTDEV=`df /boot/efi | tail -1 | cut -f1 -d' '`
 else
@@ -216,6 +218,19 @@ fi
 
 dracut -f
 ### END FIPS ###
+
+# Notify users that bootstrap will run on firstboot
+echo "Welcome to SIMP!  If this is firstboot, SIMP bootstrap is scheduled to run.
+If this host is not autosigned by Puppet, sign your Puppet certs to begin bootstrap.
+Otherwise, it should already be running! Tail /root/puppet.bootstrap.log for details.
+Wait for completion and reboot.
+
+To remove this message, delete /root/.bootstrap_msg" > /root/.bootstrap_msg
+sed -i "2i if [ -f /root/.bootstrap_msg ]\nthen\n  cat /root/.bootstrap_msg\nfi" /root/.bashrc
+source /root/.bashrc
+
+# Enable wait-online
+systemctl enable NetworkManager-wait-online
 
 # Enable the firstboot bootstrapping script.
 wget --no-check-certificate -O /etc/init.d/runpuppet https://$ksserver/ks/runpuppet;

--- a/build/distributions/CentOS/6/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -188,9 +188,7 @@ fi
 %post
 ostype="#LINUXDIST#"
 if [ $ostype == "CentOS" ]; then
-  sed -i '/enabled=/d' /etc/yum.repos.d/CentOS-Base.repo;
-  sed -i '/\[.*\]/ a\
-enabled=0' /etc/yum.repos.d/CentOS-Base.repo;
+  sed -i -e '/enabled=/d' -e '/^\[.*\]/ aenabled=0' /etc/yum.repos.d/CentOS-Base.repo;
 fi
 ksserver="#KSSERVER#"
 

--- a/build/distributions/CentOS/6/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -229,9 +229,6 @@ To remove this message, delete /root/.bootstrap_msg" > /root/.bootstrap_msg
 sed -i "2i if [ -f /root/.bootstrap_msg ]\nthen\n  cat /root/.bootstrap_msg\nfi" /root/.bashrc
 source /root/.bashrc
 
-# Enable wait-online
-systemctl enable NetworkManager-wait-online
-
 # Enable the firstboot bootstrapping script.
 wget --no-check-certificate -O /etc/init.d/runpuppet https://$ksserver/ks/runpuppet;
 chmod 700 /etc/rc.d/init.d/runpuppet;

--- a/build/distributions/CentOS/6/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -189,7 +189,7 @@ fi
 %post
 ostype="#LINUXDIST#"
 if [ $ostype == "CentOS" ]; then
-  sed -i -e '/enabled=/d' -e '/^\[.*\]/ aenabled=0' /etc/yum.repos.d/CentOS-Base.repo;
+  sed -i -e '/enabled=/d' -e '/^\[.*\]/a enabled=0' /etc/yum.repos.d/CentOS-*.repo;
 fi
 ksserver="#KSSERVER#"
 

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -189,9 +189,7 @@ fi
 %post
 ostype="#LINUXDIST#"
 if [ $ostype == "CentOS" ]; then
-  sed -i '/enabled=/d' /etc/yum.repos.d/CentOS-Base.repo;
-  sed -i '/\[.*\]/ a\
-enabled=0' /etc/yum.repos.d/CentOS-Base.repo;
+  sed -i -e '/enabled=/d' -e '/^\[.*\]/ aenabled=0' /etc/yum.repos.d/CentOS-Base.repo;
 fi
 ksserver="#KSSERVER#"
 

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -1,17 +1,17 @@
 #
-# Use the following Ruby code to generate your rootpw hash:
-#   ruby -r 'digest/sha2' -e 'puts "password".crypt("$6$" + rand(36**8).to_s(36))'
-#
-# Use the following command to generate your grub password hash:
-#   grub2-mkpasswd-pbkdf2
-#
 # Replace the following strings in this file
-# #BOOTPASS# - Your hashed bootloader password
-# #ROOTPASS# - Your hashed root password
+# #BOOTPASS# - Your SHA-512 hashed bootloader password
+# #ROOTPASS# - Your SHA-512 hashed root password
 # #KSSERVER# - The IP address of your Kickstart server
 # #YUMSERVER# - The IP address of your YUM server
 # #LINUXDIST# - The LINUX Distribution you are kickstarting
 #        - Current CASE SENSITIVE options: RedHat CentOS
+#
+# To generate the BOOTLOADER hash:
+#  > grub-crypt
+#
+# To generate the ROOTPASS hash:
+#  > ruby -r 'digest/sha2' -e 'puts "password".crypt("$6$" + rand(36**8).to_s(36))'
 
 authconfig --enableshadow --passalgo=sha512
 # anaconda has known issues when fips is turned on during boot, so it (fips=1)  was remove from bootloader line.
@@ -193,12 +193,13 @@ if [ $ostype == "CentOS" ]; then
 fi
 ksserver="#KSSERVER#"
 
-# Turn off prelinking and remove all previous
+## Comment out/delete the following if you want to disable FIPS compliance. ##
+# FIPS
+
+# Turn off prelinking and remove all previous linking
 sed -i '/PRELINKING=yes/ c\PRELINKING=no' /etc/sysconfig/prelink
 prelink -u -a
 
-## Comment out/delete the following if you want to disable FIPS compliance. ##
-# FIPS
 if [ -e /sys/firmware/efi ]; then
   BOOTDEV=`df /boot/efi | tail -1 | cut -f1 -d' '`
 else

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -8,7 +8,7 @@
 #        - Current CASE SENSITIVE options: RedHat CentOS
 #
 # To generate the BOOTLOADER hash:
-#  > grub-crypt
+#  > grub2-mkpasswd-pbkdf2
 #
 # To generate the ROOTPASS hash:
 #  > ruby -r 'digest/sha2' -e 'puts "password".crypt("$6$" + rand(36**8).to_s(36))'

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -189,7 +189,7 @@ fi
 %post
 ostype="#LINUXDIST#"
 if [ $ostype == "CentOS" ]; then
-  sed -i -e '/enabled=/d' -e '/^\[.*\]/ aenabled=0' /etc/yum.repos.d/CentOS-Base.repo;
+  sed -i -e '/enabled=/d' -e '/^\[.*\]/a enabled=0' /etc/yum.repos.d/CentOS-*.repo;
 fi
 ksserver="#KSSERVER#"
 


### PR DESCRIPTION
This patch fixes some edge cases that missed disabling CentOS repos, and syncs the structure of the CentOS 6 & 7 kickstart template files with each other.  In both files, the prelink logic has been moved
into the FIPS comment block.

SIMP-3282 #close