### PR TITLE
(SIMP-4217) simp-core: Remove prelink from SIMP ISO

### DIFF
--- a/build/distributions/CentOS/6/x86_64/DVD/6-simp_pkglist.txt
+++ b/build/distributions/CentOS/6/x86_64/DVD/6-simp_pkglist.txt
@@ -896,7 +896,6 @@ postgresql
 postgresql-libs
 postgresql-server
 ppl
-prelink
 procps
 psacct
 psmisc

--- a/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/auto.cfg
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/auto.cfg
@@ -198,10 +198,6 @@ eject /tmp/cdrom || true
 
 %post --log=/var/log/anaconda.post.log
 
-# Turn off prelinking and remove all previous
-sed -i '/PRELINKING=yes/ c\PRELINKING=no' /etc/sysconfig/prelink
-prelink -u -a
-
 export PATH=/opt/puppetlabs/bin:$PATH
 
 # FIPS

--- a/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/include/common_ks_base
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/include/common_ks_base
@@ -109,7 +109,6 @@ hdparm
 kbd
 libhugetlbfs
 policycoreutils
-prelink
 rootfiles
 selinux-policy-targeted
 setserial

--- a/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/include/min_ks_base
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/include/min_ks_base
@@ -90,7 +90,6 @@ hdparm
 kbd
 libhugetlbfs
 policycoreutils
-prelink
 rootfiles
 selinux-policy-targeted
 setserial

--- a/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/min.cfg
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/min.cfg
@@ -92,10 +92,6 @@ fi
 
 %post --log=/var/log/anaconda.post.log
 
-# Turn off prelinking and remove all previous
-sed -i '/PRELINKING=yes/ c\PRELINKING=no' /etc/sysconfig/prelink
-prelink -u -a
-
 # FIPS
 use_fips=`awk -F "fips=" '{print $2}' /proc/cmdline | cut -f1 -d' '`
 

--- a/build/distributions/CentOS/6/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -118,7 +118,6 @@ hdparm
 kbd
 libhugetlbfs
 policycoreutils
-prelink
 rootfiles
 selinux-policy-targeted
 setserial
@@ -195,10 +194,6 @@ ksserver="#KSSERVER#"
 
 ## Comment out/delete the following if you want to disable FIPS compliance. ##
 # FIPS
-
-# Turn off prelinking and remove all previous linking
-sed -i '/PRELINKING=yes/ c\PRELINKING=no' /etc/sysconfig/prelink
-prelink -u -a
 
 if [ -e /sys/firmware/efi ]; then
   BOOTDEV=`df /boot/efi | tail -1 | cut -f1 -d' '`

--- a/build/distributions/CentOS/7/x86_64/DVD/7-simp_pkglist.txt
+++ b/build/distributions/CentOS/7/x86_64/DVD/7-simp_pkglist.txt
@@ -1280,7 +1280,6 @@ postgresql-libs
 postgresql-server
 ppl
 ppp
-prelink
 procps
 procps-ng
 psacct

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/dvd/include/common_ks_base
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/dvd/include/common_ks_base
@@ -96,7 +96,6 @@ hdparm
 kbd
 libhugetlbfs
 policycoreutils
-prelink
 rootfiles
 selinux-policy-targeted
 setserial

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/dvd/include/min_ks_base
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/dvd/include/min_ks_base
@@ -75,7 +75,6 @@ hdparm
 kbd
 libhugetlbfs
 policycoreutils
-prelink
 rootfiles
 selinux-policy-targeted
 setserial

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -111,7 +111,6 @@ hdparm
 kbd
 libhugetlbfs
 policycoreutils
-prelink
 rootfiles
 selinux-policy-targeted
 setserial
@@ -195,10 +194,6 @@ ksserver="#KSSERVER#"
 
 ## Comment out/delete the following if you want to disable FIPS compliance. ##
 # FIPS
-
-# Turn off prelinking and remove all previous linking
-sed -i '/PRELINKING=yes/ c\PRELINKING=no' /etc/sysconfig/prelink
-prelink -u -a
 
 if [ -e /sys/firmware/efi ]; then
   BOOTDEV=`df /boot/efi | tail -1 | cut -f1 -d' '`


### PR DESCRIPTION
Remove installation of prelink by SIMP ISO and the subsequent
OBE prelink disable logic.

SIMP-4217 #comment simp-core prelink removal