### PR TITLE
(SIMP-4035) Fix rpm_docker for Fedora 26+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,12 @@ end
 
 
 # mandatory gems
+
+# https://github.com/net-ssh/net-ssh/issues/478
+gem 'rbnacl'
+gem 'rbnacl-libsodium'
+gem 'bcrypt_pbkdf'
+
 gem 'bundler'
 gem 'coderay'
 gem 'dotenv'

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,8 @@ end
 # when net-ssh/vagrant will support ed25519 out of the box.
 # See: https://github.com/net-ssh/net-ssh/issues/478
 gem 'rbnacl'
-gem 'rbnacl-libsodium'
+# >1.0.15 requires ruby 2.2.6, the build depends on 2.1.9
+gem 'rbnacl-libsodium', '~> 1.0.15'
 gem 'bcrypt_pbkdf'
 
 gem 'bundler'

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,9 @@ end
 
 # mandatory gems
 
-# https://github.com/net-ssh/net-ssh/issues/478
+# The following gems are required for ed25519 support in net-ssh. It is unclear
+# when net-ssh/vagrant will support ed25519 out of the box.
+# See: https://github.com/net-ssh/net-ssh/issues/478
 gem 'rbnacl'
 gem 'rbnacl-libsodium'
 gem 'bcrypt_pbkdf'

--- a/spec/acceptance/suites/rpm_docker/nodesets/default.yml
+++ b/spec/acceptance/suites/rpm_docker/nodesets/default.yml
@@ -20,11 +20,15 @@ HOSTS:
       - 'yum install -y yum-plugin-ovl || :'
       - 'yum install -y yum-utils'
 
+      # Openssl 1.0.2 required for gem-wrapper and ruby 2.1.0 openssl
+      # Grab it before disabling base
+      - 'yumdownloader openssl openssl-libs openssl-devel --arch=x86_64'
+
       # We only want to deal with the original distro packages
       - 'yum-config-manager --disable \*'
       - 'echo -e "[legacy]\nname=Legacy\nbaseurl=http://vault.centos.org/7.0.1406/os/x86_64\ngpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-7\ngpgcheck=1" > /etc/yum.repos.d/legacy.repo'
 
-      # Downgrade ALL THE THINGS!!!
+      # Downgrade ALL THE THINGS
       - 'cd /root; yum downgrade -y *'
 
       # Getting rid of package conflicts
@@ -51,10 +55,8 @@ HOSTS:
       - 'yum install -y epel-release'
       - 'yum install -y openssl util-linux rpm-build augeas-devel createrepo genisoimage git gnupg2 libicu-devel libxml2 libxml2-devel libxslt libxslt-devel rpmdevtools clamav clamav-update which ruby-devel rpm-devel rpm-sign'
 
-      # Openssl 1.0.2 required for gem-wrapper and ruby 2.1.0 openssl
-      - 'yum-config-manager --enable base'
-      - 'yumdownloader openssl openssl-libs openssl-devel --arch=x86_64'
-      - 'yum-config-manager --disable base'
+      # fakesystemd is removed and base dependencies are installed,
+      # so it's possible to 'upgrade' openssl
       - 'yum localinstall -y openssl*.rpm'
 
       # simp doc deps
@@ -102,6 +104,10 @@ HOSTS:
       - 'yum install -y yum-plugin-ovl || :'
       - 'yum install -y yum-utils'
 
+      # Openssl 1.0.2 required for gem-wrapper and ruby 2.1.0 openssl
+      # Grab it before disabling base
+      - 'yumdownloader openssl openssl-libs openssl-devel --arch=x86_64'
+
       # We only want to deal with the original distro packages
       - 'yum-config-manager --disable \*'
       - 'echo -e "[legacy]\nname=Legacy\nbaseurl=http://vault.centos.org/6.6/os/x86_64\ngpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-6\ngpgcheck=1" > /etc/yum.repos.d/legacy.repo'
@@ -133,11 +139,8 @@ HOSTS:
       - 'yum install -y epel-release'
       - 'yum install -y openssl util-linux rpm-build augeas-devel createrepo genisoimage git gnupg2 libicu-devel libxml2 libxml2-devel libxslt libxslt-devel rpmdevtools clamav which ruby-devel rpm-sign acl'
 
-      # Openssl 1.0.2 required for gem-wrapper and ruby 2.1.0 openssl
-      - 'yum-config-manager --enable base'
-      - 'yumdownloader openssl openssl-libs openssl-devel --arch=x86_64'
-      - 'yum-config-manager --disable base'
-      # Unlike el7, el6 pulls in multilib openssl; only install x86_64
+      # fakesystemd is removed and base dependencies are installed,
+      # so it's possible to 'upgrade' openssl
       - 'yum localinstall -y openssl*.x86_64.rpm'
 
       # simp doc deps

