### PR TITLE
(SIMP-4879) Make integration tests more reliable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,9 +31,11 @@ default_el6:
     - beaker
   <<: *cache_bundler
   <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10.7'
   script:
     - bundle exec rake beaker:suites[default,el6_server]
-  retry: 2
+  retry: 1
 
 default_el7:
   stage: integration
@@ -41,9 +43,11 @@ default_el7:
     - beaker
   <<: *cache_bundler
   <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10.7'
   script:
     - bundle exec rake beaker:suites[default,el7_server]
-  retry: 2
+  retry: 1
 
 rpm_el6:
   stage: integration
@@ -51,9 +55,11 @@ rpm_el6:
     - beaker
   <<: *cache_bundler
   <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10.7'
   script:
     - bundle exec rake beaker:suites[install_from_rpm,el6_server]
-  retry: 2
+  retry: 1
 
 rpm_el7:
   stage: integration
@@ -61,9 +67,11 @@ rpm_el7:
     - beaker
   <<: *cache_bundler
   <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10.7'
   script:
     - bundle exec rake beaker:suites[install_from_rpm,el7_server]
-  retry: 2
+  retry: 1
 
 forge_install_el6:
   stage: integration
@@ -71,9 +79,11 @@ forge_install_el6:
     - beaker
   <<: *cache_bundler
   <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10.7'
   script:
     - bundle exec rake beaker:suites[install_from_core_module,el6_server]
-  retry: 2
+  retry: 1
 
 forge_install_el7:
   stage: integration
@@ -81,9 +91,11 @@ forge_install_el7:
     - beaker
   <<: *cache_bundler
   <<: *setup_bundler_env
+  variables:
+    PUPPET_VERSION: '4.10.7'
   script:
     - bundle exec rake beaker:suites[install_from_core_module,el7_server]
-  retry: 2
+  retry: 1
 
 
 # Just gonna comment this one out for now...

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.3', '< 6.
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.9')
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.10')
 end
 
 # nice-to-have gems (for debugging)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
     beaker-aws (0.4.0)
       aws-sdk-v1 (~> 1.57)
       stringify-hash (~> 0.0.0)
-    beaker-docker (0.3.1)
+    beaker-docker (0.3.3)
       docker-api
       stringify-hash (~> 0.0.0)
     beaker-google (0.1.0)
@@ -48,7 +48,7 @@ GEM
       stringify-hash (~> 0.0.0)
     beaker-hiera (0.1.1)
       stringify-hash (~> 0.0.0)
-    beaker-hostgenerator (1.1.9)
+    beaker-hostgenerator (1.1.12)
       deep_merge (~> 1.0)
       stringify-hash (~> 0.0.0)
     beaker-openstack (0.2.0)
@@ -58,7 +58,7 @@ GEM
       in-parallel (~> 0.1)
       oga
       stringify-hash (~> 0.0.0)
-    beaker-puppet_install_helper (0.7.1)
+    beaker-puppet_install_helper (0.9.1)
       beaker (>= 2.0)
     beaker-rspec (6.2.3)
       beaker (~> 3.0)
@@ -89,9 +89,9 @@ GEM
     docker-api (1.34.2)
       excon (>= 0.47.0)
       multi_json
-    domain_name (0.5.20170404)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.2.1)
+    dotenv (2.4.0)
     excon (0.62.0)
     facter (2.5.1)
     faraday (0.13.1)
@@ -139,7 +139,7 @@ GEM
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
-    hiera (3.4.2)
+    hiera (3.4.3)
     hocon (1.2.5)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -172,7 +172,7 @@ GEM
     mini_portile2 (2.3.0)
     minitar (0.6.1)
     minitest (5.11.3)
-    mocha (1.4.0)
+    mocha (1.5.0)
       metaclass (~> 0.0.1)
     multi_json (1.13.1)
     multipart-post (2.0.0)
