### PR TITLE
(SIMP-4158) Update to stdlib 4.24.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,9 +21,9 @@ end
 # The following gems are required for ed25519 support in net-ssh. It is unclear
 # when net-ssh/vagrant will support ed25519 out of the box.
 # See: https://github.com/net-ssh/net-ssh/issues/478
-gem 'rbnacl'
+gem 'rbnacl', '~> 3.4.0'
 # >1.0.15 requires ruby 2.2.6, the build depends on 2.1.9
-gem 'rbnacl-libsodium', '~> 1.0.15'
+gem 'rbnacl-libsodium', '~> 1.0.15.1'
 gem 'bcrypt_pbkdf'
 
 gem 'bundler'

--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -193,7 +193,7 @@ mod 'puppetlabs-puppet_authorization',
 
 mod 'puppetlabs-stdlib',
   :git => 'https://github.com/simp/puppetlabs-stdlib',
-  :tag => '4.19.0'
+  :tag => '4.24.0'
 
 mod 'razorsedge-snmp',
   :git => 'https://github.com/simp/puppet-snmp',


### PR DESCRIPTION
For the new simp_kubernetes module

SIMP-4158 #comment update to stdlib 4.24.0