--- a/spec/acceptance/suites/rpm_docker/nodesets/default.yml
+++ b/spec/acceptance/suites/rpm_docker/nodesets/default.yml
@@ -20,10 +20,6 @@ HOSTS:
       - 'yum install -y yum-plugin-ovl || :'
       - 'yum install -y yum-utils'
 
-      # Openssl 1.0.2 required for gem-wrapper and ruby 2.1.0 openssl
-      # Grab it before disabling base
-      - 'yumdownloader openssl openssl-libs openssl-devel --arch=x86_64'
-
       # We only want to deal with the original distro packages
       - 'yum-config-manager --disable \*'
       - 'echo -e "[legacy]\nname=Legacy\nbaseurl=http://vault.centos.org/7.0.1406/os/x86_64\ngpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-7\ngpgcheck=1" > /etc/yum.repos.d/legacy.repo'
@@ -55,15 +51,11 @@ HOSTS:
       - 'yum install -y epel-release'
       - 'yum install -y openssl util-linux rpm-build augeas-devel createrepo genisoimage git gnupg2 libicu-devel libxml2 libxml2-devel libxslt libxslt-devel rpmdevtools clamav clamav-update which ruby-devel rpm-devel rpm-sign'
 
-      # fakesystemd is removed and base dependencies are installed,
-      # so it's possible to 'upgrade' openssl
-      - 'yum localinstall -y openssl*.rpm'
-
       # simp doc deps
       - 'yum -y install centos-release-scl python27 python-pip python-virtualenv fontconfig dejavu-sans-fonts dejavu-sans-mono-fonts dejavu-serif-fonts dejavu-fonts-common libjpeg-devel zlib-devel'
 
       # RVM build-deps
-      - 'yum install -y libyaml-devel glibc-headers autoconf gcc gcc-c++ glibc-devel readline-devel libffi-devel automake libtool bison sqlite-devel'
+      - 'yum install -y libyaml-devel glibc-headers autoconf gcc gcc-c++ glibc-devel readline-devel libffi-devel openssl-devel automake libtool bison sqlite-devel'
 
       # For things that want to call systemctl - we don't need them for this
       - 'ln -sf /bin/true /usr/bin/systemctl'
@@ -104,10 +96,6 @@ HOSTS:
       - 'yum install -y yum-plugin-ovl || :'
       - 'yum install -y yum-utils'
 
-      # Openssl 1.0.2 required for gem-wrapper and ruby 2.1.0 openssl
-      # Grab it before disabling base
-      - 'yumdownloader openssl openssl-libs openssl-devel --arch=x86_64'
-
       # We only want to deal with the original distro packages
       - 'yum-config-manager --disable \*'
       - 'echo -e "[legacy]\nname=Legacy\nbaseurl=http://vault.centos.org/6.6/os/x86_64\ngpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-6\ngpgcheck=1" > /etc/yum.repos.d/legacy.repo'
@@ -139,15 +127,11 @@ HOSTS:
       - 'yum install -y epel-release'
       - 'yum install -y openssl util-linux rpm-build augeas-devel createrepo genisoimage git gnupg2 libicu-devel libxml2 libxml2-devel libxslt libxslt-devel rpmdevtools clamav which ruby-devel rpm-sign acl'
 
-      # fakesystemd is removed and base dependencies are installed,
-      # so it's possible to 'upgrade' openssl
-      - 'yum localinstall -y openssl*.x86_64.rpm'
-
       # simp doc deps
       - 'yum -y install centos-release-scl python27 python-pip python-virtualenv fontconfig dejavu-sans-fonts dejavu-sans-mono-fonts dejavu-serif-fonts dejavu-fonts-common libjpeg-devel zlib-devel'
 
       # RVM build-deps
-      - 'yum install -y libyaml-devel glibc-headers autoconf gcc gcc-c++ glibc-devel readline-devel libffi-devel automake libtool bison sqlite-devel tar'
+      - 'yum install -y libyaml-devel glibc-headers autoconf gcc gcc-c++ glibc-devel readline-devel libffi-devel openssl-devel automake libtool bison sqlite-devel tar'
 
       # Puppet Deps
       - 'yum install -y ntpdate rubygems'

--- a/spec/acceptance/suites/rpm_docker/nodesets/default.yml
+++ b/spec/acceptance/suites/rpm_docker/nodesets/default.yml
@@ -10,7 +10,14 @@ HOSTS:
     docker_cmd: '/usr/sbin/sshd -D'
     docker_preserve_image: true
     docker_image_commands:
