### PR TITLE
(SIMP-4133) Fix RVM/OpenSSL failures in rpm_docker

### DIFF
--- a/spec/acceptance/suites/rpm_docker/nodesets/default.yml
+++ b/spec/acceptance/suites/rpm_docker/nodesets/default.yml
@@ -59,9 +59,9 @@ HOSTS:
       # RVM
       - 'runuser build_user -l -c "gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"'
       - 'runuser build_user -l -c "curl -sSL https://get.rvm.io | bash -s stable"'
-      - 'runuser build_user -l -c "rvm install 2.1.9"'
+      - 'runuser build_user -l -c "rvm install 2.1.9 --disable-binary"'
       - 'runuser build_user -l -c "rvm use --default 2.1.9"'
-      - 'runuser build_user -l -c "rvm all do gem install bundler"'
+      - 'runuser build_user -l -c "rvm all do gem install bundler --no-ri --no-rdoc"'
 
       # Add some gems that will drag along 90% of what the build requires
       - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc simp-rake-helpers"'
@@ -124,9 +124,9 @@ HOSTS:
       # RVM
       - 'runuser build_user -l -c "gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"'
       - 'runuser build_user -l -c "curl -sSL https://get.rvm.io | bash -s stable"'
-      - 'runuser build_user -l -c "rvm install 2.1.9"'
+      - 'runuser build_user -l -c "rvm install 2.1.9 --disable-binary"'
       - 'runuser build_user -l -c "rvm use --default 2.1.9"'
-      - 'runuser build_user -l -c "rvm all do gem install bundler"'
+      - 'runuser build_user -l -c "rvm all do gem install bundler --no-ri --no-rdoc"'
 
       # Add some gems that will drag along 90% of what the build requires
       - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc simp-rake-helpers"'


### PR DESCRIPTION
Before this patch, `bundle exec beaker:suites[rpm_docker]` had started
to fail in beaker environments that had recently built up their docker
images.  The failure was caused by a mismatch between the version
of OpenSSL provided by the OS images and the version linked by
pre-compiled binaries that are downloaded as part of by an `rvm
install`.

This patch prevents the issue by updating the docker image commands in the
`rpm_docker` Beaker nodeset to build ruby from source against the
OpenSSL on each host's OS.

SIMP-4134 #close
SIMP-4133 #comment fixed `rpm_docker` in simp-core