@@ -183,7 +183,7 @@ GEM
     netrc (0.11.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
-    oga (2.14)
+    oga (2.15)
       ast
       ruby-ll (~> 2.1)
     open_uri_redirections (0.2.1)
@@ -198,11 +198,11 @@ GEM
     pry-byebug (3.4.3)
       byebug (>= 9.0, < 9.1)
       pry (~> 0.10)
-    pry-doc (0.13.3)
+    pry-doc (0.13.4)
       pry (~> 0.11)
       yard (~> 0.9.11)
     public_suffix (3.0.2)
-    puppet (4.10.10)
+    puppet (4.10.7)
       facter (> 2.0, < 4)
       gettext-setup (>= 0.10, < 1)
       hiera (>= 2.0, < 4)
@@ -223,7 +223,7 @@ GEM
       gettext-setup (~> 0.11)
       minitar
       semantic_puppet (~> 1.0)
-    puppetlabs_spec_helper (2.6.2)
+    puppetlabs_spec_helper (2.7.0)
       mocha (~> 1.0)
       puppet-lint (~> 2.0)
       puppet-syntax (~> 2.0)
@@ -244,7 +244,7 @@ GEM
       ffi
     rbnacl-libsodium (1.0.15.1)
       rbnacl (>= 3.0.1)
-    rbvmomi (1.11.7)
+    rbvmomi (1.12.0)
       builder (~> 3.0)
       json (>= 1.8)
       nokogiri (~> 1.5)
@@ -295,7 +295,7 @@ GEM
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    simp-beaker-helpers (1.10.3)
+    simp-beaker-helpers (1.10.5)
       beaker (~> 3.14)
       beaker-puppet (~> 0.8.0)
       beaker-puppet_install_helper (~> 0.6)
@@ -324,7 +324,7 @@ GEM
       json (~> 1)
       rspec-puppet-facts (~> 0)
     spdx-licenses (1.1.0)
-    specinfra (2.73.2)
+    specinfra (2.73.3)
       net-scp
       net-ssh (>= 2.7, < 5.0)
       net-telnet
@@ -354,7 +354,7 @@ DEPENDENCIES
   parallel
   pry
   pry-doc
-  puppet (~> 4.0)
+  puppet (= 4.10.7)
   puppet-lint
   puppet-strings
   puppetlabs_spec_helper
@@ -362,7 +362,7 @@ DEPENDENCIES
   rbnacl (~> 3.4.0)
   rbnacl-libsodium (~> 1.0.15.1)
   ruby-progressbar
-  simp-beaker-helpers (~> 1.9)
+  simp-beaker-helpers (~> 1.10)
   simp-build-helpers (>= 0.1.0)
   simp-rake-helpers (>= 5.3, < 6.0)
 

--- a/spec/acceptance/suites/default/01_simp_server_bootstrap_spec.rb
+++ b/spec/acceptance/suites/default/01_simp_server_bootstrap_spec.rb
@@ -118,7 +118,7 @@ describe 'install puppetserver from puppet modules' do
       it "should run puppet on #{agent}" do
         # Run puppet and expect changes
         retry_on(agent, 'puppet agent -t',
-          :desired_exit_codes => [0,2],
+          :desired_exit_codes => [0],
           :retry_interval     => 15,
           :max_retries        => 5,
           :verbose            => true
@@ -131,8 +131,8 @@ describe 'install puppetserver from puppet modules' do
 
         # Wait for things to settle and stop making changes
         retry_on(agent, 'puppet agent -t',
-          :desired_exit_codes => [0,2],
-          :retry_interval     => 20,
+          :desired_exit_codes => [0],
+          :retry_interval     => 15,
           :max_retries        => 3,
           :verbose            => true
         )

--- a/spec/acceptance/suites/default/01_simp_server_bootstrap_spec.rb
+++ b/spec/acceptance/suites/default/01_simp_server_bootstrap_spec.rb
@@ -118,7 +118,7 @@ describe 'install puppetserver from puppet modules' do
       it "should run puppet on #{agent}" do
         # Run puppet and expect changes
         retry_on(agent, 'puppet agent -t',
-          :desired_exit_codes => [0],
+          :desired_exit_codes => [0,2],
           :retry_interval     => 15,
           :max_retries        => 5,
           :verbose            => true

--- a/spec/acceptance/suites/default/01_simp_server_bootstrap_spec.rb
+++ b/spec/acceptance/suites/default/01_simp_server_bootstrap_spec.rb
@@ -8,12 +8,22 @@ describe 'install puppetserver from puppet modules' do
 
   agents      = hosts_with_role(hosts, 'agent')
   master_fqdn = fact_on(master, 'fqdn')
+  puppetserver_status_cmd = [
+    'curl -sk',
+    "--cert /etc/puppetlabs/puppet/ssl/certs/#{master_fqdn}.pem",
+    "--key /etc/puppetlabs/puppet/ssl/private_keys/#{master_fqdn}.pem",
+    "https://#{master_fqdn}:8140/status/v1/services",
+    '| python -m json.tool',
+    '| grep state',
+    '| grep running'
+  ].join(' ')
 
   master_manifest = <<-EOF
     # Use our puppet module to set up puppetserver
     class { 'pupmod::master':
       firewall     => true,
       trusted_nets => ['0.0.0.0/0'],
+      log_level    => 'INFO'
     }
     # pupmod::master::autosign { '*': entry => '*' }
     exec { 'set autosign':
@@ -59,10 +69,12 @@ describe 'install puppetserver from puppet modules' do
     site_pp = <<-EOF
       # All nodes
       node default {
+        include 'simp_options'
         include 'simp'
       }
       # The puppetserver
       node /puppet/ {
+        include 'simp_options'
         include 'simp'
         include 'simp::server'
         include 'pupmod'
@@ -70,44 +82,40 @@ describe 'install puppetserver from puppet modules' do
       }
     EOF
 
-    yaml = YAML.load(File.read('spec/acceptance/suites/default/files/default.yaml'))
+    yaml         = YAML.load(File.read('spec/acceptance/suites/default/files/default.yaml'))
     default_yaml = yaml.merge(
       'simp_options::puppet::server' => master_fqdn,
       'simp_options::puppet::ca'     => master_fqdn,
       'simp::yum::servers'           => [master_fqdn]
-    )
+    ).to_yaml
 
     it 'should install the control repo' do
       on(master, 'mkdir -p /etc/puppetlabs/code/environments/production/{hieradata,manifests} /var/simp/environments/production/{simp_autofiles,site_files/modules/pki_files/files/keydist}')
+
       scp_to(master, 'spec/acceptance/suites/default/files/hiera.yaml', '/etc/puppetlabs/puppet/hiera.yaml')
       create_remote_file(master, '/etc/puppetlabs/code/environments/production/manifests/site.pp', site_pp)
-      create_remote_file(master, '/etc/puppetlabs/code/environments/production/hieradata/default.yaml', default_yaml.to_yaml)
+      create_remote_file(master, '/etc/puppetlabs/code/environments/production/hieradata/default.yaml', default_yaml)
+
       on(master, 'chown -R root.puppet /etc/puppetlabs/code/environments/production/{hieradata,manifests} /var/simp/environments/production/site_files/modules/pki_files/files/keydist')
       on(master, 'chmod -R g+rX /etc/puppetlabs/code/environments/production/{hieradata,manifests} /var/simp/environments/production/site_files/modules/pki_files/files/keydist')
       on(master, 'chown -R puppet.puppet /var/simp/environments/production/simp_autofiles')
+
+      on(master, 'puppet resource service puppetserver ensure=stopped')
       on(master, 'puppet resource service puppetserver ensure=running')
 
       on(master, 'puppet generate types', :accept_all_exit_codes => true)
+      retry_on(master, puppetserver_status_cmd, :retry_interval => 10)
     end
   end
 
   context 'agents' do
     agents.each do |agent|
-      it 'should configure the agent' do
+      it "should configure puppet on host #{agent}" do
         on(agent, "puppet config set server #{master_fqdn}")
         on(agent, 'puppet config set masterport 8140')
         on(agent, 'puppet config set ca_port 8141')
       end
-      it "should run the agent on #{agent}" do
-        # In the install_from_core_module test, pluginsync causes a failure here
-        #   due to https://github.com/voxpupuli/puppet-archive/issues/320
-        #   puppet/archive is not typically in the SIMP distro
-        # Also get a cert and sign it
-        Simp::TestHelpers.wait(30)
-        on(agent, 'puppet agent -t --noop', :acceptable_exit_codes => [0,1,4])
-        on(agent, 'puppet agent -t --noop', :acceptable_exit_codes => [0,1,4])
-        Simp::TestHelpers.wait(30)
-
+      it "should run puppet on #{agent}" do
         # Run puppet and expect changes
         retry_on(agent, 'puppet agent -t',
           :desired_exit_codes => [0,2],
@@ -116,14 +124,15 @@ describe 'install puppetserver from puppet modules' do
           :verbose            => true
         )
 
+        # Reboot and wait for machine to come back up
         agent.reboot
-        # Wait for machine to come back up
+        retry_on(master, puppetserver_status_cmd, :retry_interval => 10)
         retry_on(agent, 'uptime', :retry_interval => 15 )
 
         # Wait for things to settle and stop making changes
         retry_on(agent, 'puppet agent -t',
           :desired_exit_codes => [0,2],
-          :retry_interval     => 15,
+          :retry_interval     => 20,
           :max_retries        => 3,
           :verbose            => true
         )

--- a/spec/acceptance/suites/default/02_simp_server_rsync_spec.rb
+++ b/spec/acceptance/suites/default/02_simp_server_rsync_spec.rb
@@ -67,8 +67,8 @@ describe 'install rsync from GitHub (not rpm) and test simp::server::rsync_share
     agents.each do |agent|
       it "should run puppet on #{agent}" do
         retry_on(agent, 'puppet agent -t',
-          :desired_exit_codes => [0,2],
-          :retry_interval     => 20,
+          :desired_exit_codes => [0],
+          :retry_interval     => 15,
           :max_retries        => 3,
           :verbose            => true
         )

--- a/spec/acceptance/suites/default/02_simp_server_rsync_spec.rb
+++ b/spec/acceptance/suites/default/02_simp_server_rsync_spec.rb
@@ -36,45 +36,42 @@ describe 'install rsync from GitHub (not rpm) and test simp::server::rsync_share
       end
       it 'should mock freshclam' do
         master.install_package('clamav-update')
-        # create_remote_file(master, '/tmp/freshclam.conf', <<-EOF.gsub(/^\s+/,'')
-        #     DatabaseDirectory /var/simp/environments/production/rsync/Global/clamav
-        #     DatabaseMirror database.clamav.net
-        #     Bytecode yes
-        #   EOF
-        # )
-        # on(master, 'freshclam -u root --config-file=/tmp/freshclam.conf')
+        ## # Uncomment to use real FreshClam data from the internet
+        ## create_remote_file(master, '/tmp/freshclam.conf', <<-EOF.gsub(/^\s+/,'')
+        ##     DatabaseDirectory /var/simp/environments/production/rsync/Global/clamav
+        ##     DatabaseMirror database.clamav.net
+        ##     Bytecode yes
+        ##   EOF
+        ## )
+        ## on(master, 'freshclam -u root --config-file=/tmp/freshclam.conf')
+        ## on(master, 'chown clam.clam /var/simp/environments/production/rsync/Global/clamav/*')
+        ## on(master, 'chmod u=rw,g=rw,o=r /var/simp/environments/production/rsync/Global/clamav/*')
+
+        # Mock ClamAV data by just `touch`ing the data files
         on(master, 'touch /var/simp/environments/production/rsync/Global/clamav/{daily,bytecode,main}.cvd')
-        # on(master, 'chown clam.clam /var/simp/environments/production/rsync/Global/clamav/*')
-        # on(master, 'chmod u=rw,g=rw,o=r /var/simp/environments/production/rsync/Global/clamav/*')
       end
 
-      it 'classify nodes' do
+      it 'modify the existing hieradata' do
         hiera = YAML.load(on(master, 'cat /etc/puppetlabs/code/environments/production/hieradata/default.yaml').stdout)
         default_yaml = hiera.merge(
-          'simp_options::rsync' => true,
+          'simp_options::rsync'  => true,
           'simp_options::clamav' => true,
           'simp::scenario::base::rsync_stunnel' => master_fqdn
-        )
-        create_remote_file(master, '/etc/puppetlabs/code/environments/production/hieradata/default.yaml', default_yaml.to_yaml)
-      end
-      it 'should configure the system' do
-        on(master, 'puppet agent -t', :acceptable_exit_codes => [0,2,4,6])
-        on(master, 'puppet agent -t', :acceptable_exit_codes => [0,2])
-      end
-      it 'should be idempotent' do
-        on(master, 'puppet agent -t', :acceptable_exit_codes => [0])
+        ).to_yaml
+        create_remote_file(master, '/etc/puppetlabs/code/environments/production/hieradata/default.yaml', default_yaml)
       end
     end
   end
 
   context 'agents' do
     agents.each do |agent|
-      it 'should configure the system' do
-        on(agent, 'puppet agent -t', :acceptable_exit_codes => [0,2,4,6])
-        on(agent, 'puppet agent -t', :acceptable_exit_codes => [0,2])
-      end
-      it 'should be idempotent' do
-        on(agent, 'puppet agent -t', :acceptable_exit_codes => [0])
+      it "should run puppet on #{agent}" do
+        retry_on(agent, 'puppet agent -t',
+          :desired_exit_codes => [0,2],
+          :retry_interval     => 20,
+          :max_retries        => 3,
+          :verbose            => true
+        )
       end
     end
   end

--- a/spec/acceptance/suites/default/03_simp_server_ldap_spec.rb
+++ b/spec/acceptance/suites/default/03_simp_server_ldap_spec.rb
@@ -4,9 +4,8 @@ require 'yaml'
 test_name 'simp::server::ldap'
 
 describe 'use the simp::server::ldap class to create and ldap environment' do
-  masters     = hosts_with_role(hosts, 'master')
-  agents      = hosts_with_role(hosts, 'agent')
-  # master_fqdn = fact_on(master, 'fqdn')
+  masters = hosts_with_role(hosts, 'master')
+  agents  = hosts_with_role(hosts, 'agent')
 
   context 'master' do
     masters.each do |master|
@@ -33,31 +32,22 @@ describe 'use the simp::server::ldap class to create and ldap environment' do
           'simp_options::sssd' => true,
           'simp_openldap::server::conf::rootpw' => 's00persekr3t!',
           # 'simp_options::ldap::uri' => ['ldap://#{master_fqdn}']
-        )
+        ).to_yaml
         create_remote_file(master, '/etc/puppetlabs/code/environments/production/manifests/site.pp', site_pp)
