### PR TITLE
(SIMP-4925) Remove puppet-archive from SIMP ISO and RPMs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       json (~> 1.4)
       nokogiri (~> 1)
     bcrypt_pbkdf (1.0.0)
-    beaker (3.34.0)
+    beaker (3.35.0)
       beaker-abs (~> 0.4)
       beaker-aws (~> 0.1)
       beaker-docker (~> 0.1)
@@ -58,14 +58,14 @@ GEM
       in-parallel (~> 0.1)
       oga
       stringify-hash (~> 0.0.0)
-    beaker-puppet_install_helper (0.9.1)
+    beaker-puppet_install_helper (0.9.4)
       beaker (>= 2.0)
     beaker-rspec (6.2.3)
       beaker (~> 3.0)
       rspec (~> 3.0)
       serverspec (~> 2)
       specinfra (~> 2)
-    beaker-vagrant (0.4.0)
+    beaker-vagrant (0.5.0)
       stringify-hash (~> 0.0.0)
     beaker-vcloud (0.2.0)
       beaker-vmpooler
@@ -202,7 +202,7 @@ GEM
       pry (~> 0.11)
       yard (~> 0.9.11)
     public_suffix (3.0.2)
-    puppet (4.10.7)
+    puppet (4.10.11)
       facter (> 2.0, < 4)
       gettext-setup (>= 0.10, < 1)
       hiera (>= 2.0, < 4)
@@ -212,7 +212,7 @@ GEM
       puppet (>= 2.7.16)
       rest-client (~> 1.8.0)
     puppet-lint (2.3.5)
-    puppet-strings (1.2.1)
+    puppet-strings (2.0.0)
       rgen
       yard (~> 0.9.5)
     puppet-syntax (2.4.1)
@@ -295,7 +295,7 @@ GEM
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    simp-beaker-helpers (1.10.5)
+    simp-beaker-helpers (1.10.7)
       beaker (~> 3.14)
       beaker-puppet (~> 0.8.0)
       beaker-puppet_install_helper (~> 0.6)
@@ -354,7 +354,7 @@ DEPENDENCIES
   parallel
   pry
   pry-doc
-  puppet (= 4.10.7)
+  puppet (~> 4.0)
   puppet-lint
   puppet-strings
   puppetlabs_spec_helper

--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -507,10 +507,6 @@ mod 'trlinkin-nsswitch',
   :git => 'https://github.com/simp/puppet-nsswitch',
   :ref => 'f1d51eeecf3d95a3d38562a50743ee7c915d0624'
 
-mod 'voxpupuli-archive',
-  :git => 'https://github.com/simp/puppet-archive',
-  :tag => 'v1.3.0'
-
 mod 'voxpupuli-yum',
   :git => 'https://github.com/simp/voxpupuli-yum',
   :tag => 'v2.1.0'

--- a/build/rpm/dependencies.yaml
+++ b/build/rpm/dependencies.yaml
@@ -1,18 +1,30 @@
-# This file holds a list of RPM dependencies/obsoletes that apply
-# to Puppet module RPMs.  Module entries in this file are needed when
-# any of the following conditions occur:
+# This file holds a list of RPM dependencies/obsoletes/releases/external
+# dependencies that apply to Puppet module RPMs.  Module entries in this
+# file are needed when any of the following conditions occur:
 #
-# (1) We need to specify an obsoletes.
+# (1) We need to specify a release qualifier (package version).
+#     - This is necessary for components that have not changed since
+#       they were released with a release version of '2016', the
+#       default release version used when building SIMP-6.0.0 RPMs.
+#       (The current default is '0'.)
+#     - This is necessary when we need to specify RPM metadata-only
+#       package changes, such as a change in puppet module
+#       dependencies, obsoletes, or external dependencies.
+#
+# (2) We need to specify an obsoletes.
 #     This is required when a project has changed owner and
 #     the RPM name will change from pupmod-<old owner>-<module name>
 #     to pupmod-<new owner>-<module name>.
 #
-# (2) We want to restrict the depedencies.
+# (3) We want to restrict the dependencies.
 #     This is useful when modules require modules for OS's other
 #     than RedHat/CentOS or require modules that conflict with SIMP
 #     capabilities. We don't really need the dependencies in this
 #     case, and excluding them has no impact on SIMP system
 #     operations.
+#
+# (4) We want to add external dependencies, i.e., dependencies
+#     that are not Puppet modules.
 #
 # For all modules listed in this file,
 # * The RPM obsoletes will be pulled from this file.
@@ -25,9 +37,28 @@
 # * Both the RPM dependency names and versions will be pulled
 #   from the metadata.json file in the module.
 #
