### PR TITLE
(SIMP-4225) simp-core: Enable GPG check simp_filesystem.repo

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,9 @@ GEM
     aws-sdk-v1 (1.67.0)
       json (~> 1.4)
       nokogiri (~> 1)
-    beaker (3.29.0)
+    bcrypt_pbkdf (1.0.0)
+    beaker (3.30.0)
+      beaker-abs (~> 0.4)
       beaker-aws (~> 0.1)
       beaker-docker (~> 0.1)
       beaker-google (~> 0.1)
@@ -34,7 +36,8 @@ GEM
       rsync (~> 1.0.9)
       stringify-hash (~> 0.0)
       thor (~> 0.19)
-    beaker-aws (0.3.0)
+    beaker-abs (0.4.0)
+    beaker-aws (0.4.0)
       aws-sdk-v1 (~> 1.57)
       stringify-hash (~> 0.0.0)
     beaker-docker (0.2.0)
@@ -45,13 +48,13 @@ GEM
       stringify-hash (~> 0.0.0)
     beaker-hiera (0.1.1)
       stringify-hash (~> 0.0.0)
-    beaker-hostgenerator (1.1.4)
+    beaker-hostgenerator (1.1.5)
       deep_merge (~> 1.0)
       stringify-hash (~> 0.0.0)
-    beaker-openstack (0.1.0)
-      fog (~> 1.38)
+    beaker-openstack (0.2.0)
+      fog-openstack
       stringify-hash (~> 0.0.0)
-    beaker-puppet (0.8.0)
+    beaker-puppet (0.9.0)
       in-parallel (~> 0.1)
       oga
       stringify-hash (~> 0.0.0)
@@ -62,14 +65,14 @@ GEM
       rspec (~> 3.0)
       serverspec (~> 2)
       specinfra (~> 2)
-    beaker-vagrant (0.1.1)
+    beaker-vagrant (0.2.0)
       stringify-hash (~> 0.0.0)
     beaker-vcloud (0.2.0)
       beaker-vmpooler
       beaker-vmware
       rbvmomi (~> 1.9)
       stringify-hash (~> 0.0.0)
-    beaker-vmpooler (1.1.0)
+    beaker-vmpooler (1.2.0)
       stringify-hash (~> 0.0.0)
     beaker-vmware (0.2.0)
       fission (~> 0.4)
@@ -95,155 +98,22 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
-    fast_gettext (1.1.0)
+    fast_gettext (1.1.1)
     ffi (1.9.18)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
-    fog (1.41.0)
-      fog-aliyun (>= 0.1.0)
-      fog-atmos
-      fog-aws (>= 0.6.0)
-      fog-brightbox (~> 0.4)
-      fog-cloudatcost (~> 0.1.0)
-      fog-core (~> 1.45)
-      fog-digitalocean (>= 0.3.0)
-      fog-dnsimple (~> 1.0)
-      fog-dynect (~> 0.0.2)
-      fog-ecloud (~> 0.1)
-      fog-google (<= 0.1.0)
-      fog-internet-archive
-      fog-joyent
-      fog-json
-      fog-local
-      fog-openstack
-      fog-powerdns (>= 0.1.1)
-      fog-profitbricks
-      fog-rackspace
-      fog-radosgw (>= 0.0.2)
-      fog-riakcs
-      fog-sakuracloud (>= 0.0.4)
-      fog-serverlove
-      fog-softlayer
-      fog-storm_on_demand
-      fog-terremark
-      fog-vmfusion
-      fog-voxel
-      fog-vsphere (>= 0.4.0)
-      fog-xenserver
-      fog-xml (~> 0.1.1)
-      ipaddress (~> 0.5)
-      json (>= 1.8, < 2.0)
-    fog-aliyun (0.2.0)
-      fog-core (~> 1.27)
-      fog-json (~> 1.0)
-      ipaddress (~> 0.8)
-      xml-simple (~> 1.1)
-    fog-atmos (0.1.0)
-      fog-core
-      fog-xml
-    fog-aws (2.0.0)
-      fog-core (~> 1.38)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-      ipaddress (~> 0.8)
-    fog-brightbox (0.14.0)
-      fog-core (~> 1.22)
-      fog-json
-      inflecto (~> 0.0.2)
-    fog-cloudatcost (0.1.2)
-      fog-core (~> 1.36)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-      ipaddress (~> 0.8)
-    fog-core (1.45.0)
+    fog-core (2.0.0)
       builder
       excon (~> 0.58)
       formatador (~> 0.2)