-        create_remote_file(master, '/etc/puppetlabs/code/environments/production/hieradata/default.yaml', default_yaml.to_yaml)
-      end
-
-      it 'should configure the system' do
-        on(master, 'puppet agent -t', :acceptable_exit_codes => [0,2,4,6])
-        Simp::TestHelpers.wait(30)
-        retry_on(master, 'puppet agent -t', :desired_exit_codes => [0,2], :max_retries => 3, :retry_interval => 20)
-      end
-
-      it 'should be idempotent' do
-        on(master, 'puppet agent -t', :acceptable_exit_codes => [0])
+        create_remote_file(master, '/etc/puppetlabs/code/environments/production/hieradata/default.yaml', default_yaml)
       end
     end
   end
 
   context 'agents' do
     agents.each do |agent|
-      it 'should configure the system' do
-        on(agent, 'puppet agent -t', :acceptable_exit_codes => [0,2,4,6])
-        on(agent, 'puppet agent -t', :acceptable_exit_codes => [0,2])
-      end
-      it 'should be idempotent' do
-        on(agent, 'puppet agent -t', :acceptable_exit_codes => [0])
+      it "should run puppet on #{agent}" do
+        retry_on(agent, 'puppet agent -t',
+          :desired_exit_codes => [0,2],
+          :retry_interval     => 20,
+          :max_retries        => 3,
+          :verbose            => true
+        )
       end
     end
   end