-# NOTE: This file is only used for simp-rake-helpers >= 5.3.0
+# IMPORTANT ADDITIONAL NOTES:
+# (1) One of the main reasons this global file exists, instead of
+#     storing this information in each project, itself, is because we
+#     need to build RPMs of non-SIMP components from their respective
+#     GitHub projects. Maintaining this information in SIMP-owned
+#     forks of non SIMP-components has shown to be untenable.
+#
+# (2) Any time the version of a non-SIMP component changes, you **MUST**
+#     evaluate if that change results in the addition of, removal of,
+#     or change to an entry in this file.
+#
+# (3) Each entry **MUST** remain in this file until a newer version
+#     of the component is to be released.  This is because the
+#     ISO-building process may create a different RPM for the same
+#     version of this component, potentially with incorrect RPM
+#     metadata, instead of using the existing, released RPM.
+#
+# (4) This file is only used for simp-rake-helpers >= 5.3.0
 ---
 
+# This entry can be removed when the augeasproviders_nagios version
+# used advances beyond 2.0.2.
 'augeasproviders_nagios':
   :release: '2016'
 
@@ -52,25 +83,37 @@
     - 'pupmod-puppetlabs-stdlib'
     - 'pupmod-puppet-yum'
 
-'file_concat':
-  :release: '2016'
-
 'gitlab':
   :requires:
     # exclude pupmod-puppetlabs-apt
     - 'pupmod-puppetlabs-stdlib'
 
-# Make sure we create an RPM that fixes the obsoletes problem of
-# pupmod-puppet-grafana-3.0.0-0 packaged for SIMP 6.1.0.
-# Since we are releasing a newer version, 4.1.1-0, we can fix
-# the problem by using the same obsoletes, here, but a newer
-# version of simp-rake-helpers.
+# Three adjustments required for the next 4.1.1 release:
+# (1) (NEW) Up the release qualifier to '1', since 4.1.1-0 was already
+#     released and the change from 4.1.1-0 to 4.1.1-1 is simply a
+#     packaging change,(i.e., dependencies list change).
+# (2) As with 4.1.1-0, make sure we create an RPM that fixes
+#     the obsoletes problem of pupmod-puppet-grafana-3.0.0-0
+#     packaged for SIMP 6.1.0.
+# (3) (NEW) Exclude the problematic puppet-archive module dependency.
+#     
 'grafana':
+  :release: '1'
   :obsoletes:
     'pupmod-bfraser-grafana': '2.5.0-2016.1'
   :external_dependencies:
     'rubygem-puppetserver-toml':
       :min: '0.1.2'
+  :requires:
+    # Exclude the problematic puppet-archive module.
+    # ('puppet generate types' fails with puppet-archive).
+    - 'pupmod-puppetlabs-stdlib'
+
+'java':
+  :requires:
+    # Exclude the problematic puppet-archive module.
+    # ('puppet generate types' fails with puppet-archive).
+    - 'pupmod-puppetlabs-stdlib'
 
 # Make sure we create an RPM that fixes the obsoletes problem of
 # pupmod-elastic-logstash-5.2.1-0 packaged for SIMP 6.1.0.

--- a/src/assets/simp/build/simp.spec
+++ b/src/assets/simp/build/simp.spec
@@ -33,7 +33,6 @@ Requires: pupmod-herculesteam-augeasproviders_shellvar >= 3.0.0, pupmod-hercules
 Requires: pupmod-herculesteam-augeasproviders_ssh >= 3.0.0, pupmod-herculesteam-augeasproviders_ssh < 4.0.0
 Requires: pupmod-herculesteam-augeasproviders_sysctl >= 2.1.0-2016, pupmod-herculesteam-augeasproviders_sysctl < 3.0.0
 Requires: pupmod-onyxpoint-gpasswd >= 1.0.0-2016, pupmod-onyxpoint-gpasswd < 2.0.0
-Requires: pupmod-puppet-archive >= 1.1.0, pupmod-puppet-archive < 3.0.0
 Requires: pupmod-puppet-yum >= 2.0.0, pupmod-puppet-yum < 3.0.0
 Requires: pupmod-puppetlabs-apache >= 1.10.0-2016, pupmod-puppetlabs-apache < 4.0.0
 Requires: pupmod-puppetlabs-concat >= 2.2.0-2016, pupmod-puppetlabs-concat < 5.0.0
@@ -230,7 +229,6 @@ fi
   simp package
 - Update versions of numerous dependencies of both simp and simp-extras
   packages.*
-- Add pupmod-puppet-archive dependency to simp package
 - Move pupmod-puppet-yum from simp-extras package to simp packages, as
   required by pupmod-simp-tpm
 


### PR DESCRIPTION
Remove problematic puppet-archive
- Remove from Puppetfile.tracking, so pupmod-puppet-archive is not packaged in a SIMP 6.2.0 ISO
- Remove from the relevant RPM requires lists for non-SIMP puppet module RPMs
- Remove from the simp RPM requires list

NOTE:
Removal of this dependency affects the puppet-grafana and puppetlabs-java modules as follows:
- puppet-grafana:
  -  The grafana application package cannot be installed by this module on Debian.
  - The 'archive' installation method cannot be selected for the grafana application package.  The default installation method is 'package'.

- puppetlabs-java
  - Cannot use java::oracle to install Oracle Java
SIMP-4925 #close