-      # For SELinux Builds
+      # See https://github.com/CentOS/sig-cloud-instance-images/issues/15
+      - 'rm -f /var/lib/rpm/__db*'
+      - 'rpm --rebuilddb'
+      - 'yum clean all'
+      # This is a hack to force an exit code of 0
+      # Sometimes yum-plugin-ovl will install dependencies, which will fail with rpmdb errors
+      # since yum-plugin-ovl is not installed (chicken and egg)
+      - 'yum install -y yum-plugin-ovl || :'
       - 'yum install -y yum-utils'
 
       # We only want to deal with the original distro packages
@@ -44,11 +51,17 @@ HOSTS:
       - 'yum install -y epel-release'
       - 'yum install -y openssl util-linux rpm-build augeas-devel createrepo genisoimage git gnupg2 libicu-devel libxml2 libxml2-devel libxslt libxslt-devel rpmdevtools clamav clamav-update which ruby-devel rpm-devel rpm-sign'
 
+      # Openssl 1.0.2 required for gem-wrapper and ruby 2.1.0 openssl
+      - 'yum-config-manager --enable base'
+      - 'yumdownloader openssl openssl-libs openssl-devel --arch=x86_64'
+      - 'yum-config-manager --disable base'
+      - 'yum localinstall -y openssl*.rpm'
+
       # simp doc deps
       - 'yum -y install centos-release-scl python27 python-pip python-virtualenv fontconfig dejavu-sans-fonts dejavu-sans-mono-fonts dejavu-serif-fonts dejavu-fonts-common libjpeg-devel zlib-devel'
 
       # RVM build-deps
-      - 'yum install -y libyaml-devel glibc-headers autoconf gcc gcc-c++ glibc-devel readline-devel libffi-devel openssl-devel automake libtool bison sqlite-devel'
+      - 'yum install -y libyaml-devel glibc-headers autoconf gcc gcc-c++ glibc-devel readline-devel libffi-devel automake libtool bison sqlite-devel'
 
       # For things that want to call systemctl - we don't need them for this
       - 'ln -sf /bin/true /usr/bin/systemctl'
@@ -79,7 +92,14 @@ HOSTS:
     image: centos:6.6
     docker_preserve_image: true
     docker_image_commands:
-      # For SELinux Builds
+      # See https://github.com/CentOS/sig-cloud-instance-images/issues/15
+      - 'rm -f /var/lib/rpm/__db*'
+      - 'rpm --rebuilddb'
+      - 'yum clean all'
+      # This is a hack to force an exit code of 0
+      # Sometimes yum-plugin-ovl will install dependencies, which will fail with rpmdb errors
+      # since yum-plugin-ovl is not installed (chicken and egg)
+      - 'yum install -y yum-plugin-ovl || :'
       - 'yum install -y yum-utils'
 
       # We only want to deal with the original distro packages
@@ -87,7 +107,8 @@ HOSTS:
       - 'echo -e "[legacy]\nname=Legacy\nbaseurl=http://vault.centos.org/6.6/os/x86_64\ngpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-6\ngpgcheck=1" > /etc/yum.repos.d/legacy.repo'
 
       # Downgrade ALL THE THINGS!!!
-      - 'cd /root; yum downgrade -y *'
+      # ...except yum and python-urlgrabber, which yum-plugin-ovl has dependencies on
+      - 'cd /root; yum -x yum -x python-urlgrabber downgrade -y *'
 
       # Getting rid of package conflicts
       - '\cp -a /etc/ssh /root'
@@ -112,11 +133,18 @@ HOSTS:
       - 'yum install -y epel-release'
       - 'yum install -y openssl util-linux rpm-build augeas-devel createrepo genisoimage git gnupg2 libicu-devel libxml2 libxml2-devel libxslt libxslt-devel rpmdevtools clamav which ruby-devel rpm-sign acl'
 
+      # Openssl 1.0.2 required for gem-wrapper and ruby 2.1.0 openssl
+      - 'yum-config-manager --enable base'
+      - 'yumdownloader openssl openssl-libs openssl-devel --arch=x86_64'
+      - 'yum-config-manager --disable base'
+      # Unlike el7, el6 pulls in multilib openssl; only install x86_64
+      - 'yum localinstall -y openssl*.x86_64.rpm'
+
       # simp doc deps
       - 'yum -y install centos-release-scl python27 python-pip python-virtualenv fontconfig dejavu-sans-fonts dejavu-sans-mono-fonts dejavu-serif-fonts dejavu-fonts-common libjpeg-devel zlib-devel'
 
       # RVM build-deps
