### PR TITLE
(SIMP-3631) Un-pin the yum repos

### DIFF
--- a/build/distributions/CentOS/7/x86_64/yum_data/repos/epel.repo
+++ b/build/distributions/CentOS/7/x86_64/yum_data/repos/epel.repo
@@ -1,5 +1,4 @@
 [epel]
 name=epel
-#mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=x86_64&country=US
-baseurl=http://lug.mtu.edu/epel/7/x86_64/
+mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=x86_64&country=US
 failovermethod=priority


### PR DESCRIPTION
The YUM repositories should not have been moved away from the
'mirrorlist'. This was causing ISO builds to fail.

SIMP-3631 #comment un-pinned the yum repos