### PR TITLE
(SIMP-5092) Remove `gem install` from nodesets

### DIFF
--- a/build/Dockerfiles/SIMP6_Build.dockerfile
+++ b/build/Dockerfiles/SIMP6_Build.dockerfile
@@ -49,7 +49,7 @@ RUN yum install -y rubygems vim-enhanced jq
 
 # Set up RVM
 RUN runuser build_user -l -c "echo 'gem: --no-ri --no-rdoc' > .gemrc"
-RUN runuser build_user -l -c "gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"
+RUN runuser build_user -l -c "gpg2 --keyserver hkp://pgp.mit.edu --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB || gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"
 RUN runuser build_user -l -c "curl -sSL https://get.rvm.io | bash -s stable"
 RUN runuser build_user -l -c "rvm install 2.1.9 --disable-binary"
 RUN runuser build_user -l -c "rvm use --default 2.1.9"

--- a/build/Dockerfiles/SIMP6_Build.dockerfile
+++ b/build/Dockerfiles/SIMP6_Build.dockerfile
@@ -54,10 +54,6 @@ RUN runuser build_user -l -c "curl -sSL https://get.rvm.io | bash -s stable"
 RUN runuser build_user -l -c "rvm install 2.1.9 --disable-binary"
 RUN runuser build_user -l -c "rvm use --default 2.1.9"
 RUN runuser build_user -l -c "rvm all do gem install bundler"
-RUN runuser build_user -l -c "rvm use default; gem install simp-rake-helpers"
-RUN runuser build_user -l -c "rvm use default; gem install json"
-RUN runuser build_user -l -c "rvm use default; gem install charlock_holmes"
-RUN runuser build_user -l -c "rvm use default; gem install posix-spawn"
 
 # Check out a copy of simp-core for building
 RUN runuser build_user -l -c "git clone https://github.com/simp/simp-core"

--- a/build/Dockerfiles/SIMP7_Build.dockerfile
+++ b/build/Dockerfiles/SIMP7_Build.dockerfile
@@ -49,7 +49,7 @@ RUN yum install -y rubygems vim-enhanced jq
 
 # Set up RVM
 RUN runuser build_user -l -c "echo 'gem: --no-ri --no-rdoc' > .gemrc"
-RUN runuser build_user -l -c "gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"
+RUN runuser build_user -l -c "gpg2 --keyserver hkp://pgp.mit.edu --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB || gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"
 RUN runuser build_user -l -c "curl -sSL https://get.rvm.io | bash -s stable"
 RUN runuser build_user -l -c "rvm install 2.1.9 --disable-binary"
 RUN runuser build_user -l -c "rvm use --default 2.1.9"

--- a/build/Dockerfiles/SIMP7_Build.dockerfile
+++ b/build/Dockerfiles/SIMP7_Build.dockerfile
@@ -54,10 +54,6 @@ RUN runuser build_user -l -c "curl -sSL https://get.rvm.io | bash -s stable"
 RUN runuser build_user -l -c "rvm install 2.1.9 --disable-binary"
 RUN runuser build_user -l -c "rvm use --default 2.1.9"
 RUN runuser build_user -l -c "rvm all do gem install bundler"
-RUN runuser build_user -l -c "rvm use default; gem install simp-rake-helpers"
-RUN runuser build_user -l -c "rvm use default; gem install json"
-RUN runuser build_user -l -c "rvm use default; gem install charlock_holmes"
-RUN runuser build_user -l -c "rvm use default; gem install posix-spawn"
 
 # Check out a copy of simp-core for building
 RUN runuser build_user -l -c "git clone https://github.com/simp/simp-core"

--- a/spec/acceptance/suites/rpm_docker/nodesets/el6.yml
+++ b/spec/acceptance/suites/rpm_docker/nodesets/el6.yml
@@ -76,12 +76,6 @@ HOSTS:
       - 'runuser build_user -l -c "rvm use --default 2.1.9"'
       - 'runuser build_user -l -c "rvm all do gem install bundler --no-ri --no-rdoc"'
 
-      # Add some gems that will drag along 90% of what the build requires
-      - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc simp-rake-helpers"'
-      - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc json"'
-      - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc charlock_holmes"'
-      - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc posix-spawn"'
-
 CONFIG:
   log_level: verbose
   type: aio

--- a/spec/acceptance/suites/rpm_docker/nodesets/el6.yml
+++ b/spec/acceptance/suites/rpm_docker/nodesets/el6.yml
@@ -70,7 +70,7 @@ HOSTS:
       - 'yum -y install python27'
 
       # RVM
-      - 'runuser build_user -l -c "gpg2 --keyserver hkp://pgp.mit.edu --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"'
+      - 'runuser build_user -l -c "gpg2 --keyserver hkp://pgp.mit.edu --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB || gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"'
       - 'runuser build_user -l -c "curl -sSL https://get.rvm.io | bash -s stable"'
       - 'runuser build_user -l -c "rvm install 2.1.9 --disable-binary"'
       - 'runuser build_user -l -c "rvm use --default 2.1.9"'

--- a/spec/acceptance/suites/rpm_docker/nodesets/el7.yml
+++ b/spec/acceptance/suites/rpm_docker/nodesets/el7.yml
@@ -74,7 +74,7 @@ HOSTS:
       - 'yum --enablerepo=base -y install python27'
 
       # RVM
-      - 'runuser build_user -l -c "gpg2 --keyserver hkp://pgp.mit.edu --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"'
+      - 'runuser build_user -l -c "gpg2 --keyserver hkp://pgp.mit.edu --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB || gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"'
       - 'runuser build_user -l -c "curl -sSL https://get.rvm.io | bash -s stable"'
       - 'runuser build_user -l -c "rvm install 2.1.9 --disable-binary"'
       - 'runuser build_user -l -c "rvm use --default 2.1.9"'

--- a/spec/acceptance/suites/rpm_docker/nodesets/el7.yml
+++ b/spec/acceptance/suites/rpm_docker/nodesets/el7.yml
@@ -80,12 +80,6 @@ HOSTS:
       - 'runuser build_user -l -c "rvm use --default 2.1.9"'
       - 'runuser build_user -l -c "rvm all do gem install bundler --no-ri --no-rdoc"'
 
-      # Add some gems that will drag along 90% of what the build requires
-      - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc simp-rake-helpers"'
-      - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc json"'
-      - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc charlock_holmes"'
-      - 'runuser build_user -l -c "rvm use default; gem install --no-ri --no-rdoc posix-spawn"'
-
 CONFIG:
   log_level: verbose
   type: aio


### PR DESCRIPTION
Before this patch, fresh container builds of the simp-core beaker suite
rpm_docker would fail with:

```
ERROR:  Error installing simp-rake-helpers:
    The last version of net-telnet (>= 0) to support your Ruby & RubyGems was 0.1.1. Try installing it with `gem install net-telnet -v 0.1.1` and then running the current command again
    net-telnet requires Ruby version >= 2.3.0. The current ruby version is 2.1.0.
```

The `Gemfile.lock` in simp-core already pins `net-telnet` to 0.1.1. However,
the rpm_docker nodesets naively attempt to install simp-rake-helpers before the
tests without bundler, which fetches the latest (and incompatible) net-telnet
as a dependency.

To prevent future dependency problems, this patch removes the unpinned `gem
install` lines from the `rpm_docker` nodesets and runs bundler using the
existing `Gemfile.lock` to manage dependencies, as designed.

SIMP-5092 #close