-      - 'yum install -y libyaml-devel glibc-headers autoconf gcc gcc-c++ glibc-devel readline-devel libffi-devel openssl-devel automake libtool bison sqlite-devel tar'
+      - 'yum install -y libyaml-devel glibc-headers autoconf gcc gcc-c++ glibc-devel readline-devel libffi-devel automake libtool bison sqlite-devel tar'
 
       # Puppet Deps
       - 'yum install -y ntpdate rubygems'

--- a/spec/acceptance/suites/rpm_docker/nodesets/rhel.yml
+++ b/spec/acceptance/suites/rpm_docker/nodesets/rhel.yml
@@ -11,13 +11,20 @@ HOSTS:
     docker_cmd: '/usr/sbin/sshd -D'
     docker_preserve_image: true
     docker_image_commands:
-      # For SELinux Builds
+      # See https://github.com/CentOS/sig-cloud-instance-images/issues/15
+      - 'rm -f /var/lib/rpm/__db*'
+      - 'rpm --rebuilddb'
+      - 'yum clean all'
+      # This is a hack to force an exit code of 0
+      # Sometimes yum-plugin-ovl will install dependencies, which will fail with rpmdb errors
+      # since yum-plugin-ovl is not installed (chicken and egg)
+      - 'yum install -y yum-plugin-ovl || :'
       - 'yum install -y yum-utils'
 
       # We only want to deal with the original distro packages
       - 'yum-config-manager --disable \*'
 
-      # Downgrade ALL THE THINGS!!!
+      # Downgrade ALL THE THINGS
       - 'cd /root; yum downgrade -y *'
 
       # Getting rid of package conflicts
@@ -59,9 +66,9 @@ HOSTS:
       # RVM
       - 'runuser build_user -l -c "gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"'
       - 'runuser build_user -l -c "curl -sSL https://get.rvm.io | bash -s stable"'
-      - 'runuser build_user -l -c "rvm install 2.1.9"'
+      - 'runuser build_user -l -c "rvm install 2.1.9 --disable-binary"'
       - 'runuser build_user -l -c "rvm use --default 2.1.9"'
-      - 'runuser build_user -l -c "rvm all do gem install bundler"'
+      - 'runuser build_user -l -c "rvm all do gem install bundler --no-ri --no-rdoc"'
 
       # Add some gems that will drag along 90% of what the build requires
       - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc simp-rake-helpers"'
@@ -79,7 +86,14 @@ HOSTS:
     image: rhel:6.6-6
     docker_preserve_image: true
     docker_image_commands:
-      # For SELinux Builds
+      # See https://github.com/CentOS/sig-cloud-instance-images/issues/15
+      - 'rm -f /var/lib/rpm/__db*'
+      - 'rpm --rebuilddb'
+      - 'yum clean all'
+      # This is a hack to force an exit code of 0
+      # Sometimes yum-plugin-ovl will install dependencies, which will fail with rpmdb errors
+      # since yum-plugin-ovl is not installed (chicken and egg)
+      - 'yum install -y yum-plugin-ovl || :'
       - 'yum install -y yum-utils'
 
       # We only want to deal with the original distro packages
@@ -87,7 +101,8 @@ HOSTS:
       - 'echo -e "[legacy]\nname=Legacy\nbaseurl=http://vault.centos.org/6.6/os/x86_64\ngpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-6\ngpgcheck=1" > /etc/yum.repos.d/legacy.repo'
 
       # Downgrade ALL THE THINGS!!!
-      - 'cd /root; yum downgrade -y *'
+      # ...except yum and python-urlgrabber, which yum-plugin-ovl has dependencies on
+      - 'cd /root; yum -x yum -x python-urlgrabber downgrade -y *'
 
       # Getting rid of package conflicts
       - '\cp -a /etc/ssh /root'
@@ -124,9 +139,9 @@ HOSTS:
       # RVM
       - 'runuser build_user -l -c "gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"'
       - 'runuser build_user -l -c "curl -sSL https://get.rvm.io | bash -s stable"'
-      - 'runuser build_user -l -c "rvm install 2.1.9"'
+      - 'runuser build_user -l -c "rvm install 2.1.9 --disable-binary"'
       - 'runuser build_user -l -c "rvm use --default 2.1.9"'
-      - 'runuser build_user -l -c "rvm all do gem install bundler"'
+      - 'runuser build_user -l -c "rvm all do gem install bundler --no-ri --no-rdoc"'
 
       # Add some gems that will drag along 90% of what the build requires
       - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc simp-rake-helpers"'


### PR DESCRIPTION
In rpm_docker:

- Fixed constantly corrupted rpmdb
  - https://github.com/CentOS/sig-cloud-instance-images/issues/15
- Installed openssl 1.0.2, required by git-wrappers and RVM
- Fixed net-ssh inability to use ed-25519 out of the box
  - https://github.com/net-ssh/net-ssh/issues/478

SIMP-4035 #close