### PR TITLE
(SIMP-4482) Support UEFI PXEboot

### DIFF
--- a/build/distributions/CentOS/6/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -12,11 +12,19 @@
 #
 # To generate the ROOTPASS hash:
 #  > ruby -r 'digest/sha2' -e 'puts "password".crypt("$6$" + rand(36**8).to_s(36))'
+#
+# Optionally:
+# - Adjust the bootloader line for UEFI boot per inline instructions below
+# - Disable FIPS per inline instructions below
 
 authconfig --enableshadow --passalgo=sha512
+
 # anaconda has known issues when fips is turned on during boot, so it (fips=1)  was remove from bootloader line.
 # see url: https://groups.google.com/forum/?fromgroups#!topic/simp-announce/3pBQDZl1OVc
 bootloader --location=mbr --iscrypted --password=#BOOTPASS#
+## Comment out the line above and uncomment the following line to use UEFI boot
+#bootloader --iscrypted --password=#BOOTPASS#
+
 rootpw --iscrypted #ROOTPASS#
 zerombr
 key --skip
@@ -138,7 +146,7 @@ chmod 750 /tmp/repodetect.sh;
 %post --nochroot --erroronfail
 
 # If we dropped a LUKS key-file, we need to copy it into place.
-if [ -f /boot/disk_creds]; then
+if [ -f /boot/disk_creds ]; then
   cp /boot/disk_creds $SYSIMAGE/etc/.cryptcreds
   chown root:root $SYSIMAGE/etc/.cryptcreds
   chmod 400 $SYSIMAGE/etc/.cryptcreds
@@ -192,15 +200,11 @@ if [ $ostype == "CentOS" ]; then
 fi
 ksserver="#KSSERVER#"
 
-## Comment out/delete the following if you want to disable FIPS compliance. ##
-# FIPS
+## Comment out/delete the following block of commands if you want to disable FIPS compliance. ##
+### START FIPS ###
 
-if [ -e /sys/firmware/efi ]; then
-  BOOTDEV=`df /boot/efi | tail -1 | cut -f1 -d' '`
-else
-  BOOTDEV=`df /boot | tail -1 | cut -f1 -d' '`
-fi
 # In case you need a working fallback
+BOOTDEV=`df /boot | tail -1 | cut -f1 -d' '`
 DEFAULT_KERNEL_INFO=`/sbin/grubby --default-kernel`
 DEFAULT_INITRD=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep initrd | cut -f2 -d'='`
 DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 title | cut -f2 -d'='`

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -12,11 +12,18 @@
 #
 # To generate the ROOTPASS hash:
 #  > ruby -r 'digest/sha2' -e 'puts "password".crypt("$6$" + rand(36**8).to_s(36))'
+#
+# Optionally:
+# - Adjust the bootloader line for UEFI boot per inline instructions below
+# - Disable FIPS per inline instructions below
 
 authconfig --enableshadow --passalgo=sha512
 # anaconda has known issues when fips is turned on during boot, so it (fips=1)  was remove from bootloader line.
 # see url: https://groups.google.com/forum/?fromgroups#!topic/simp-announce/3pBQDZl1OVc
 bootloader --location=mbr --iscrypted --password=#BOOTPASS#
+## Comment out the line above and uncomment the following line to use UEFI boot
+#bootloader --iscrypted --password=#BOOTPASS#
+
 rootpw --iscrypted #ROOTPASS#
 zerombr
 firewall --enabled --ssh
@@ -58,6 +65,7 @@ dracut-fips
 fipscheck
 git
 gnupg
+grub2-efi-x64
 iptables
 iptables-ipv6
 irqbalance
@@ -86,6 +94,7 @@ redhat-lsb
 rpm
 rsync
 rsyslog
+shim-x64
 smartmontools
 sssd
 stunnel
@@ -192,15 +201,11 @@ if [ $ostype == "CentOS" ]; then
 fi
 ksserver="#KSSERVER#"
 
-## Comment out/delete the following if you want to disable FIPS compliance. ##
-# FIPS
+## Comment out/delete the following block of commands if you want to disable FIPS compliance. ##
+### START FIPS ###
 
-if [ -e /sys/firmware/efi ]; then
-  BOOTDEV=`df /boot/efi | tail -1 | cut -f1 -d' '`
-else
-  BOOTDEV=`df /boot | tail -1 | cut -f1 -d' '`
-fi
 # In case you need a working fallback
+BOOTDEV=`df /boot | tail -1 | cut -f1 -d' '`
 DEFAULT_KERNEL_INFO=`/sbin/grubby --default-kernel`
 DEFAULT_INITRD=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep initrd | cut -f2 -d'='`
 DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 title | cut -f2 -d'='`


### PR DESCRIPTION
- Added directions/sample code for changes required in order to UEFI PXEboot.
- Added packages for UEFI and secure boot to CentOS 7 client PXEboot configuration.
- Fixed bug in which the boot partition was incorrectly determined
  when booting via UEFI.

SIMP-4482 # comment simp-core pupclient_x86_64.cfg changes