--- a/spec/acceptance/suites/default/03_simp_server_ldap_spec.rb
+++ b/spec/acceptance/suites/default/03_simp_server_ldap_spec.rb
@@ -43,8 +43,8 @@ describe 'use the simp::server::ldap class to create and ldap environment' do
     agents.each do |agent|
       it "should run puppet on #{agent}" do
         retry_on(agent, 'puppet agent -t',
-          :desired_exit_codes => [0,2],
-          :retry_interval     => 20,
+          :desired_exit_codes => [0],
+          :retry_interval     => 15,
           :max_retries        => 3,
           :verbose            => true
         )

--- a/spec/acceptance/suites/default/files/default.yaml
+++ b/spec/acceptance/suites/default/files/default.yaml
@@ -16,6 +16,7 @@ simp_options::selinux: true
 simp_options::stunnel: true
 simp_options::tcpwrappers: true
 simp_options::firewall: true
+simp_options::package_ensure: installed
 sssd::domains: ['LOCAL']
 
 # Settings required for acceptance test, some may be required
@@ -27,6 +28,8 @@ simp_options::trusted_nets: ['0.0.0.0/0']
 simp::yum::os_update_url: http://mirror.centos.org/centos/$releasever/os/$basearch/
 simp::yum::enable_simp_repos: false
 simp::scenario::base::puppet_server_hosts_entry: false