-    fog-digitalocean (0.3.0)
-      fog-core (~> 1.42)
-      fog-json (>= 1.0)
-      fog-xml (>= 0.1)
-      ipaddress (>= 0.5)
-    fog-dnsimple (1.0.0)
-      fog-core (~> 1.38)
-      fog-json (~> 1.0)
-    fog-dynect (0.0.3)
-      fog-core
-      fog-json
-      fog-xml
-    fog-ecloud (0.3.0)
-      fog-core
-      fog-xml
-    fog-google (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-internet-archive (0.0.1)
-      fog-core
-      fog-json
-      fog-xml
-    fog-joyent (0.0.1)
-      fog-core (~> 1.42)
-      fog-json (>= 1.0)
-    fog-json (1.0.2)
-      fog-core (~> 1.0)
+      mime-types
+    fog-json (1.1.0)
+      fog-core (~> 2.0)
       multi_json (~> 1.10)
-    fog-local (0.4.0)
-      fog-core (~> 1.27)
     fog-openstack (0.1.22)
       fog-core (>= 1.40)
       fog-json (>= 1.0)
       ipaddress (>= 0.8)
-    fog-powerdns (0.1.1)
-      fog-core (~> 1.27)
-      fog-json (~> 1.0)
-      fog-xml (~> 0.1)
-    fog-profitbricks (4.1.1)
-      fog-core (~> 1.42)
-      fog-json (~> 1.0)
-    fog-rackspace (0.1.5)
-      fog-core (>= 1.35)
-      fog-json (>= 1.0)
-      fog-xml (>= 0.1)
-      ipaddress (>= 0.8)
-    fog-radosgw (0.0.5)
-      fog-core (>= 1.21.0)
-      fog-json
-      fog-xml (>= 0.0.1)
-    fog-riakcs (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-sakuracloud (1.7.5)
-      fog-core
-      fog-json
-    fog-serverlove (0.1.2)
-      fog-core
-      fog-json
-    fog-softlayer (1.1.4)
-      fog-core
-      fog-json
-    fog-storm_on_demand (0.1.1)
-      fog-core
-      fog-json
-    fog-terremark (0.1.0)
-      fog-core
-      fog-xml
-    fog-vmfusion (0.1.0)
-      fission
-      fog-core
-    fog-voxel (0.1.0)
-      fog-core
-      fog-xml
-    fog-vsphere (1.13.1)
-      fog-core
-      rbvmomi (~> 1.9)
-    fog-xenserver (0.3.0)
-      fog-core
-      fog-xml
-    fog-xml (0.1.3)
-      fog-core
-      nokogiri (>= 1.5.11, < 2.0.0)
     formatador (0.2.5)
     gettext (3.2.6)
       locale (>= 2.0.5)
@@ -277,7 +147,6 @@ GEM
     httpclient (2.8.3)
     hurley (0.2)
     in-parallel (0.1.17)
-    inflecto (0.0.2)
     inifile (3.0.0)
     ipaddress (0.8.3)
     json (1.8.6)
@@ -303,10 +172,10 @@ GEM
     mime-types (2.99.3)
     mini_portile2 (2.3.0)
     minitar (0.6.1)
-    minitest (5.10.3)
+    minitest (5.11.1)
     mocha (1.3.0)
       metaclass (~> 0.0.1)
-    multi_json (1.12.2)
+    multi_json (1.13.1)
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -315,7 +184,7 @@ GEM
     netrc (0.11.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
-    oga (2.11)
+    oga (2.13)
       ast
       ruby-ll (~> 2.1)
     open_uri_redirections (0.2.1)
@@ -359,7 +228,7 @@ GEM
       puppet-lint (~> 2.0)
       puppet-syntax (~> 2.0)
       rspec-puppet (~> 2.0)
-    r10k (2.6.1)
+    r10k (2.6.2)
       colored (= 1.2)
       cri (~> 2.6.1)
       gettext-setup (~> 0.5)
@@ -371,6 +240,10 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rb-readline (0.5.5)
+    rbnacl (3.4.0)
+      ffi
+    rbnacl-libsodium (1.0.15.1)
+      rbnacl (>= 3.0.1)
     rbvmomi (1.11.6)
       builder (~> 3.0)
       json (>= 1.8)
@@ -387,7 +260,7 @@ GEM
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
       rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.0)
+    rspec-core (3.7.1)
       rspec-support (~> 3.7.0)
     rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -422,7 +295,7 @@ GEM
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    simp-beaker-helpers (1.8.10)
+    simp-beaker-helpers (1.9.0)
       beaker (~> 3.14)
       beaker-puppet_install_helper (~> 0.6)
     simp-build-helpers (0.1.1)
@@ -463,20 +336,19 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
-    xml-simple (1.1.5)
     yard (0.9.12)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt_pbkdf
   beaker
   beaker-rspec
   bundler
   coderay
   dotenv
   google-api-client (= 0.9.4)
-  in-parallel
   metadata-json-lint
   parallel
   pry
@@ -486,10 +358,12 @@ DEPENDENCIES
   puppet-strings
   puppetlabs_spec_helper
   rake
+  rbnacl (~> 3.4.0)
+  rbnacl-libsodium (~> 1.0.15.1)
   ruby-progressbar
-  simp-beaker-helpers (~> 1.7)
+  simp-beaker-helpers (~> 1.9)
   simp-build-helpers (>= 0.1.0)
   simp-rake-helpers (~> 5.0)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/build/distributions/CentOS/6/x86_64/DVD/ks/diskdetect.sh
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/diskdetect.sh
@@ -14,6 +14,7 @@ for disk in \
   /sys/block/vd[a-z] \
   /sys/block/vd[a-z][a-z] \
   /sys/block/hd[a-z] \
+  /sys/block/nvme[0-9]n[0-9] \
   ;
 do
   [ -d "$disk" ] || continue

--- a/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/auto.cfg
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/auto.cfg
@@ -33,11 +33,11 @@ else
 fi
 %end
 
-%post --nochroot --erroronfail
+%post --nochroot --erroronfail --log=/mnt/sysimage/var/log/anaconda.post-nochroot.log
+
 # SOURCE is the DVD; SYSIMAGE is the chroot'd root dir
 SOURCE="/mnt/source"
 SYSIMAGE="/mnt/sysimage"
-DEF_VERSION='6'
 
 # If we dropped a LUKS key-file, we need to copy it into place.
 if [ -f /boot/disk_creds ]; then
@@ -96,22 +96,17 @@ if [ -b /dev/cdrom ]; then
   fi
 fi
 
+if [ -f "${SYSIMAGE}/opt/puppetlabs/puppet/bin/facter" ]; then
+  facter="chroot ${SYSIMAGE} /opt/puppetlabs/puppet/bin/facter"
+else
+  facter="chroot ${SYSIMAGE} facter"
+fi
+
 # Get the Linux distribution
-# The $1 element of redhat-release is "CentOS" or "Red"
-# The latter is changed to RedHat
-ostype=`awk '{print $1}' ${SYSIMAGE}/etc/redhat-release 2>/dev/null`;
-if [ $ostype == "Red" ]; then
-  ostype="RedHat"
-fi
-
-# Get the version of RedHat/CentOS we're running under
-rhversion=`sed -n '3{p; q }' /.buildstamp 2>/dev/null`;
-# If this screws up for some reason, put something sane in place.
-if [ -z $rhversion ]; then
-    rhversion=$DEF_VERSION
-fi
-
-htype="x86_64";
+ostype=`$facter operatingsystem`
+rhversion=`$facter operatingsystemrelease`
+majrhversion=`$facter operatingsystemmajrelease`
+htype=`$facter architecture`
 
 UMASKSAVE=`umask`
 umask 0002
@@ -123,11 +118,17 @@ if [ $? -ne 0 ]; then
   echo "Run the following commands once the install has completed:" | tee -a ${SYSIMAGE}/root/postinstall.err
   echo -e "\tmount /dev/dvd /media" | tee -a ${SYSIMAGE}/root/postinstall.err
   echo -e "\tcp -a /media/* /media/.discinfo /media/.treeinfo /var/www/yum/$ostype/$rhversion/$htype" | tee -a ${SYSIMAGE}/root/postinstall.err
-  echo -e "\trm -rf /var/www/yum/$ostype/$rhversion/$htype/ks/dvd" | tee -a ${SYSIMAGE}/root/postinstall.err
-  echo -e "\tcp -a /var/www/yum/$ostype/$rhversion/$htype/SIMP /var/www/yum/SIMP" | tee -a ${SYSIMAGE}/root/postinstall.err
-  echo -e "\trm -rf /var/www/yum/$ostype/$rhversion/$htype/SIMP" | tee -a ${SYSIMAGE}/root/postinstall.err
+  echo -e "\tcp -a /var/www/yum/$ostype/$rhversion/$htype/SIMP /var/www/yum" | tee -a ${SYSIMAGE}/root/postinstall.err
   echo -e "\tcp -a /var/www/yum/$ostype/$rhversion/$htype/ks /var/www" | tee -a ${SYSIMAGE}/root/postinstall.err
+  echo -e "\trm -rf /var/www/yum/$ostype/$rhversion/$htype/SIMP" | tee -a ${SYSIMAGE}/root/postinstall.err
   echo -e "\trm -rf /var/www/yum/$ostype/$rhversion/$htype/ks" | tee -a ${SYSIMAGE}/root/postinstall.err
+  echo -e "\trm -rf /var/www/yum/$ostype/$rhversion/$htype/Config" | tee -a ${SYSIMAGE}/root/postinstall.err
+  echo -e "\trm -rf /var/www/yum/$ostype/$rhversion/$htype/*simp_pkglist.txt" | tee -a ${SYSIMAGE}/root/postinstall.err
+  if [ -e RPM-GPG-KEY-SIMP-Dev ]; then
+    echo -e "\tmkdir -p ${SYSIMAGE}/var/www/yum/SIMP-Dev/GPGKEYS" | tee -a ${SYSIMAGE}/root/postinstall.err
+    echo -e "\tmv ${SYSIMAGE}/var/www/yum/$ostype/$rhversion/$htype/RPM-GPG-KEY-SIMP-Dev ${SYSIMAGE}/var/www/yum/SIMP-Dev/GPGKEYS" | tee -a ${SYSIMAGE}/root/postinstall.err
+  fi
+
   echo -e "\tcd /var/www/yum/SIMP/x86_64; for file in ../noarch/*.rpm do; ln -s $file; done;" | tee -a ${SYSIMAGE}/root/postinstall.err
   echo -e "\tcd createrepo .;" | tee -a ${SYSIMAGE}/root/postinstall.err
   echo -e "\tcd /var/www/yum/SIMP/i386; for file in ../noarch/*.rpm do; ln -s $file; done;" | tee -a ${SYSIMAGE}/root/postinstall.err
@@ -135,18 +136,22 @@ if [ $? -ne 0 ]; then
 else
   cp -a * .discinfo .treeinfo ${SYSIMAGE}/var/www/yum/$ostype/$rhversion/$htype
   cp -a ${SYSIMAGE}/var/www/yum/$ostype/$rhversion/$htype/SIMP ${SYSIMAGE}/var/www/yum
-  rm -rf ${SYSIMAGE}/var/www/yum/$ostype/$rhversion/$htype/SIMP
   cp -a ${SYSIMAGE}/var/www/yum/$ostype/$rhversion/$htype/ks ${SYSIMAGE}/var/www
+  rm -rf ${SYSIMAGE}/var/www/yum/$ostype/$rhversion/$htype/SIMP
   rm -rf ${SYSIMAGE}/var/www/yum/$ostype/$rhversion/$htype/ks
   rm -rf ${SYSIMAGE}/var/www/yum/$ostype/$rhversion/$htype/Config
   rm -rf ${SYSIMAGE}/var/www/yum/$ostype/$rhversion/$htype/*simp_pkglist.txt
+
+  if [ -e RPM-GPG-KEY-SIMP-Dev ]; then
+    mkdir -p ${SYSIMAGE}/var/www/yum/SIMP-Dev/GPGKEYS
+    mv ${SYSIMAGE}/var/www/yum/$ostype/$rhversion/$htype/RPM-GPG-KEY-SIMP-Dev ${SYSIMAGE}/var/www/yum/SIMP-Dev/GPGKEYS
+  fi
 fi
 
-if [ "$rhversion" != "$DEF_VERSION" ]; then
-    pushd .;
-    cd ${SYSIMAGE}/var/www/yum/$ostype;
-    ln -s $rhversion "$DEF_VERSION";
-    popd
+if [ ! -d "${SYSIMAGE}/var/www/yum/${ostype}/${majrhversion}" ]; then
+  cd "${SYSIMAGE}/var/www/yum/${ostype}";
+  ln -sf $rhversion $majrhversion;
+  cd -;
 fi
 
 popd
@@ -161,7 +166,7 @@ chmod -R u=rwX,g=rX,o-rwx ${SYSIMAGE}/var/www;
 src_dir="${SYSIMAGE}/var/www/yum/${ostype}/${rhversion}/${htype}/images/pxeboot"
 rsync_dir="${SYSIMAGE}/var/simp/environments/simp/rsync/${ostype}/Global/tftpboot/linux-install"
 rsync_target=`echo "${ostype}-${rhversion}-${htype}" | tr '[:upper:]' '[:lower:]'`
-rsync_link=`echo "${ostype}-${DEF_VERSION}-${htype}" | tr '[:upper:]' '[:lower:]'`
+rsync_link=`echo "${ostype}-${majrhversion}-${htype}" | tr '[:upper:]' '[:lower:]'`
 
 tftpboot_setup_success=1
 if [ -d "${src_dir}" ]; then
@@ -187,12 +192,12 @@ if [ $tftpboot_setup_success -ne 0 ]; then
   echo -e "Could not add PXE Images from the disc to ${rsync_dir}/${rsync_target}" | tee -a ${SYSIMAGE}/root/postinstall.err
 fi
 
-echo "Kickstarted" > ${SYSIMAGE}/root/simp-kickstarted.txt
 # Don't care if this fails.
 eject /tmp/cdrom || true
 %end
 
-%post
+%post --log=/var/log/anaconda.post.log
+
 # Turn off prelinking and remove all previous
 sed -i '/PRELINKING=yes/ c\PRELINKING=no' /etc/sysconfig/prelink
 prelink -u -a
@@ -228,8 +233,8 @@ done
 
 ostype=`facter operatingsystem`
 rhversion=`facter operatingsystemrelease`
+majrhversion=`facter operatingsystemmajrelease`
 htype=`facter architecture`
-
 
 if [ -d /var/www/yum/SIMP/$htype ]; then
   cd /var/www/yum/SIMP/$htype;
@@ -240,32 +245,46 @@ if [ -d /var/www/yum/SIMP/$htype ]; then
 
   createrepo . >& /dev/null;
 
+  extrakey=''
+  if [ -e /var/www/yum/SIMP-Dev/GPGKEYS/RPM-GPG-KEY-SIMP-Dev ]; then
+    extrakey='file:///var/www/yum/SIMP-Dev/GPGKEYS/RPM-GPG-KEY-SIMP-Dev'
+  fi
+
   cat << EOF >> /etc/yum.repos.d/simp_filesystem.repo
 [flocal-$htype]
 name=Local within the filesystem
 baseurl=file:///var/www/yum/SIMP/$htype
 enabled=1
-gpgcheck=0
+gpgcheck=1
+gpgkey=file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet
+    file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs
+    file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP
+    file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch
+    file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana
+    file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-PGDG-96
+    file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-$majrhversion
+    file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-CentOS-$majrhversion
+    $extrakey
 EOF
 fi
-
-yum clean all;
-yum -y --enablerepo=flocal-noarch --enablerepo=flocal-$htype update;
-
 
 cat << EOF >> /etc/yum.repos.d/simp_filesystem.repo
 [frhbase]
 name=$ostype $rhversion base repo
 baseurl=file:///var/www/yum/$ostype/$rhversion/$htype
 enabled=1
-gpgcheck=0
+gpgcheck=1
+gpgkey=file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-CentOS-$majrhversion
 EOF
 
-if [ $ostype == "CentOS" ]; then
+if [ "$ostype" == "CentOS" ]; then
   sed -i '/enabled=/d' /etc/yum.repos.d/CentOS-Base.repo;
   sed -i '/\[.*\]/ a\
 enabled=0' /etc/yum.repos.d/CentOS-Base.repo;
 fi
+
+yum clean all;
+yum -y --enablerepo=flocal-$htype --enablerepo=frhbase update;
 
 pass_hash='$6$1tkixqzp$iihri50cUBpvDcIfq1ieftkj6ToRBrlQutpzP2sdGo5/h6dDfdXvFkmVtODwEJD0W2XYScmKrnkqRnnMEkaRi.'
 
@@ -277,37 +296,41 @@ chage -d 0 simp;
 
 pam_mod="password     requisite     pam_cracklib.so try_first_pass difok=4 retry=3 minlen=14 minclass=3 maxrepeat=2 maxsequence=4 dcredit=-1 ucredit=-1 lcredit=-1 ocredit=-1 gecoscheck reject_username enforce_for_root\n"
 for auth_file in password system; do
+  # A double check to make sure we're not running this on a managed system...
   if [ -f /etc/pam.d/${auth_file}-auth ] && [ ! `grep -q 'Puppet' /etc/pam.d/${auth_file}-auth` ]; then
     # Remove the items that will double prompt us out of the box
     sed -i "/pam_\(pwquality\|cracklib\).so/d" /etc/pam.d/${auth_file}-auth
     # Add our cracklib line
     sed -i "s/\(password.*pam_unix.so.*\)/${pam_mod}\1/" /etc/pam.d/${auth_file}-auth
+  fi
 done
 
 simp_opt=`awk -F "simp_opt=" '{print $2}' /proc/cmdline | cut -f1 -d' '`
 
 #Runs a script on startup to retrieve openstack user-data and place it in whatever you specify $udlocation to be
-if [ $simp_opt == "openstack" ]; then
-cat << EOF >> /etc/init.d/user-data
+if [ "$simp_opt" == "openstack" ]; then
+  cat << EOF >> /etc/init.d/user-data
 #!/bin/sh
 udlocation="/var/simp/user-data"
 udaddress="169.254.169.254"
+
 case \$1 in
    start)
       echo "Retrieving user-data"
-      curl "https://\$udaddress/latest/user-data" > \$udlocation
+      mkdir -p '/var/simp'
+      curl -k "https://\$udaddress/latest/user-data" > \$udlocation
       chmod 700 \$udlocation
       ;;
    restart)
       echo "Retrieving user-data"
-      curl "https://\$udaddress/latest/user-data" > \$udlocation
+      curl -k "https://\$udaddress/latest/user-data" > \$udlocation
       chmod 700 \$udlocation
       ;;
    status)
       if [ -f \$udlocation ]; then
         echo "\${udlocation} exists!"
       else
-        echo "\${udlocation} doesn't exist..."
+        echo "\${udlocation} does not exist..."
       fi
       ;;
   stop)
@@ -320,7 +343,7 @@ EOF
    ln -s /etc/init.d/user-data /etc/rc.d/rc3.d/K92user-data
 fi
 
-if [ -f /root/simp-kickstarted.txt ]; then
-  rm /root/simp-kickstarted.txt
-fi
+# create marker file that indicates a SIMP ISO install
+mkdir -p /etc/simp
+echo "Kickstarted from SIMP ISO" > /etc/simp/.iso_install
 %end

--- a/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/include/common_ks_base
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/include/common_ks_base
@@ -1,4 +1,4 @@
-authconfig --enableshadow --passalgo=sha512 --enablemd5
+authconfig --enableshadow --passalgo=sha512
 network --nodns --hostname=puppet.change.me
 rootpw --iscrypted $6$80gio95q$anOG/VG/cs0vNfYblxQKnH7J3z9omZbxe3Gpa2VojlNf8CbWmtZWXbd/O.4HdlGbGFTRLmvtVe8.jEjQpbxDl/
 bootloader --location=mbr --driveorder=sda,hda --iscrypted --password=$6$EiDpY9dX.blbssNm$9KxoNaquKc1HEAjO.uH1EqFO.PpC.uJyfvjoIAvgojAKoio7MXHCwxm4vwBW4TNlKQxkZaNRJ9cxDmmStDe9H.
@@ -10,7 +10,7 @@ logging --level=info
 selinux --enforcing
 timezone --utc GMT
 
-clearpart --all --initlabel
+clearpart --all
 
 %include /tmp/part-include
 %include /tmp/repo-include

--- a/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/include/min_ks_base
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/include/min_ks_base
@@ -1,4 +1,4 @@
-authconfig --enableshadow --passalgo=sha512 --enablemd5
+authconfig --enableshadow --passalgo=sha512
 network --bootproto=dhcp --nodns --hostname=puppet.change.me
 skipx
 rootpw --iscrypted $6$80gio95q$anOG/VG/cs0vNfYblxQKnH7J3z9omZbxe3Gpa2VojlNf8CbWmtZWXbd/O.4HdlGbGFTRLmvtVe8.jEjQpbxDl/
@@ -11,7 +11,7 @@ logging --level=info
 selinux --permissive
 timezone --utc GMT
 
-clearpart --all --initlabel
+clearpart --all
 
 %include /tmp/part-include
 %include /tmp/repo-include

--- a/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/min.cfg
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/min.cfg
@@ -7,6 +7,7 @@ lang en_US
 %include /mnt/stage2/ks/dvd/include/min_ks_base
 
 %pre
+
 cd /mnt
 # This is a horrible, horrible, hack to work around bugs in Anaconda.
 if [ ! -d source ]; then
@@ -34,7 +35,8 @@ else
 fi
 %end
 
-%post --nochroot --erroronfail
+%post --nochroot --erroronfail --log=/mnt/sysimage/var/log/anaconda.post-nochroot.log
+
 # SOURCE is the DVD; SYSIMAGE is the chroot'd root dir
 SOURCE="/mnt/source"
 SYSIMAGE="/mnt/sysimage"
@@ -88,12 +90,11 @@ if [ -f /boot/disk_creds ]; then
 fi
 %end
 
-%post
+%post --log=/var/log/anaconda.post.log
+
 # Turn off prelinking and remove all previous
 sed -i '/PRELINKING=yes/ c\PRELINKING=no' /etc/sysconfig/prelink
 prelink -u -a
-
-export PATH=/opt/puppetlabs/bin:$PATH
 
 # FIPS
 use_fips=`awk -F "fips=" '{print $2}' /proc/cmdline | cut -f1 -d' '`
@@ -140,6 +141,7 @@ for auth_file in password system; do
     sed -i "/pam_\(pwquality\|cracklib\).so/d" /etc/pam.d/${auth_file}-auth
     # Add our cracklib line
     sed -i "s/\(password.*pam_unix.so.*\)/${pam_mod}\1/" /etc/pam.d/${auth_file}-auth
+  fi
 done
 
 %end

--- a/build/distributions/CentOS/7/x86_64/DVD/EFI/BOOT/grub.cfg
+++ b/build/distributions/CentOS/7/x86_64/DVD/EFI/BOOT/grub.cfg
@@ -24,14 +24,6 @@ menuentry 'simp-disk-crypt' {
   linuxefi /images/pxeboot/vmlinuz ks=cdrom:/ks/dvd/auto.cfg simp_disk_crypt
   initrdefi /images/pxeboot/initrd.img
 }
-menuentry 'simp-big' {
-  linuxefi /images/pxeboot/vmlinuz ks=cdrom:/ks/dvd/auto.cfg simp_opt=big
-  initrdefi /images/pxeboot/initrd.img
-}
-menuentry 'simp-big-disk-crypt' {
-  linuxefi /images/pxeboot/vmlinuz ks=cdrom:/ks/dvd/auto.cfg simp_opt=big simp_disk_crypt
-  initrdefi /images/pxeboot/initrd.img
-}
 menuentry 'simp-prompt' {
   linuxefi /images/pxeboot/vmlinuz ks=cdrom:/ks/dvd/auto.cfg simp_opt=prompt
   initrdefi /images/pxeboot/initrd.img

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/diskdetect.sh
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/diskdetect.sh
@@ -14,6 +14,7 @@ for disk in \
   /sys/block/vd[a-z] \
   /sys/block/vd[a-z][a-z] \
   /sys/block/hd[a-z] \
+  /sys/block/nvme[0-9]n[0-9] \
   ;
 do
   [ -d "$disk" ] || continue

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/dvd/auto.cfg
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/dvd/auto.cfg
@@ -1,11 +1,12 @@
 install
 cdrom
-keyboard us
+keyboard --xlayouts=us
 lang en_US
 
 %include /mnt/install/repo/ks/dvd/include/common_ks_base
 
 %pre
+
 cd /mnt
 # This is a horrible, horrible, hack to work around bugs in Anaconda.
 if [ ! -d source ]; then
@@ -33,7 +34,7 @@ else
 fi
 %end
 
-%post --nochroot --erroronfail
+%post --nochroot --erroronfail --log=/mnt/sysimage/var/log/anaconda/ks-post-nochroot.log
 
 # SOURCE is the DVD; SYSIMAGE is the chroot'd root dir
 SOURCE="/mnt/source"
@@ -103,8 +104,6 @@ else
 fi
 
 # Get the Linux distribution
-# The $1 element of redhat-release is "CentOS" or "Red"
-# The latter is changed to RedHat
 ostype=`$facter operatingsystem`
 rhversion=`$facter operatingsystemrelease`
 majrhversion=`$facter operatingsystemmajrelease`
@@ -120,11 +119,17 @@ if [ $? -ne 0 ]; then
   echo "Run the following commands once the install has completed:" | tee -a ${SYSIMAGE}/root/postinstall.err
   echo -e "\tmount /dev/dvd /media" | tee -a ${SYSIMAGE}/root/postinstall.err
   echo -e "\tcp -a /media/* /media/.discinfo /media/.treeinfo /var/www/yum/$ostype/$rhversion/$htype" | tee -a ${SYSIMAGE}/root/postinstall.err
-  echo -e "\trm -rf /var/www/yum/$ostype/$rhversion/$htype/ks/dvd" | tee -a ${SYSIMAGE}/root/postinstall.err
-  echo -e "\tcp -a /var/www/yum/$ostype/$rhversion/$htype/SIMP /var/www/yum/SIMP" | tee -a ${SYSIMAGE}/root/postinstall.err
-  echo -e "\trm -rf /var/www/yum/$ostype/$rhversion/$htype/SIMP" | tee -a ${SYSIMAGE}/root/postinstall.err
+  echo -e "\tcp -a /var/www/yum/$ostype/$rhversion/$htype/SIMP /var/www/yum" | tee -a ${SYSIMAGE}/root/postinstall.err
   echo -e "\tcp -a /var/www/yum/$ostype/$rhversion/$htype/ks /var/www" | tee -a ${SYSIMAGE}/root/postinstall.err
+  echo -e "\trm -rf /var/www/yum/$ostype/$rhversion/$htype/SIMP" | tee -a ${SYSIMAGE}/root/postinstall.err
   echo -e "\trm -rf /var/www/yum/$ostype/$rhversion/$htype/ks" | tee -a ${SYSIMAGE}/root/postinstall.err
+  echo -e "\trm -rf /var/www/yum/$ostype/$rhversion/$htype/Config" | tee -a ${SYSIMAGE}/root/postinstall.err
+  echo -e "\trm -rf /var/www/yum/$ostype/$rhversion/$htype/*simp_pkglist.txt" | tee -a ${SYSIMAGE}/root/postinstall.err
+  if [ -e RPM-GPG-KEY-SIMP-Dev ]; then
+    echo -e "\tmkdir -p ${SYSIMAGE}/var/www/yum/SIMP-Dev/GPGKEYS" | tee -a ${SYSIMAGE}/root/postinstall.err
+    echo -e "\tmv ${SYSIMAGE}/var/www/yum/$ostype/$rhversion/$htype/RPM-GPG-KEY-SIMP-Dev ${SYSIMAGE}/var/www/yum/SIMP-Dev/GPGKEYS" | tee -a ${SYSIMAGE}/root/postinstall.err
+  fi
+
   echo -e "\tcd /var/www/yum/SIMP/x86_64; for file in ../noarch/*.rpm do; ln -s $file; done;" | tee -a ${SYSIMAGE}/root/postinstall.err
   echo -e "\tcd createrepo .;" | tee -a ${SYSIMAGE}/root/postinstall.err
   echo -e "\tcd /var/www/yum/SIMP/i386; for file in ../noarch/*.rpm do; ln -s $file; done;" | tee -a ${SYSIMAGE}/root/postinstall.err
@@ -137,6 +142,11 @@ else
   rm -rf ${SYSIMAGE}/var/www/yum/$ostype/$rhversion/$htype/ks
   rm -rf ${SYSIMAGE}/var/www/yum/$ostype/$rhversion/$htype/Config
   rm -rf ${SYSIMAGE}/var/www/yum/$ostype/$rhversion/$htype/*simp_pkglist.txt
+
+  if [ -e RPM-GPG-KEY-SIMP-Dev ]; then
+    mkdir -p ${SYSIMAGE}/var/www/yum/SIMP-Dev/GPGKEYS
+    mv ${SYSIMAGE}/var/www/yum/$ostype/$rhversion/$htype/RPM-GPG-KEY-SIMP-Dev ${SYSIMAGE}/var/www/yum/SIMP-Dev/GPGKEYS
+  fi
 fi
 
 if [ ! -d "${SYSIMAGE}/var/www/yum/${ostype}/${majrhversion}" ]; then
@@ -187,7 +197,8 @@ fi
 eject /tmp/cdrom || true
 %end
 
-%post
+%post --log=/var/log/anaconda/ks-post.log
+
 # For the new binaries if they exist
 export PATH=/opt/puppetlabs/bin:$PATH
 
@@ -222,6 +233,7 @@ sed -i 's/--class os/--class os --unrestricted/g' /boot/grub2/grub.cfg
 
 ostype=`facter operatingsystem`
 rhversion=`facter operatingsystemrelease`
+majrhversion=`facter operatingsystemmajrelease`
 htype=`facter architecture`
 
 if [ -d /var/www/yum/SIMP/$htype ]; then
@@ -233,25 +245,46 @@ if [ -d /var/www/yum/SIMP/$htype ]; then
 
   createrepo . >& /dev/null;
 
+  extrakey=''
+  if [ -e /var/www/yum/SIMP-Dev/GPGKEYS/RPM-GPG-KEY-SIMP-Dev ]; then
+    extrakey='file:///var/www/yum/SIMP-Dev/GPGKEYS/RPM-GPG-KEY-SIMP-Dev'
+  fi
+
   cat << EOF >> /etc/yum.repos.d/simp_filesystem.repo
 [flocal-$htype]
 name=Local within the filesystem
 baseurl=file:///var/www/yum/SIMP/$htype
 enabled=1
-gpgcheck=0
+gpgcheck=1
+gpgkey=file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet
+    file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs
+    file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP
+    file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch
+    file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana
+    file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-PGDG-96
+    file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-$majrhversion
+    file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-CentOS-$majrhversion
+    $extrakey
 EOF
 fi
-
-yum clean all;
-yum -y --enablerepo=flocal-noarch --enablerepo=flocal-$htype update;
 
 cat << EOF >> /etc/yum.repos.d/simp_filesystem.repo
 [frhbase]
 name=$ostype $rhversion base repo
 baseurl=file:///var/www/yum/$ostype/$rhversion/$htype
 enabled=1
-gpgcheck=0
+gpgcheck=1
+gpgkey=file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-CentOS-$majrhversion
 EOF
+
+if [ "$ostype" == "CentOS" ]; then
+  sed -i '/enabled=/d' /etc/yum.repos.d/CentOS-Base.repo;
+  sed -i '/\[.*\]/ a\
+enabled=0' /etc/yum.repos.d/CentOS-Base.repo;
+fi
+
+yum clean all;
+yum -y --enablerepo=flocal-$htype --enablerepo=frhbase update;
 
 pass_hash='$6$5SnplwrFxmHy4j/v$WgcZV1.W6/wQq1SJh/gnV7E5Tr1iIuJgdCFmhdlzHnCdWR927Q/Q4eKZXtFAVOY7eNRb3e30ezM5xbmP8G7t50'
 
@@ -275,8 +308,8 @@ done
 simp_opt=`awk -F "simp_opt=" '{print $2}' /proc/cmdline | cut -f1 -d' '`
 
 #Runs a script on startup to retrieve openstack user-data and place it in whatever you specify $udlocation to be
-if [ $simp_opt == "openstack" ]; then
-cat << EOF >> /etc/init.d/user-data
+if [ "$simp_opt" == "openstack" ]; then
+  cat << EOF >> /etc/init.d/user-data
 #!/bin/sh
 udlocation="/var/simp/user-data"
 udaddress="169.254.169.254"
@@ -309,4 +342,8 @@ EOF
    ln -s /etc/init.d/user-data /etc/rc.d/rc3.d/S92user-data
    ln -s /etc/init.d/user-data /etc/rc.d/rc3.d/K92user-data
 fi
+
+# create marker file that indicates a SIMP ISO install
+mkdir -p /etc/simp
+echo "Kickstarted from SIMP ISO" > /etc/simp/.iso_install
 %end

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/dvd/include/common_ks_base
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/dvd/include/common_ks_base
@@ -1,4 +1,4 @@
-authconfig --enableshadow --passalgo=sha512 --enablemd5
+authconfig --enableshadow --passalgo=sha512
 network --nodns --hostname=puppet.change.me
 rootpw --iscrypted $6$3iLC5g2j9z/UvuAX$wKQy4.T92omIx7aEQ6iVunQHSG0l2eVd7be47kUKC2nWFoJhoARx68h8x.jcR99TZZRrFf8SKzVlvK3JdhKkf0
 bootloader --location=mbr --driveorder=sda,hda --iscrypted --password=grub.pbkdf2.sha512.10000.38F6446B9655E8E98CEA82F10EFE4DA30A963932FE415EC72B744FB04EB3636384BD968004B64E5A900CF7D08C9064725A6F2E8246F5874BC4954F9B489D72BA.EE006A76847C20D226064CB77FEC9C697229DE22C5149331425AB3EEBCB99504F712ACBE101D332B35D8A277C7D7E74D8A905C474533A3C7B0428D3BD416382C
@@ -9,14 +9,14 @@ logging --level=info
 selinux --enforcing
 timezone --utc GMT
 
-clearpart --all --initlabel
+clearpart --all
 
 %include /tmp/part-include
 %include /tmp/repo-include
 
 reboot
 
-%packages --nobase
+%packages
 -sendmail
 -sysklogd
 acl

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/dvd/include/min_ks_base
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/dvd/include/min_ks_base
@@ -1,4 +1,4 @@
-authconfig --enableshadow --passalgo=sha512 --enablemd5
+authconfig --enableshadow --passalgo=sha512
 network --bootproto=dhcp --nodns --hostname=puppet.change.me
 skipx
 rootpw --iscrypted $6$3iLC5g2j9z/UvuAX$wKQy4.T92omIx7aEQ6iVunQHSG0l2eVd7be47kUKC2nWFoJhoARx68h8x.jcR99TZZRrFf8SKzVlvK3JdhKkf0
@@ -10,14 +10,14 @@ logging --level=info
 selinux --permissive
 timezone --utc GMT
 
-clearpart --all --initlabel
+clearpart --all
 
 %include /tmp/part-include
 %include /tmp/repo-include
 
 reboot
 
-%packages --nobase
+%packages
 -sendmail
 -sysklogd
 acl

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/dvd/min.cfg
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/dvd/min.cfg
@@ -8,6 +8,7 @@ services --enabled=network,iptables,ip6tables,sssd,rsyslog,sshd --disabled=Netwo
 %include /mnt/install/repo/ks/dvd/include/min_ks_base
 
 %pre
+
 cd /mnt
 # This is a horrible, horrible, hack to work around bugs in Anaconda.
 if [ ! -d source ]; then
@@ -35,7 +36,7 @@ else
 fi
 %end
 
-%post --nochroot --erroronfail
+%post --nochroot --erroronfail --log=/mnt/sysimage/var/log/anaconda/ks-post-nochroot.log
 
 # SOURCE is the DVD; SYSIMAGE is the chroot'd root dir
 SOURCE="/mnt/source"
@@ -89,9 +90,7 @@ if [ -f /boot/disk_creds ]; then
 fi
 %end
 
-%post
-# For the new binaries if they exist
-export PATH=/opt/puppetlabs/bin:$PATH
+%post --log=/var/log/anaconda/ks-post.log
 
 # FIPS
 use_fips=`awk -F "fips=" '{print $2}' /proc/cmdline | cut -f1 -d' '`
@@ -140,5 +139,6 @@ for auth_file in password system; do
     sed -i "/pam_\(pwquality\|cracklib\).so/d" /etc/pam.d/${auth_file}-auth
     # Add our cracklib line
     sed -i "s/\(password.*pam_unix.so.*\)/${pam_mod}\1/" /etc/pam.d/${auth_file}-auth
+  fi
 done
 %end

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -33,13 +33,13 @@ skipx
 %include /tmp/repo-include
 
 text
-keyboard us
+keyboard --xlayouts=us
 lang en_US
 url --noverifyssl --url https://#YUMSERVER#/yum/#LINUXDIST#/7/x86_64
 
 %include /tmp/part-include
 
-%packages --nobase
+%packages
 -sendmail
 -sysklogd
 acl

--- a/spec/acceptance/suites/rpm_docker/nodesets/default.yml
+++ b/spec/acceptance/suites/rpm_docker/nodesets/default.yml
@@ -10,7 +10,11 @@ HOSTS:
     docker_cmd: '/usr/sbin/sshd -D'
     docker_preserve_image: true
     docker_image_commands:
-      # See https://github.com/CentOS/sig-cloud-instance-images/issues/15
+      # The following 3 commands are intended to solve the problem in
+      # https://github.com/CentOS/sig-cloud-instance-images/issues/15.
+      # However, sometimes these commands cause yum problems, instead
+      # of fixing yum problems.  If the install of yum-plugin-ovl and
+      # yum-utils fails, try commenting out these commands.
       - 'rm -f /var/lib/rpm/__db*'
       - 'rpm --rebuilddb'
       - 'yum clean all'
@@ -86,7 +90,11 @@ HOSTS:
     image: centos:6.6
     docker_preserve_image: true
     docker_image_commands:
-      # See https://github.com/CentOS/sig-cloud-instance-images/issues/15
+      # The following 3 commands are intended to solve the problem in
+      # https://github.com/CentOS/sig-cloud-instance-images/issues/15.
+      # However, sometimes these commands cause yum problems, instead
+      # of fixing yum problems.  If the install of yum-plugin-ovl and
+      # yum-utils fails, try commenting out these commands.
       - 'rm -f /var/lib/rpm/__db*'
       - 'rpm --rebuilddb'
       - 'yum clean all'


### PR DESCRIPTION
* Enabled GPG checking for the two repos in
  /etc/yum.repos.d/simp_filesystem.repo
* Other updates/fixes
  - Installed RPM-GPG-KEY-SIMP-Dev in an appropriate place
  - Fixed kickstart scriptlet errors
    - Bash language errors
    - %post yum operations
  - Updated CentOS 7 kickstart files to reflect Kickstart API
    changes/deprecations
  - Adjusted CentOS 6 kickstart files to more closely match
    CentOS 7 kickstart files
  - Added a type of SSSD to the list of devices in diskdetect.sh
  - Removed OBE simp-big and simp-big-disk-crypt options in
    CentOS 7 grub.cfg
  - Added a marker file to indicate when SIMP is installed
    from a SIMP ISO
* Documented a potential Docker container problem and the
  workaround I had to use to build ISOs for CentOS 6.

SIMP-4223 #close
SIMP-4225 #close
SIMP-4226 #close
SIMP-3854 #close SIMP-Dev key installed in appropriate place
SIMP-2953 #comment ISO-install marker file created