### PR TITLE
(SIMP-4124) docker: Update to released module

### DIFF
--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -137,10 +137,8 @@ mod 'puppetlabs-concat',
   :tag => '3.0.0'
 
 mod 'puppetlabs-docker',
-  # TODO Changes have been made to this module upstream that have not been
-  # released yet. See SIMP-4120 and SIMP-4124
   :git => 'https://github.com/simp/puppetlabs-docker',
-  :ref => 'master'
+  :tag => '1.0.4'
 
 mod 'puppetlabs-hocon',
   :git => 'https://github.com/simp/pupmod-puppetlabs-hocon',

--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -429,7 +429,7 @@ mod 'simp-simp_grafana',
 
 mod 'simp-simp_kubernetes',
   :git => 'https://github.com/jeefberkey/pupmod-simp-simp_kubernetes',
-  :ref => 'iptables'
+  :ref => 'master'
 
 mod 'simp-simp_logstash',
   :git => 'https://github.com/simp/pupmod-simp-simp_logstash',

--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -428,7 +428,7 @@ mod 'simp-simp_grafana',
   :tag => '1.0.4'
 
 mod 'simp-simp_kubernetes',
-  :git => 'https://github.com/jeefberkey/pupmod-simp-simp_kubernetes',
+  :git => 'https://github.com/simp/pupmod-simp-simp_kubernetes',
   :ref => 'master'
 
 mod 'simp-simp_logstash',


### PR DESCRIPTION
This commit updates the Puppetfile to a released version of the
puppetlabs/docker module.

SIMP-4124 #close