### PR TITLE
(SIMP-5089) Update clamav versions

### DIFF
--- a/build/distributions/CentOS/6/x86_64/DVD/6-simp_pkglist.txt
+++ b/build/distributions/CentOS/6/x86_64/DVD/6-simp_pkglist.txt
@@ -106,7 +106,6 @@ chkconfig
 chkrootkit
 cifs-utils
 clamav
-clamav-data-empty
 clamav-lib
 classpathx-jaf
 classpathx-mail

--- a/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
@@ -6,23 +6,23 @@ chkrootkit:
   :rpm_name: chkrootkit-0.49-9.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/Packages/c/chkrootkit-0.49-9.el6.x86_64.rpm
 clamav:
-  :rpm_name: clamav-0.100.0-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-0.100.0-1.el6.x86_64.rpm
+  :rpm_name: clamav-0.100.1-1.el6.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-0.100.1-1.el6.x86_64.rpm
 clamav-db:
-  :rpm_name: clamav-db-0.100.0-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-db-0.100.0-1.el6.x86_64.rpm
+  :rpm_name: clamav-db-0.100.1-1.el6.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-db-0.100.1-1.el6.x86_64.rpm
 clamav-devel:
-  :rpm_name: clamav-devel-0.100.0-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-devel-0.100.0-1.el6.x86_64.rpm
+  :rpm_name: clamav-devel-0.100.1-1.el6.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-devel-0.100.1-1.el6.x86_64.rpm
 clamav-milter:
-  :rpm_name: clamav-milter-0.100.0-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-milter-0.100.0-1.el6.x86_64.rpm
+  :rpm_name: clamav-milter-0.100.1-1.el6.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-milter-0.100.1-1.el6.x86_64.rpm
 clamav-unofficial-sigs:
   :rpm_name: clamav-unofficial-sigs-3.7.1-7.el6.noarch.rpm
   :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-unofficial-sigs-3.7.1-7.el6.noarch.rpm
 clamd:
-  :rpm_name: clamd-0.100.0-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamd-0.100.0-1.el6.x86_64.rpm
+  :rpm_name: clamd-0.100.1-1.el6.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamd-0.100.1-1.el6.x86_64.rpm
 clamsmtp:
   :rpm_name: clamsmtp-1.10-7.el6.x86_64.rpm
   :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamsmtp-1.10-7.el6.x86_64.rpm

--- a/build/distributions/CentOS/7/x86_64/DVD/7-simp_pkglist.txt
+++ b/build/distributions/CentOS/7/x86_64/DVD/7-simp_pkglist.txt
@@ -168,7 +168,6 @@ chrony
 cifs-utils
 clamav
 clamav-data
-clamav-data-empty
 clamav-devel
 clamav-filesystem
 clamav-lib

--- a/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
@@ -6,35 +6,32 @@ chkrootkit:
   :rpm_name: chkrootkit-0.50-4el7.x86_64.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/chkrootkit-0.50-4el7.x86_64.rpm
 clamav:
-  :rpm_name: clamav-0.100.0-2.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-0.100.0-2.el7.x86_64.rpm
+  :rpm_name: clamav-0.100.1-1.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-0.100.1-1.el7.x86_64.rpm
 clamav-data:
-  :rpm_name: clamav-data-0.100.0-2.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-data-0.100.0-2.el7.noarch.rpm
-clamav-data-empty:
-  :rpm_name: clamav-data-empty-0.100.0-2.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-data-empty-0.100.0-2.el7.noarch.rpm
+  :rpm_name: clamav-data-0.100.1-1.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-data-0.100.1-1.el7.noarch.rpm
 clamav-devel:
-  :rpm_name: clamav-devel-0.100.0-2.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-devel-0.100.0-2.el7.x86_64.rpm
+  :rpm_name: clamav-devel-0.100.1-1.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-devel-0.100.1-1.el7.x86_64.rpm
 clamav-filesystem:
-  :rpm_name: clamav-filesystem-0.100.0-2.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-filesystem-0.100.0-2.el7.noarch.rpm
+  :rpm_name: clamav-filesystem-0.100.1-1.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-filesystem-0.100.1-1.el7.noarch.rpm
 clamav-lib:
-  :rpm_name: clamav-lib-0.100.0-2.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-lib-0.100.0-2.el7.x86_64.rpm
+  :rpm_name: clamav-lib-0.100.1-1.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-lib-0.100.1-1.el7.x86_64.rpm
 clamav-scanner-systemd:
-  :rpm_name: clamav-scanner-systemd-0.100.0-2.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-scanner-systemd-0.100.0-2.el7.x86_64.rpm
+  :rpm_name: clamav-scanner-systemd-0.100.1-1.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-scanner-systemd-0.100.1-1.el7.x86_64.rpm
 clamav-server-systemd:
-  :rpm_name: clamav-server-systemd-0.100.0-2.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-server-systemd-0.100.0-2.el7.x86_64.rpm
+  :rpm_name: clamav-server-systemd-0.100.1-1.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-server-systemd-0.100.1-1.el7.x86_64.rpm
 clamav-update:
-  :rpm_name: clamav-update-0.100.0-2.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-update-0.100.0-2.el7.x86_64.rpm
+  :rpm_name: clamav-update-0.100.1-1.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-update-0.100.1-1.el7.x86_64.rpm
 clamd:
