### PR TITLE
(SIMP-4419) core: Add puppetlabs/mount_providers

### DIFF
--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -94,7 +94,7 @@ mod 'herculesteam-augeasproviders_grub',
 
 mod 'herculesteam-augeasproviders_mounttab',
   :git => 'https://github.com/simp/augeasproviders_mounttab',
-  :tag => '2.0.2'
+  :tag => '2.0.3'
 
 mod 'herculesteam-augeasproviders_nagios',
   :git => 'https://github.com/simp/augeasproviders_nagios',

--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -172,6 +172,10 @@ mod 'puppetlabs-java_ks',
   :git => 'https://github.com/simp/puppetlabs-java_ks',
   :tag => '1.6.0'
 
+mod 'puppetlabs-mount_providers',
+  :git => 'https://github.com/simp/puppetlabs-mount_providers',
+  :tag => '1.0.0'
+
 mod 'puppetlabs-motd',
   :git => 'https://github.com/simp/puppetlabs-motd',
   :tag => '1.7.0'

--- a/build/rpm/dependencies.yaml
+++ b/build/rpm/dependencies.yaml
@@ -49,11 +49,6 @@
 'augeasproviders_apache':
   :release: '2016'
 
-'augeasproviders_mounttab':
-  :release: '2016'
-  :requires:
-    - 'pupmod-puppetlabs-mount_providers'
-
 'augeasproviders_nagios':
   :release: '2016'
 

--- a/build/rpm/dependencies.yaml
+++ b/build/rpm/dependencies.yaml
@@ -51,6 +51,8 @@
 
 'augeasproviders_mounttab':
   :release: '2016'
+  :requires:
+    - 'pupmod-puppetlabs-mount_providers'
 
 'augeasproviders_nagios':
   :release: '2016'
@@ -63,7 +65,6 @@
 
 'docker':
   :requires:
-    # exclude pupmod-stahnma-epel
     # exclude pupmod-puppetlabs-apt
     - 'pupmod-puppetlabs-stdlib'
 

--- a/src/assets/simp/build/simp.spec
+++ b/src/assets/simp/build/simp.spec
@@ -31,6 +31,7 @@ Requires: pupmod-puppetlabs-inifile >= 1.6.0-2016, pupmod-puppetlabs-inifile < 3
 Requires: pupmod-puppetlabs-java >= 1.2.0-2016, pupmod-puppetlabs-java < 2.0.0
 Requires: pupmod-puppetlabs-java_ks >= 1.4.0-2016, pupmod-puppetlabs-java_ks < 2.0.0
 Requires: pupmod-puppetlabs-motd >= 1.4.0-2016, pupmod-puppetlabs-motd < 2.0.0
+Requires: pupmod-puppetlabs-mount_providers >= 1.0.0, pupmod-puppetlabs-mount_providers < 2.0.0
 Requires: pupmod-puppetlabs-postgresql >= 4.8.0, pupmod-puppetlabs-postgresql < 6.0.0
 Requires: pupmod-puppetlabs-puppetdb >= 5.0.0, pupmod-puppetlabs-puppetdb < 7.0.0
 Requires: pupmod-puppetlabs-puppet_authorization >= 0.2.0, pupmod-puppetlabs-puppet_authorization < 1.0.0


### PR DESCRIPTION
- Add the puppetlabs/mount_providers module, required as a depedency for
  herculesteam/augeasproviders_mounttab. The augeasprovider was
  previously non-functional.
- Add puppetlabs/mount_providers as an RPM depedency on
  herculesteam/augeasproviders_mounttab

SIMP-4419 #close