+
+pupmod::master::log_level: INFO
 # Make sure puppet doesn't run (hopefully)
 pupmod::agent::cron::minute: '0'
 pupmod::agent::cron::hour: '0'

--- a/spec/acceptance/suites/default/nodesets/default.yml
+++ b/spec/acceptance/suites/default/nodesets/default.yml
@@ -1,0 +1,1 @@
+el7_server.yml

--- a/spec/acceptance/suites/default/nodesets/el6_server.yml
+++ b/spec/acceptance/suites/default/nodesets/el6_server.yml
@@ -9,7 +9,7 @@ HOSTS:
     platform:   el-6-x86_64
     box:        centos/6
     hypervisor: vagrant
-    vagrant_memsize: 4096
+    vagrant_memsize: 4608
     vagrant_cpus: 2
   agent-el7:
     roles:

--- a/spec/acceptance/suites/default/nodesets/el7_server.yml
+++ b/spec/acceptance/suites/default/nodesets/el7_server.yml
@@ -9,7 +9,7 @@ HOSTS:
     platform:   el-7-x86_64
     box:        centos/7
     hypervisor: vagrant
-    vagrant_memsize: 4096
+    vagrant_memsize: 4608
     vagrant_cpus: 2
   agent-el7:
     roles:

--- a/spec/acceptance/suites/install_from_core_module/00_simp_server_install_spec.rb
+++ b/spec/acceptance/suites/install_from_core_module/00_simp_server_install_spec.rb
@@ -5,7 +5,7 @@ test_name 'puppetserver module install via PuppetForge'
 
 describe 'install puppetserver modules from PuppetForge' do
 
