### PR TITLE
(SIMP-4319) simp-core: Include grub2-efi-x64 in ISO

### DIFF
--- a/build/distributions/CentOS/7/x86_64/DVD/7-simp_pkglist.txt
+++ b/build/distributions/CentOS/7/x86_64/DVD/7-simp_pkglist.txt
@@ -469,7 +469,7 @@ groff-base
 grub
 grub2
 grub2-common
-grub2-efi
+grub2-efi-x64
 grub2-pc
 grub2-pc-modules
 grub2-tools


### PR DESCRIPTION
Fixed a typo in 7-simp_pkglist.txt.
This package does not apply to RedHat/CentOS 6

SIMP-4319 #close