-  :rpm_name: clamd-0.100.0-2.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamd-0.100.0-2.el7.x86_64.rpm
+  :rpm_name: clamd-0.100.1-1.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamd-0.100.1-1.el7.x86_64.rpm
 elasticsearch:
   :rpm_name: elasticsearch-5.6.10.rpm
   :source: https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.10.rpm

--- a/build/distributions/RedHat/6/x86_64/yum_data/packages.yaml
+++ b/build/distributions/RedHat/6/x86_64/yum_data/packages.yaml
@@ -6,23 +6,23 @@ chkrootkit:
   :rpm_name: chkrootkit-0.49-9.el6.x86_64.rpm
   :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/Packages/c/chkrootkit-0.49-9.el6.x86_64.rpm
 clamav:
-  :rpm_name: clamav-0.100.0-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-0.100.0-1.el6.x86_64.rpm
+  :rpm_name: clamav-0.100.1-1.el6.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-0.100.1-1.el6.x86_64.rpm
 clamav-db:
-  :rpm_name: clamav-db-0.100.0-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-db-0.100.0-1.el6.x86_64.rpm
+  :rpm_name: clamav-db-0.100.1-1.el6.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-db-0.100.1-1.el6.x86_64.rpm
 clamav-devel:
-  :rpm_name: clamav-devel-0.100.0-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-devel-0.100.0-1.el6.x86_64.rpm
+  :rpm_name: clamav-devel-0.100.1-1.el6.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-devel-0.100.1-1.el6.x86_64.rpm
 clamav-milter:
-  :rpm_name: clamav-milter-0.100.0-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-milter-0.100.0-1.el6.x86_64.rpm
+  :rpm_name: clamav-milter-0.100.1-1.el6.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-milter-0.100.1-1.el6.x86_64.rpm
 clamav-unofficial-sigs:
   :rpm_name: clamav-unofficial-sigs-3.7.1-7.el6.noarch.rpm
   :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-unofficial-sigs-3.7.1-7.el6.noarch.rpm
 clamd:
-  :rpm_name: clamd-0.100.0-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamd-0.100.0-1.el6.x86_64.rpm
+  :rpm_name: clamd-0.100.1-1.el6.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamd-0.100.1-1.el6.x86_64.rpm
 clamsmtp:
   :rpm_name: clamsmtp-1.10-7.el6.x86_64.rpm
   :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamsmtp-1.10-7.el6.x86_64.rpm

--- a/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
@@ -6,35 +6,32 @@ chkrootkit:
   :rpm_name: chkrootkit-0.50-4el7.x86_64.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/chkrootkit-0.50-4el7.x86_64.rpm
 clamav:
-  :rpm_name: clamav-0.100.0-2.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-0.100.0-2.el7.x86_64.rpm
+  :rpm_name: clamav-0.100.1-1.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-0.100.1-1.el7.x86_64.rpm
 clamav-data:
-  :rpm_name: clamav-data-0.100.0-2.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-data-0.100.0-2.el7.noarch.rpm
-clamav-data-empty:
-  :rpm_name: clamav-data-empty-0.100.0-2.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-data-empty-0.100.0-2.el7.noarch.rpm
+  :rpm_name: clamav-data-0.100.1-1.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-data-0.100.1-1.el7.noarch.rpm
 clamav-devel:
-  :rpm_name: clamav-devel-0.100.0-2.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-devel-0.100.0-2.el7.x86_64.rpm
+  :rpm_name: clamav-devel-0.100.1-1.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-devel-0.100.1-1.el7.x86_64.rpm
 clamav-filesystem:
-  :rpm_name: clamav-filesystem-0.100.0-2.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-filesystem-0.100.0-2.el7.noarch.rpm
+  :rpm_name: clamav-filesystem-0.100.1-1.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-filesystem-0.100.1-1.el7.noarch.rpm
 clamav-lib:
-  :rpm_name: clamav-lib-0.100.0-2.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-lib-0.100.0-2.el7.x86_64.rpm
+  :rpm_name: clamav-lib-0.100.1-1.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-lib-0.100.1-1.el7.x86_64.rpm
 clamav-scanner-systemd:
-  :rpm_name: clamav-scanner-systemd-0.100.0-2.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-scanner-systemd-0.100.0-2.el7.x86_64.rpm
+  :rpm_name: clamav-scanner-systemd-0.100.1-1.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-scanner-systemd-0.100.1-1.el7.x86_64.rpm
 clamav-server-systemd:
-  :rpm_name: clamav-server-systemd-0.100.0-2.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-server-systemd-0.100.0-2.el7.x86_64.rpm
+  :rpm_name: clamav-server-systemd-0.100.1-1.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-server-systemd-0.100.1-1.el7.x86_64.rpm
 clamav-update:
-  :rpm_name: clamav-update-0.100.0-2.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-update-0.100.0-2.el7.x86_64.rpm
+  :rpm_name: clamav-update-0.100.1-1.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-update-0.100.1-1.el7.x86_64.rpm
 clamd:
-  :rpm_name: clamd-0.100.0-2.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamd-0.100.0-2.el7.x86_64.rpm
+  :rpm_name: clamd-0.100.1-1.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamd-0.100.1-1.el7.x86_64.rpm
 elasticsearch:
   :rpm_name: elasticsearch-5.6.10.rpm
   :source: https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.10.rpm


### PR DESCRIPTION
- Updates clamav versions from 0.100.0-2 to 0.100.1-1 to reflect latest
epel release
- Removes clamav-data-empty, which is no longer listed in the epel
mirrors

SIMP-5089 #close