-  masters     = hosts_with_role(hosts, 'master')
+  masters = hosts_with_role(hosts, 'master')
 
   hosts.each do |host|
     it 'should set the root password' do

--- a/spec/acceptance/suites/install_from_rpm/01_simp_server_spec.rb
+++ b/spec/acceptance/suites/install_from_rpm/01_simp_server_spec.rb
@@ -8,10 +8,19 @@ describe 'install SIMP via rpm' do
 
   use_puppet_repo = ENV['BEAKER_puppet_repo'] || true
 
-  masters = hosts_with_role(hosts, 'master')
-  agents  = hosts_with_role(hosts, 'agent')
-  let(:domain)      { fact_on(master, 'domain') }
-  let(:master_fqdn) { fact_on(master, 'fqdn') }
+  masters     = hosts_with_role(hosts, 'master')
+  agents      = hosts_with_role(hosts, 'agent')
+  domain      = fact_on(master, 'domain')
+  master_fqdn = fact_on(master, 'fqdn')
+  puppetserver_status_cmd = [
+    'curl -sk',
+    "--cert /etc/puppetlabs/puppet/ssl/certs/#{master_fqdn}.pem",
+    "--key /etc/puppetlabs/puppet/ssl/private_keys/#{master_fqdn}.pem",
+    "https://#{master_fqdn}:8140/status/v1/services",
+    '| python -m json.tool',
+    '| grep state',
+    '| grep running'
+  ].join(' ')
 
   hosts.each do |host|
     it 'should set the root password' do
@@ -73,17 +82,16 @@ describe 'install SIMP via rpm' do
         on(master, 'simp bootstrap --no-verbose -u --remove_ssldir > /dev/null')
       end
 
-      it 'should reboot the host' do
+      it 'should reboot the master' do
         master.reboot
-        sleep(240)
+        retry_on(master, puppetserver_status_cmd, :retry_interval => 10)
       end
 
       it 'should settle after reboot' do
         on(master, '/opt/puppetlabs/bin/puppet agent -t', :acceptable_exit_codes => [0,2,4,6])
-      end
-      it 'should have puppet runs with no changes' do
         on(master, '/opt/puppetlabs/bin/puppet agent -t', :acceptable_exit_codes => [0] )
       end
+
       it 'should generate agent certs' do
         togen = []
         agents.each do |agent|
@@ -97,20 +105,20 @@ describe 'install SIMP via rpm' do
 
   context 'agents' do
     agents.each do |agent|
-      it 'should install the agent' do
+      it "should install puppet and deps on #{agent}" do
         agent.install_package('epel-release')
         agent.install_package('puppet-agent')
         agent.install_package('net-tools')
         setup_repo(agent)
       end
 
-      it 'should configure the agent' do
+      it "should configure puppet on host #{agent}" do
         on(agent, "puppet config set server #{master_fqdn}")
         on(agent, 'puppet config set masterport 8140')
         on(agent, 'puppet config set ca_port 8141')
       end
 
-      it 'should run the agent' do
+      it "should run puppet on #{agent}" do
         # Run puppet and expect changes
         retry_on(agent, 'puppet agent -t',
           :desired_exit_codes => [0,2],
@@ -119,10 +127,12 @@ describe 'install SIMP via rpm' do
           :verbose            => true
         )
 
-        agent.reboot
         # Wait for machine to come back up
+        agent.reboot
+        retry_on(master, puppetserver_status_cmd, :retry_interval => 10)
         retry_on(agent, 'uptime', :retry_interval => 15 )
 
+        # Wait for things to settle and stop making changes
         retry_on(agent, '/opt/puppetlabs/bin/puppet agent -t',
           :desired_exit_codes => [0,2],
           :retry_interval     => 15,

--- a/spec/acceptance/suites/install_from_tar/01_simp_server_spec.rb
+++ b/spec/acceptance/suites/install_from_tar/01_simp_server_spec.rb
@@ -140,7 +140,7 @@ describe 'install SIMP via tarball' do
       it "should run puppet on #{agent}" do
         # Run puppet and expect changes
         retry_on(agent, 'puppet agent -t',
-          :desired_exit_codes => [0,2],
+          :desired_exit_codes => [0],
           :retry_interval     => 15,
           :max_retries        => 5,
           :verbose            => true
@@ -153,7 +153,7 @@ describe 'install SIMP via tarball' do
 
         # Wait for things to settle and stop making changes
         retry_on(agent, 'puppet agent -t',
-          :desired_exit_codes => [0,2],
+          :desired_exit_codes => [0],
           :retry_interval     => 15,
           :max_retries        => 3,
           :verbose            => true

--- a/spec/acceptance/suites/install_from_tar/01_simp_server_spec.rb
+++ b/spec/acceptance/suites/install_from_tar/01_simp_server_spec.rb
@@ -8,12 +8,21 @@ describe 'install SIMP via tarball' do
 
   use_puppet_repo = ENV['BEAKER_puppet_repo'] || true
 
-  masters = hosts_with_role(hosts, 'master')
-  agents  = hosts_with_role(hosts, 'agent')
-  let(:domain)      { fact_on(master, 'domain') }
-  let(:master_fqdn) { fact_on(master, 'fqdn') }
-  let(:majver)      { fact_on(master, 'operatingsystemmajrelease') }
-  let(:osname)      { fact_on(master, 'operatingsystem') }
+  masters     = hosts_with_role(hosts, 'master')
+  agents      = hosts_with_role(hosts, 'agent')
+  domain      = fact_on(master, 'domain')
+  master_fqdn = fact_on(master, 'fqdn')
+  let(:majver) { fact_on(master, 'operatingsystemmajrelease') }
+  let(:osname) { fact_on(master, 'operatingsystem') }
+  puppetserver_status_cmd = [
+    'curl -sk',
+    "--cert /etc/puppetlabs/puppet/ssl/certs/#{master_fqdn}.pem",
+    "--key /etc/puppetlabs/puppet/ssl/private_keys/#{master_fqdn}.pem",
+    "https://#{master_fqdn}:8140/status/v1/services",
+    '| python -m json.tool',
+    '| grep state',
+    '| grep running'
+  ].join(' ')
 
   hosts.each do |host|
     it 'should set the root password' do
@@ -89,21 +98,19 @@ describe 'install SIMP via tarball' do
       it 'should run simp bootstrap' do
         # Remove the lock file because we've already added the vagrant user stuff
         on(master, 'rm -f /root/.simp/simp_bootstrap_start_lock')
-
         on(master, 'simp bootstrap --no-verbose -u --remove_ssldir > /dev/null')
       end
 
       it 'should reboot the host' do
         master.reboot
-        sleep(240)
+        retry_on(master, puppetserver_status_cmd, :retry_interval => 10)
       end
 
       it 'should settle after reboot' do
         on(master, '/opt/puppetlabs/bin/puppet agent -t', :acceptable_exit_codes => [0,2,4,6])
-      end
-      it 'should have puppet runs with no changes' do
         on(master, '/opt/puppetlabs/bin/puppet agent -t', :acceptable_exit_codes => [0] )
       end
+
       it 'should generate agent certs' do
         togen = []
         agents.each do |agent|
@@ -117,20 +124,20 @@ describe 'install SIMP via tarball' do
 
   context 'agents' do
     agents.each do |agent|
-      it 'should install the agent' do
+      it "should install puppet and deps on #{agent}" do
         agent.install_package('epel-release')
         agent.install_package('puppet-agent')
         agent.install_package('net-tools')
         internet_deprepo(agent)
       end
 
-      it 'should configure the agent' do
+      it "should configure puppet on host #{agent}" do
         on(agent, "puppet config set server #{master_fqdn}")
         on(agent, 'puppet config set masterport 8140')
         on(agent, 'puppet config set ca_port 8141')
       end
 
-      it 'should run the agent' do
+      it "should run puppet on #{agent}" do
         # Run puppet and expect changes
         retry_on(agent, 'puppet agent -t',
           :desired_exit_codes => [0,2],
@@ -139,11 +146,13 @@ describe 'install SIMP via tarball' do
           :verbose            => true
         )
 
-        agent.reboot
         # Wait for machine to come back up
+        agent.reboot
+        retry_on(master, puppetserver_status_cmd, :retry_interval => 10)
         retry_on(agent, 'uptime', :retry_interval => 15 )
 
-        retry_on(agent, '/opt/puppetlabs/bin/puppet agent -t',
+        # Wait for things to settle and stop making changes
+        retry_on(agent, 'puppet agent -t',
           :desired_exit_codes => [0,2],
           :retry_interval     => 15,
           :max_retries        => 3,


### PR DESCRIPTION
Previously, the beaker suite integration tests were not reliable. This
commit reworked sections to minimize failures and make sure that they
can be used to test changes to our codebase.

* Check puppetserver status before running the agent
* Use a retry_on loop to see how many times it takes to become
  idempotent
* Set simp_options::package_ensure
* Set PUPPET_VERSION in CI to 4.7.1
* General code cleanup

SIMP-4879 #close