### PR TITLE
(SIMP-5058) Add test to verify SIMP rsyslog config

### DIFF
--- a/spec/acceptance/common_files/simp_conf.yaml.erb
+++ b/spec/acceptance/common_files/simp_conf.yaml.erb
@@ -85,19 +85,6 @@ cli::simp::scenario: simp
 # SIMP repositories.
 cli::use_internet_simp_yum_repos: false
 
-# === grub::password ===
-# The password to access GRUB.
-#
-# The value entered is used to set the GRUB password and to generate a hash
-# stored in grub::password.
-#
-# P@ssw0rdP@ssw0rd
-grub::password: grub.pbkdf2.sha512.10000.12F3895DD7ADE63F7FE88A79B00C84BE64E7F5D17DB1642390C2551622F2BE322E76698FF98A726A44D91775E70F8AE9DAFB933FE96342C68997D82F9E558CA0.D22D09E348D94B37120FE9E29A052E97244BCA6A3AD0DC5BA304373BED93026ED0801E4B0E7442C63CC992A6A76DD90948806762FB02204CD5603A7E1A6A2AD6
-
-# === puppetdb::master::config::puppetdb_port ===
-# The PuppetDB server port number.
-puppetdb::master::config::puppetdb_port: 8139
-
 # === puppetdb::master::config::puppetdb_server ===
 # The DNS name or IP of the PuppetDB server.
 puppetdb::master::config::puppetdb_server: "%{hiera('simp_options::puppet::server')}"
@@ -126,15 +113,6 @@ simp::yum::servers:
 # === simp::yum::simp_update_url ===
 # Full URL to a YUM repo for SIMP packages
 simp::yum::simp_update_url: https://packagecloud.io/simp-project/6_X/el/$releasever/$basearch
-
-# === simp_openldap::server::conf::rootpw ===
-# The salted LDAP Root password hash.
-#
-# When set via 'simp config', this password hash is generated from
-# the password entered on the command line.
-#
-# P@ssw0rdP@ssw0rd
-simp_openldap::server::conf::rootpw: "{SSHA}JuPH7TsHnjSMKhFurGaEHiUuJYiQdjno"
 
 # === simp_options::dns::search ===
 # The DNS domain search string.

--- a/spec/acceptance/common_files/simp_conf.yaml.erb
+++ b/spec/acceptance/common_files/simp_conf.yaml.erb
@@ -85,6 +85,15 @@ cli::simp::scenario: simp
 # SIMP repositories.
 cli::use_internet_simp_yum_repos: false
 
+# === grub::password ===
+# The password to access GRUB.
+#
+# The value entered is used to set the GRUB password and to generate a hash
+# stored in grub::password.
+#
+# P@ssw0rdP@ssw0rd
+grub::password: grub.pbkdf2.sha512.10000.12F3895DD7ADE63F7FE88A79B00C84BE64E7F5D17DB1642390C2551622F2BE322E76698FF98A726A44D91775E70F8AE9DAFB933FE96342C68997D82F9E558CA0.D22D09E348D94B37120FE9E29A052E97244BCA6A3AD0DC5BA304373BED93026ED0801E4B0E7442C63CC992A6A76DD90948806762FB02204CD5603A7E1A6A2AD6
+
 # === puppetdb::master::config::puppetdb_port ===
 # The PuppetDB server port number.
 puppetdb::master::config::puppetdb_port: 8139
@@ -117,6 +126,15 @@ simp::yum::servers:
 # === simp::yum::simp_update_url ===
 # Full URL to a YUM repo for SIMP packages
 simp::yum::simp_update_url: https://packagecloud.io/simp-project/6_X/el/$releasever/$basearch
+
+# === simp_openldap::server::conf::rootpw ===
+# The salted LDAP Root password hash.
+#
+# When set via 'simp config', this password hash is generated from
+# the password entered on the command line.
+#
+# P@ssw0rdP@ssw0rd
+simp_openldap::server::conf::rootpw: "{SSHA}JuPH7TsHnjSMKhFurGaEHiUuJYiQdjno"
 
 # === simp_options::dns::search ===
 # The DNS domain search string.
@@ -158,6 +176,8 @@ simp_options::dns::servers:
 #     SIMP documentation for instructions on how to safely convert a non-FIPS
 #     system to a FIPS system.
 #
+#  NOTE:  This setting is immaterial, as simp config will set the value
+#         based on the actual system setting.
 simp_options::fips: false
 
 # === simp_options::ldap ===
@@ -168,7 +188,7 @@ simp_options::ldap: true
 
 # === simp_options::ldap::base_dn ===
 # The Base Distinguished Name of the LDAP server.
-# simp_options::ldap::base_dn: dc=camelot,dc=local
+# simp_options::ldap::base_dn: dc=test,dc=local
 
 # === simp_options::ldap::bind_hash ===
 # The salted LDAP Bind password hash.
@@ -216,15 +236,18 @@ simp_options::sssd: true
 #
 # No log forwarding is enabled when this list is empty.  Only use hostnames
 # here if at all possible.
-simp_options::syslog::log_servers: []
+simp_options::syslog::log_servers: <%= (syslog_servers.nil? or syslog_servers.empty?) ? '[]': '[ ' + syslog_servers.join(', ') + ' ]' %>
+
+# === simp_options::syslog::failover_log_servers ===
+# Failover log server(s) in case your log servers(s) fail.
+simp_options::syslog::failover_log_servers: []
 
 # === simp_options::trusted_nets ===
 # A list of subnets to permit, in CIDR notation.
 #
 # If you need this to be more (or less) restrictive for a given class,
 # you can override it in Hiera.
-simp_options::trusted_nets:
-- 0.0.0.0/0
+simp_options::trusted_nets: <%= (trusted_nets.nil? or trusted_nets.empty?) ? '[]': '[ ' + trusted_nets.join(', ') + ' ]' %>
 
 # === sssd::domains ===
 # A list of domains for SSSD to use.

--- a/spec/acceptance/common_files/site/local_users.pp
+++ b/spec/acceptance/common_files/site/local_users.pp
@@ -17,8 +17,6 @@ class site::local_users(
     gid        => $local_admin,
     home       => "/var/${local_admin}",
     managehome => true,
-    # P@ssw0rdP@ssw0rd
-    password   => '$6$rounds=10000$hDSthQpS$bo5vJ.QNtf5XzQxJzNi0bq1e2nAjLm8gS1r8zxxb/nFHyllEPdSAismdHxa78V37aJvw8lbc5Ba4Js/ytbUd8.'
   }
 
   pam::access::rule { "allow_${local_admin}":

--- a/spec/acceptance/common_files/site/local_users.pp
+++ b/spec/acceptance/common_files/site/local_users.pp
@@ -1,0 +1,37 @@
+class site::local_users(
+  String $local_admin = 'localadmin'
+) {
+
+  # Beaker is **NOT** helpful in this case...
+  sshd_config { 'PasswordAuthentication':
+    value => 'yes',
+    notify  => Service['sshd']
+  }
+
+  group {$local_admin:
+    ensure => 'present'
+  }
+
+  user { $local_admin:
+    ensure     => 'present',
+    gid        => $local_admin,
+    home       => "/var/${local_admin}",
+    managehome => true,
+    # P@ssw0rdP@ssw0rd
+    password   => '$6$rounds=10000$hDSthQpS$bo5vJ.QNtf5XzQxJzNi0bq1e2nAjLm8gS1r8zxxb/nFHyllEPdSAismdHxa78V37aJvw8lbc5Ba4Js/ytbUd8.'
+  }
+
+  pam::access::rule { "allow_${local_admin}":
+    users      => [ $local_admin ],
+    origins    => ['ALL'],
+    permission => '+'
+  }
+
+  sudo::user_specification { "sudo_${local_admin}":
+    user_list => [ $local_admin ],
+    runas     => 'root',
+    cmnd      => [ '/bin/su root', '/bin/su - root', '/usr/bin/sudosh' ],
+    passwd    => false
+  }
+
+}

--- a/spec/acceptance/common_files/site/local_users.pp
+++ b/spec/acceptance/common_files/site/local_users.pp
@@ -9,7 +9,8 @@ class site::local_users(
   }
 
   group {$local_admin:
-    ensure => 'present'
+    ensure => 'present',
+    gid    => 1001
   }
 
   user { $local_admin:
@@ -17,6 +18,7 @@ class site::local_users(
     gid        => $local_admin,
     home       => "/var/${local_admin}",
     managehome => true,
+    uid        => 1001
   }
 
   pam::access::rule { "allow_${local_admin}":

--- a/spec/acceptance/common_files/site/manifests/local_users.pp
+++ b/spec/acceptance/common_files/site/manifests/local_users.pp
@@ -10,7 +10,7 @@ class site::local_users(
 
   group {$local_admin:
     ensure => 'present',
-    gid    => 1001
+    gid    => 2001
   }
 
   user { $local_admin:
@@ -18,7 +18,7 @@ class site::local_users(
     gid        => $local_admin,
     home       => "/var/${local_admin}",
     managehome => true,
-    uid        => 1001
+    uid        => 2001
   }
 
   pam::access::rule { "allow_${local_admin}":

--- a/spec/acceptance/common_files/site/manifests/test_ldifs.pp
+++ b/spec/acceptance/common_files/site/manifests/test_ldifs.pp
@@ -1,0 +1,64 @@
+#  This creates 3 ldifs in /root/ldifs with test LDAP user setup
+#
+#  add_test_users.ldif:  Creates LDAP users and groups as follows
+#
+#    Groups Created
+#    admin1
+#    admin2
+#    NotAllowed
+#    Test
+#    security
+#
+#    Users Created   Member Groups
+#    admin1          admin1
+#    admin2          admin2
+#    baduser         NotAllowed
+#    user1           Test
+#    user2           Test
+#    auditor1        security
+#
+#  modify_test_users.ldif:  Adds users to groups
+#
+#    User    Groups Added
+#    admin1  users, administrators
+#    admin2  users, administrators
+#    user1   users
+#    user2   users
+#
+# @param $base_dn The LDAP Base DN
+# @param $user_password_hash The initial password hash used to set the 
+#   LDAP 'userPassword field for all users
+class site::test_ldifs(
+  String      $base_dn               = $::simp_options::ldap::base_dn,
+  String      $user_password_hash
+) {
+
+  file {  '/root/ldifs':
+    ensure  => 'directory',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0750',
+  }
+
+  file {  '/root/ldifs/add_test_users.ldif':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0640',
+    content =>  epp('site/ldifs/add_test_users.ldif.epp')
+  }
+
+  file {  '/root/ldifs/modify_test_users.ldif':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0640',
+    content =>  epp('site/ldifs/modify_test_users.ldif.epp')
+  }
+
+  file {  '/root/ldifs/force_test_users_password_reset.ldif':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0640',
+    content =>  epp('site/ldifs/force_test_users_password_reset.ldif.epp')
+  }
+
+}

--- a/spec/acceptance/common_files/site/templates/ldifs/add_test_users.ldif.epp
+++ b/spec/acceptance/common_files/site/templates/ldifs/add_test_users.ldif.epp
@@ -1,0 +1,173 @@
+dn: cn=admin1,ou=Group,<%= $site::test_ldifs::base_dn %>
+objectClass: posixGroup
+objectClass: top
+cn: admin1
+gidNumber: 3001
+description: "Admin One group"
+
+dn: uid=admin1,ou=People,<%= $site::test_ldifs::base_dn %>
+uid: admin1
+cn: admin1
+givenName: admin
+sn: one
+mail: admin1@test.local
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: top
+objectClass: shadowAccount
+objectClass: ldapPublicKey
+shadowMax: 180
+shadowMin: 1
+shadowWarning: 7
+shadowLastChange: 10701
+sshPublicKey: <some SSH public key>
+loginShell: /bin/bash
+uidNumber: 3001
+gidNumber: 3001
+homeDirectory: /home/admin1
+userPassword: <%= $site::test_ldifs::user_password_hash %>
+pwdReset: FALSE
+
+dn: cn=admin2,ou=Group,<%= $site::test_ldifs::base_dn %>
+objectClass: posixGroup
+objectClass: top
+cn: admin2
+gidNumber: 3002
+description: "Admin Two group"
+
+dn: uid=admin2,ou=People,<%= $site::test_ldifs::base_dn %>
+uid: admin2
+cn: admin2
+givenName: Admin
+sn: Two
+mail: admin2@test.local
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: top
+objectClass: shadowAccount
+objectClass: ldapPublicKey
+shadowMax: 180
+shadowMin: 1
+shadowWarning: 7
+shadowLastChange: 10701
+sshPublicKey: <some SSH public key>
+loginShell: /bin/bash
+uidNumber: 3002
+gidNumber: 3002
+homeDirectory: /home/admin2
+userPassword: <%= $site::test_ldifs::user_password_hash %>
+pwdReset: FALSE
+
+dn: cn=NotAllowed,ou=Group,<%= $site::test_ldifs::base_dn %>
+objectClass: posixGroup
+objectClass: top
+cn: NotAllowed
+gidNumber: 9999
+description: "Users not allowed to log in group"
+
+dn: uid=baduser,ou=People,<%= $site::test_ldifs::base_dn %>
+uid: baduser
+cn: baduser
+givenName: Bad
+sn: User
+mail: baduser@test.local
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: top
+objectClass: shadowAccount
+objectClass: ldapPublicKey
+shadowMax: 180
+shadowMin: 1
+shadowWarning: 7
+shadowLastChange: 10701
+sshPublicKey: <some SSH public key>
+loginShell: /bin/bash
+uidNumber: 9001
+gidNumber: 9999
+homeDirectory: /home/baduser
+userPassword: <%= $site::test_ldifs::user_password_hash %>
+pwdReset: FALSE
+
+dn: cn=Test Group,ou=Group,<%= $site::test_ldifs::base_dn %>
+objectClass: posixGroup
+objectClass: top
+cn: testgroup
+gidNumber: 4000
+description: "Test Group group"
+
+dn: uid=user1,ou=People,<%= $site::test_ldifs::base_dn %>
+uid: user1
+cn: user1
+givenName: User
+sn: One
+mail: user1@test.local
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: top
+objectClass: shadowAccount
+objectClass: ldapPublicKey
+shadowMax: 180
+shadowMin: 1
+shadowWarning: 7
+shadowLastChange: 10701
+sshPublicKey: <some SSH public key>
+loginShell: /bin/bash
+uidNumber: 4001
+gidNumber: 4000
+homeDirectory: /home/user1
+userPassword: <%= $site::test_ldifs::user_password_hash %>
+pwdReset: FALSE
+
+dn: uid=user2,ou=People,<%= $site::test_ldifs::base_dn %>
+uid: user2
+cn: user2
+givenName: User
+sn: Two
+mail: user2@test.local
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: top
+objectClass: shadowAccount
+objectClass: ldapPublicKey
+shadowMax: 180
+shadowMin: 1
+shadowWarning: 7
+shadowLastChange: 10701
+sshPublicKey: <some SSH public key>
+loginShell: /bin/bash
+uidNumber: 4002
+gidNumber: 4000
+homeDirectory: /home/user2
+userPassword: <%= $site::test_ldifs::user_password_hash %>
+pwdReset: FALSE
+
+dn: cn=security,ou=Group,<%= $site::test_ldifs::base_dn %>
+objectClass: posixGroup
+objectClass: top
+cn: security
+gidNumber: 7700
+description: "The group used for auditors in simp"
+
+dn: uid=auditor1,ou=People,<%= $site::test_ldifs::base_dn %>
+uid: auditor1
+cn: auditor1
+givenName: Auditor
+sn: one
+mail: auditor1@test.local
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: top
+objectClass: shadowAccount
+objectClass: ldapPublicKey
+shadowMax: 180
+shadowMin: 1
+shadowWarning: 7
+shadowLastChange: 10701
+sshPublicKey: <some SSH public key>
+loginShell: /bin/bash
+uidNumber: 7001
+gidNumber: 7700
+homeDirectory: /home/auditor1
+userPassword: <%= $site::test_ldifs::user_password_hash %>
+pwdReset: FALSE
+

--- a/spec/acceptance/common_files/site/templates/ldifs/force_test_users_password_reset.ldif.epp
+++ b/spec/acceptance/common_files/site/templates/ldifs/force_test_users_password_reset.ldif.epp
@@ -1,0 +1,42 @@
+dn: uid=admin1,ou=People,<%= $site::test_ldifs::base_dn %>
+changetype: modify
+replace: pwdReset
+pwdReset: TRUE
+-
+replace: shadowLastChange
+shadowLastChange: 10101
+
+
+dn: uid=admin2,ou=People,<%= $site::test_ldifs::base_dn %>
+changetype: modify
+replace: pwdReset
+pwdReset: TRUE
+-
+replace: shadowLastChange
+shadowLastChange: 10101
+
+
+dn: uid=user1,ou=People,<%= $site::test_ldifs::base_dn %>
+changetype: modify
+replace: pwdReset
+pwdReset: TRUE
+-
+replace: shadowLastChange
+shadowLastChange: 10101
+
+
+dn: uid=user2,ou=People,<%= $site::test_ldifs::base_dn %>
+changetype: modify
+replace: pwdReset
+pwdReset: TRUE
+-
+replace: shadowLastChange
+shadowLastChange: 10101
+
+dn: uid=auditor1,ou=People,<%= $site::test_ldifs::base_dn %>
+changetype: modify
+replace: pwdReset
+pwdReset: TRUE
+-
+replace: shadowLastChange
+shadowLastChange: 10101

--- a/spec/acceptance/common_files/site/templates/ldifs/modify_test_users.ldif.epp
+++ b/spec/acceptance/common_files/site/templates/ldifs/modify_test_users.ldif.epp
@@ -1,0 +1,13 @@
+dn: cn=users,ou=Group,<%= $site::test_ldifs::base_dn %>
+changeType: modify
+add: memberUid
+memberUid: admin1
+memberUid: admin2
+memberUid: user1
+memberUid: user2
+
+dn: cn=administrators,ou=Group,<%= $site::test_ldifs::base_dn %>
+changeType: modify
+add: memberUid
+memberUid: admin1
+memberUid: admin2

--- a/spec/acceptance/common_files/ssh_change_password_script
+++ b/spec/acceptance/common_files/ssh_change_password_script
@@ -1,0 +1,37 @@
+#!/usr/bin/expect -f
+
+set user [lindex $argv 0]
+set host [lindex $argv 1]
+set pass [lindex $argv 2]
+set newpass [lindex $argv 3]
+set extraopts [lindex $argv 4]
+set timeout 10
+
+if { $extraopts == "" } {
+ spawn ssh -o StrictHostKeyChecking=no -o NumberOfPasswordPrompts=1 $host -l $user ;
+} else {
+ spawn ssh -o StrictHostKeyChecking=no -o NumberOfPasswordPrompts=1 $extraopts $host -l $user
+}
+
+# wait for password prompt
+expect "*password:"
+send "$pass\r"
+
+# wait for username in command line prompt before sending each command
+expect "$user@$host "
+send "whoami\r"
+
+expect "$user@$host "
+send "passwd\r"
+expect "Current Password:"
+send "$pass\r"
+expect "New password:"
+send "$newpass\r"
+expect "Retype new password:"
+send "$newpass\r"
+
+expect "$user@$host "
+send "exit \$?\r"
+
+catch wait result
+exit [lindex $result 3]

--- a/spec/acceptance/common_files/ssh_cmd_script
+++ b/spec/acceptance/common_files/ssh_cmd_script
@@ -1,0 +1,31 @@
+#!/usr/bin/expect -f
+
+set user [lindex $argv 0]
+set host [lindex $argv 1]
+set pass [lindex $argv 2]
+set cmd  [lindex $argv 3]
+set extraopts [lindex $argv 4]
+set timeout 10
+
+if { $extraopts == "" } {
+ spawn ssh -o StrictHostKeyChecking=no -o NumberOfPasswordPrompts=1 $host -l $user ;
+} else {
+ spawn ssh -o StrictHostKeyChecking=no -o NumberOfPasswordPrompts=1 $extraopts $host -l $user
+}
+
+# wait for password prompt
+expect "*password:"
+send "$pass\r"
+
+# wait for username in command line prompt before sending each command
+expect "$user@$host "
+send "whoami\r"
+expect "$user@$host "
+send "pwd\r"
+expect "$user@$host "
+send "$cmd\r"
+expect "$user@$host "
+send "exit \$?\r"
+
+catch wait result
+exit [lindex $result 3]

--- a/spec/acceptance/common_files/ssh_password_change_required_script
+++ b/spec/acceptance/common_files/ssh_password_change_required_script
@@ -1,0 +1,30 @@
+#!/usr/bin/expect -f
+
+set user [lindex $argv 0]
+set host [lindex $argv 1]
+set pass [lindex $argv 2]
+set newpass [lindex $argv 3]
+set extraopts [lindex $argv 4]
+set timeout 10
+
+if { $extraopts == "" } {
+ spawn ssh -o StrictHostKeyChecking=no -o NumberOfPasswordPrompts=1 $host -l $user ;
+} else {
+ spawn ssh -o StrictHostKeyChecking=no -o NumberOfPasswordPrompts=1 $extraopts $host -l $user
+}
+
+# wait for password prompt
+expect "*password:"
+send "$pass\r"
+
+# wait for password change prompt
+expect "Current Password:"
+send "$pass\r"
+expect "New password:"
+send "$newpass\r"
+expect "Retype new password:"
+send "$newpass\r"
+expect "*updated successfully"
+
+catch wait result
+exit [lindex $result 3]

--- a/spec/acceptance/common_files/ssh_sudo_sudosh_script
+++ b/spec/acceptance/common_files/ssh_sudo_sudosh_script
@@ -1,0 +1,57 @@
+#!/usr/bin/expect -f
+
+set user [lindex $argv 0]
+set host [lindex $argv 1]
+set pass [lindex $argv 2]
+set extraopts [lindex $argv 3]
+set timeout 10
+
+if { $extraopts == "" } {
+ spawn ssh -o StrictHostKeyChecking=no -o NumberOfPasswordPrompts=1 $host -l $user ;
+} else {
+ spawn ssh -o StrictHostKeyChecking=no -o NumberOfPasswordPrompts=1 $extraopts $host -l $user
+}
+
+# wait for password prompt
+expect "*password:"
+send "$pass\r"
+
+# wait for username in command line prompt before sending each command
+expect "$user@$host "
+send "whoami\r"
+expect "$user@$host "
+send "pwd\r"
+expect "$user@$host "
+send "sudo sudosh\r"
+
+# root may not have /etc/bashrc in its bashrc, so wait
+# for a minimal prompt separator ' ' (yes, a very weak
+# expectation) and then source the /etc/bashrc to get
+# a better expect string
+expect " "
+send "source /etc/bashrc\r"
+
+# wait for root in command line prompt before sending each command
+expect "root@$host "
+send "whoami\r"
+expect "root@$host "
+send "pwd\r"
+expect "root@$host "
+send "tail -n 5 /var/log/messages\r"
+expect "root@$host "
+# sleep allows time for log messages to spew to the screen
+# before closing the connection
+send "sleep 1\r"
+expect "root@$host "
+send "exit 0\r"
+
+# wait for username in command line prompt before sending each command
+expect "$user@$host "
+send "whoami\r"
+expect "$user@$host "
+send "pwd\r"
+expect "$user@$host "
+send "exit 0\r"
+
+catch wait result
+exit [lindex $result 3]

--- a/spec/acceptance/nodesets/el6_server.yml
+++ b/spec/acceptance/nodesets/el6_server.yml
@@ -59,6 +59,7 @@ HOSTS:
   agent-el6:
     roles:
       - agent
+      - syslog_server
     platform:   el-6-x86_64
     box:        <%= box_6 %>
     hypervisor: <%= hypervisor %>

--- a/spec/acceptance/nodesets/el7_server.yml
+++ b/spec/acceptance/nodesets/el7_server.yml
@@ -41,6 +41,7 @@ HOSTS:
   agent-el7:
     roles:
       - agent
+      - syslog_server
     platform:   el-7-x86_64
     box:        <%= box_7 %>
     hypervisor: <%= hypervisor %>

--- a/spec/acceptance/suites/README.md
+++ b/spec/acceptance/suites/README.md
@@ -133,7 +133,21 @@ This test attempts to set up two repos:
 2. The dependency repo, containing extra RPMs required by SIMP that aren't in
    the CentOS Base repos.
 
-It then installs the `simp` RPM and runs `simp config` and `simp bootstrap`.
+Then, using the repos, it
+
+1. Installs the `simp` RPM and runs `simp config` and `simp bootstrap` on the
+   SIMP server
+2. Runs `puppet agent -t` on the SIMP server and 2 clients (1 CentOS6, 1 CentOS7)
+   until convergence.
+
+In this configuration, one of the clients is also the remote syslog server.
+
+_Tests run_:
+
+1. Verifies rsyslog integration.  Specifically, it stimulates applications
+   to generate events of interest, and then verifies the actual application
+   messages get logged locally and remotely, as expected.
+
 
 Use the following ENV variables to configure the test:
 

--- a/spec/acceptance/suites/install_from_tar/10_rsyslog_integration_spec.rb
+++ b/spec/acceptance/suites/install_from_tar/10_rsyslog_integration_spec.rb
@@ -1,0 +1,420 @@
+require 'spec_helper_tar'
+require 'erb'
+
+test_name 'rsyslog integration'
+
+# The rsyslog and simp_rsyslog module acceptance tests verify the plumbing
+# of rsyslog connectivity.  However, for the most part, those tests mock
+# message sending using 'logger', and thus do not ensure logging on a SIMP
+# system is complete/accurate.  We attempt to address this testing deficiency
+# here by stimulating applications to generate events of interest, and then
+# verifying actual application messages get logged locally and remotely, as
+# expected.
+#
+# NOTES:
+# 1) Although this integration test is essential, it is unfortunately
+#    fragile, as application syslog message identity, level, and content are
+#    all subject to change.  This means the test, and possibly simp_rsyslog,
+#    may need to be updated when applications are updated.
+# 2) There are numerous inconsistencies in the names of local and
+#    remote logs, and into which local/remote log messages are written.
+#    (See SIMP-3480).  The tests are written for the *current* rsyslog
+#    configuration, not the *desired* rsyslog configuration.
+# 3) In most cases, messages from a syslog server, itself, that would
+#    have been forwarded if the host was not a syslog server, are written
+#    to /var/log/hosts/<syslog server fqdn>, instead of the local file
+#    to which other hosts write their messages. This provides consistency
+#    for the sysadmins examining host logs on the syslog server.
+# 4) More tests need to be done...Notes can be found in a
+#    commented out block at the end of the file.
+#
+describe 'Validation of rsyslog forwarding' do
+
+  syslog_servers = hosts_with_role(hosts, 'syslog_server')
+  non_syslog_servers = hosts - syslog_servers
+
+  domain         = fact_on(master, 'domain')
+  master_fqdn    = fact_on(master, 'fqdn')
+
+  # messages       = array of message search strings
+  # remote_log     = basename of remote log file
+  # hosts          = hosts for which messages should exist
+  # domain         = domain of test servers
+  def verify_remote_log_messages(messages, remote_log, hosts, domain)
+    syslog_servers = hosts_with_role(hosts, 'syslog_server')
+
+    hosts.each do |host|
+      logdir = "/var/log/hosts/#{host.name}.#{domain}"
+      messages.each do |message|
+        on(syslog_servers, "egrep '#{message}' #{logdir}/#{remote_log}")
+      end
+    end
+  end
+
+  def restart_rsyslog(hosts)
+    cmds = [
+      'puppet resource service rsyslog ensure=stopped',
+      'puppet resource service rsyslog ensure=running'
+    ]
+    on(hosts, "#{cmds.join('; ')}")
+
+    # give rsyslogd time to really start up
+    sleep(5)
+  end
+
+  let(:files_dir) { 'spec/acceptance/common_files' }
+
+  let(:default_yaml_filename) {
+    '/etc/puppetlabs/code/environments/simp/hieradata/default.yaml'
+  }
+
+  let(:site_module_path) {
+    '/etc/puppetlabs/code/environments/simp/modules/site'
+  }
+
+  let(:default_hieradata) {
+    # hieradata that allows beaker operations access
+    beaker_hiera = YAML.load(File.read("#{files_dir}/beaker_hiera.yaml"))
+
+    hiera        = beaker_hiera.merge( {
+      'simp::rsync_stunnel'         => master_fqdn,
+      'rsyslog::enable_tls_logging' => true,
+      'simp_rsyslog::forward_logs'  => true,
+
+      # to ensure all hosts have a cron that runs every minute for a test below
+      'swap::cron_step'             => 1,
+
+      # set up local users for further testing
+      'classes'                     => [ 'site::local_users' ]
+    } )
+    hiera
+  }
+
+  let (:bad_default_hieradata) {
+    hiera = default_hieradata.dup
+    # unknown class 'oops'
+    hiera['classes'] = [ 'site::local_users', 'oops' ]
+    hiera
+  }
+
+  let (:forward_audit_logs_hieradata) {
+    hiera = default_hieradata.dup
+    hiera['auditd::config::audisp::syslog::drop_audit_logs'] = false
+    hiera
+  }
+
+  context 'additional site manifest/hieradata staging' do
+    it 'should install additional manifests and update hieradata' do
+      dest = "#{site_module_path}/manifests/local_users.pp"
+      scp_to(master, "#{files_dir}/site/local_users.pp", dest)
+      on(master, "chown root:puppet #{dest}")
+      on(master, "chmod 0640 #{dest}")
+
+      create_remote_file(master, default_yaml_filename, default_hieradata.to_yaml)
+    end
+  end
+
+  context 'basic logs' do
+    it 'should generate local puppet agent and puppet server logs' do
+      on(hosts, 'puppet agent -t', :accept_all_exit_codes => true)
+
+      # To force an error, add an unknown class 'oops' to the default.yaml
+      create_remote_file(master, default_yaml_filename, bad_default_hieradata.to_yaml)
+      on(hosts, 'puppet agent -t', :accept_all_exit_codes => true)
+
+      # Restore valid default.yaml
+      create_remote_file(master, default_yaml_filename, default_hieradata.to_yaml)
+
+      on(non_syslog_servers, "grep 'Applied catalog in' /var/log/puppet-agent.log")
+      on(non_syslog_servers, "grep 'Could not find class ::oops ' /var/log/puppet-agent-err.log")
+
+      on(master, "ls /var/log/puppetserver.log")
+      on(master, "grep 'Could not find class ::oops ' /var/log/puppetserver-err.log")
+    end
+
+    it 'should forward puppet agent logs' do
+      verify_remote_log_messages(['Applied catalog in'], 'puppet_agent.log', hosts, domain)
+      verify_remote_log_messages(['Could not find class ::oops '], 'puppet_agent_error.log',
+        hosts, domain)
+    end
+
+    it 'should forward puppetserver logs' do
+      logdir = "/var/log/hosts/#{master.name}.#{domain}"
+      on(syslog_servers, "ls #{logdir}/puppetserver.log")
+      on(syslog_servers, "grep 'Could not find class ::oops ' #{logdir}/puppetserver_error.log")
+    end
+
+    it 'should generate systemd log messages in the local secure log' do
+      hosts.each do |host|
+        facts = JSON.load(on(host, 'puppet facts').stdout)
+        if facts['values']['systemd']
+          on(host, 'systemctl restart haveged.service')
+          unless host.host_hash[:roles].include?('syslog_server')
+            on(host, "grep 'systemd: Stopping Entropy Daemon based on the HAVEGE' /var/log/secure")
+            on(host, "grep 'systemd: Starting Entropy Daemon based on the HAVEGE' /var/log/secure")
+          end
+        else
+          puts "Skipping host #{host.name}, which does not use systemd"
+        end
+      end
+    end
+
+    it 'should forward systemd logs' do
+      hosts.each do |host|
+        facts = JSON.load(on(host, 'puppet facts').stdout)
+        if facts['values']['systemd']
+          logdir = "/var/log/hosts/#{host.name}.#{domain}"
+          on(syslog_servers, "grep 'systemd: Stopping Entropy Daemon based on the HAVEGE' #{logdir}/secure.log")
+          on(syslog_servers, "grep 'systemd: Starting Entropy Daemon based on the HAVEGE' #{logdir}/secure.log")
+        else
+          puts "Skipping host #{host.name}, which does not use systemd"
+        end
+      end
+    end
+
+    it 'should generate a local yum log' do
+      hosts.each do |host|
+        host.install_package('expect')
+        unless host.host_hash[:roles].include?('syslog_server')
+          on(host, "grep 'Installed: expect' /var/log/yum.log")
+        end
+      end
+    end
+
+    it 'should forward yum logs' do
+      verify_remote_log_messages(['Installed: expect'], 'secure.log', hosts, domain)
+    end
+
+    it 'should generate a local cron log' do
+      # retry_on() is supposed to work on Hosts array, but doesn't
+      non_syslog_servers.each do |host|
+        retry_on(host,
+          "egrep 'CROND.*: .root. CMD ./usr/local/sbin/dynamic_swappiness.rb' /var/log/cron",
+          {:retry_interval =>5, :max_retries => 15}
+        )
+      end
+    end
+
+    it 'should forward cron logs' do
+      verify_remote_log_messages(['CROND.*: .root. CMD ./usr/local/sbin/dynamic_swappiness.rb'],
+        'cron.log', hosts, domain)
+    end
+
+    it "should forward 'crond' identity logs" do
+      # When you restart the crond service, its shutdown logs go to secure.log,
+      # locally, but <host>/cron.log on the remote server.  This inconsistency
+      # is not ideal, but, as the logs are not lost, is not a show stopper.
+      skip('crond logs end up in <host>/cron.log, not <host>/secure.log')
+    end
+
+    # Per rsyslog and simp_rsyslog config:
+    # Local server:         local7.*      => /var/log/boot.log
+    # Forward rule(?):      local7.warn (and above)
+    # Remote syslog server: boot identity => /var/log/host/<host>/boot.log
+    it "should forward 'boot' identity logs" do
+      # Rebooting machine doesn't result in messages with identity 'boot' being
+      # forwarded to the remote syslog server
+      # FIXME
+      # - Is the boot identity appropriate?
+      # - Should the boot identity be added to the forwarding rule or is
+      #   local7.warn sufficient?
+      # - Should the remote syslot server rule be local7.*, instead of
+      #   boot identity?
+      skip('Unable to generate appropriate logs for forwarding')
+    end
+  end
+
+  context 'security application logs' do
+    it 'should generate aide a local aide log' do
+      on(hosts, '/usr/sbin/aide -C', :accept_all_exit_codes => true)
+      # since we haven't updated the database but have made many changes,
+      # some changes should be noted
+      on(non_syslog_servers, "grep 'found differences between database and filesystem' /var/log/aide/aide.log")
+    end
+
+    it 'should forward aide logs' do
+      verify_remote_log_messages(['found differences between database and filesystem'],
+        'aide.log', hosts, domain)
+    end
+
+    it 'should generate a local iptables.log' do
+      hosts.each { |host| host.install_package('wget') }
+
+      # None of the servers are set up as web servers, yet, so attempting
+      # web access to these servers should result in iptables dropped
+      # packet logs
+      non_syslog_servers.each do |host|
+        cmd = "wget --tries=1 --timeout=1 https://#{host.name}.#{domain}/somefile"
+        on(syslog_servers, cmd, :accept_all_exit_codes => true)
+      end
+
+      syslog_servers.each do |host|
+        cmd = "wget --tries=1 --timeout=1 https://#{host.name}.#{domain}/somefile"
+        on(non_syslog_servers.first, cmd, :accept_all_exit_codes => true)
+      end
+
+      on(non_syslog_servers, "grep 'kernel: IPT:' /var/log/iptables.log")
+    end
+
+    it 'should forward iptables dropped packet logs' do
+      verify_remote_log_messages(['kernel: IPT:'], 'iptables.log', hosts, domain)
+    end
+
+    it 'should generate a local sudosh.log' do
+      # This test will use an expect script that ssh's to a host as a
+      # local user configured with no password sudosh privileges, runs
+      # 'sudo sudosh', and then executes a root-level command.
+      scp_to(master, "#{files_dir}/ssh_sudo_sudosh_script", '/usr/local/bin/ssh_sudo_sudosh_script')
+      on(master, "chmod +x /usr/local/bin/ssh_sudo_sudosh_script")
+      master_os_major = fact_on(master, 'operatingsystemmajrelease')
+      hosts.each do |host|
+        os_major = fact_on(host, 'operatingsystemmajrelease')
+        cmd ="/usr/local/bin/ssh_sudo_sudosh_script localadmin #{host.name} P@ssw0rdP@ssw0rd"
+
+        # FIXME: Workaround for SIMP-5082
+        if master_os_major.to_s == '7'
+          if (os_major.to_s == '6')
+            cmd +=" '-o MACs=hmac-sha1'"
+          end
+        elsif master_os_major.to_s == '6'
+          if (os_major.to_s == '7')
+            cmd +=" '-o MACs=hmac-sha2-256'"
+          end
+        end
+
+      hosts.each do |host|
+        on(master, cmd)
+        unless host.host_hash[:roles].include?('syslog_server')
+          on(host, "grep 'sudosh: starting session for localadmin as root' /var/log/sudosh.log")
+          on(host, "grep 'sudosh: stopping session for localadmin as root' /var/log/sudosh.log")
+        end
+      end
+    end
+
+    it 'should forward sudosh logs' do
+      verify_remote_log_messages(
+        [ 'sudosh: starting session for localadmin as root',
+          'sudosh: stopping session for localadmin as root'
+        ],
+        'sudosh.log', hosts, domain)
+    end
+
+    it 'should generate sudo messages in the local secure log' do
+      # The previous test should have generated sudo logs about 'sudo sudosh'
+      on(non_syslog_servers, "grep 'sudo: localadmin : .* COMMAND=.*/sudosh' /var/log/secure")
+    end
+
+    it 'should forward sudo logs' do
+      verify_remote_log_messages(
+        ['sudo: localadmin : .* COMMAND=.*/sudosh'], 'secure.log',
+        hosts, domain)
+    end
+
+    it 'should enable audit log forwarding' do
+      create_remote_file(master, default_yaml_filename, forward_audit_logs_hieradata.to_yaml)
+      on(hosts, 'puppet agent -t', :accept_all_exit_codes => true)
+
+      # FIXME: Workaround for SIMP-5161 bug
+      restart_rsyslog(hosts)
+    end
+
+    it 'should generate a local audit.log' do
+      # Generate audit records by changing the selinux context of a file.
+      # Since we don't want to screw anything up, first create a file
+      # in root's home dir and then change its context.
+      on(hosts, 'date > /root/date.txt')
+      on(hosts, 'ls -Z /root/date.txt')
+      on(hosts, 'chcon --user system_u /root/date.txt')
+      on(hosts, 'chcon --user unconfined_u /root/date.txt')
+      on(hosts, "grep 'type=SYSCALL .*/chcon' /var/log/audit/audit.log")
+    end
+
+    it 'should forward audit logs' do
+      retried = false
+      begin
+        verify_remote_log_messages(['type=SYSCALL .*/chcon'], 'auditd.log', hosts, domain)
+      rescue Beaker::Host::CommandFailure => e
+        if retried
+          $stderr.puts '#'*80
+          $stderr.puts 'Restart of auditd did not allow audit logs to be forwarded'
+          $stderr.puts '#'*80
+          raise e
+        end
+
+        $stderr.puts '>'*80
+        $stderr.puts 'WARNING: Failed to forward audit logs.'
+        $stderr.puts 'WARNING: Restarting auditd and retrying.'
+        # Have had problems with this that I haven't able to track down.
+        # Examination of the auditd source code does not show an obvious reason
+        # why the dispatch stops working.  Events to the syslog dispatcher that
+        # can't be sent to syslog are simply discarded and the syslog C api is
+        # being used normally...
+        on(hosts, 'service auditd restart')
+
+        # redo some chcon operations
+        on(hosts, 'chcon --user system_u /root/date.txt')
+        on(hosts, 'chcon --user unconfined_u /root/date.txt')
+        $stderr.puts '<'*80
+
+        retried = true
+        retry
+      end
+    end
+
+    it 'should generate auditd messages in the local secure log' do
+      # restarting via a pair of 'puppet resource service auditd ensure=...'
+      # operations returned a failure with 'stopped', so had to fall back on
+      # command that actually works (even on el7)
+      on(hosts, 'service auditd restart')
+
+      on(non_syslog_servers, "egrep 'auditd\\[[0-9]+\\]: ' /var/log/secure")
+    end
+
+    it 'should forward auditd logs' do
+      verify_remote_log_messages(['auditd\\[[0-9]+\\]: '], 'secure.log', hosts, domain)
+    end
+
+    # turn off audit forwarding for future tests, as it can be prolific
+    it 'should disable audit log forwarding' do
+      create_remote_file(master, default_yaml_filename, default_hieradata.to_yaml)
+      on(hosts, 'puppet agent -t', :accept_all_exit_codes => true)
+
+      # FIXME: Workaround for SIMP-5161 bug
+      restart_rsyslog(hosts)
+    end
+
+    it "should forward 'audit' identity logs" do
+      # Don't know how to stimulate auditd to create such logs
+      # (TODO Is forwarding rule OBE?)
+      skip('Unable to generate appropriate logs for forwarding')
+    end
+
+  end
+
+=begin
+  context 'other important application logs' do
+# Some other logs for which we have rules generated from SIMP modules
+#
+# Log Type                 Local Log                  Remote Host-specific Log
+# emergency logs (*.emerg) /var/log/secure            /var/log/host/<host>/emergency.log
+# kernel logs (kern.*)     No match                   /var/log/host/<host>/kernel.log
+# dhcpd logs               /var/log/dhcpd.log         /var/log/host/<host>/dhcpd.log
+# httpd error logs         /var/log/httpd/error_log   /var/log/host/<host>/httpd_error.log
+# httpd non-error logs     /var/log/httpd/access_log  /var/log/host/<host>/httpd.log
+# mail logs                /var/log/maillog           /var/log/host/<host>/mail.log
+# snmpd logs               /var/log/snmpd.log         /var/log/host/<host>/snmpd.log
+# slapd audit logs         /var/log/slapd_audit.log   /var/log/host/<host>/slapd_audit.log
+# spool logs               /var/log/spooler           /var/log/host/<host>/spool.log
+# any other *.info and     N/A                        /var/log/host/<host>/messages.log
+#   above forwarded
+#   messages that have
+#   no specific dest file
+# catchall for remaining   N/A                        /var/log/host/<host>/catchall.log
+#   forwarded messages that
+#   have no specific dest
+#   file and don't make it
+#   into /var/log/host/<host>/messages.
+  end
+=end
+
+end

--- a/spec/acceptance/suites/install_from_tar/20_local_users_spec.rb
+++ b/spec/acceptance/suites/install_from_tar/20_local_users_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper_tar'
+
+test_name 'local user access'
+
+# There have been SIMP problems in the past in which a local user with
+# root privileges has not been able to login when that user's password
+# has been changed.  This test is to make sure that regression never
+# occurs!
+
+describe 'local user access' do
+
+  let(:files_dir) { 'spec/acceptance/common_files' }
+
+  context 'local user login' do
+    it 'should have localadmin user on all hosts' do
+      # The user in this test, localadmin, has been ASSUMED to have
+      # been setup in a previous test using the local_users.pp manifest.
+      # Just in case someone rearranges the test files and doesn't
+      # adjust this test, accordingly...
+      on(hosts, 'id -u localadmin')
+    end
+
+    it 'local user should be able to login via ssh' do
+      # This test will use an expect script that ssh's to a host as a
+      # user and then runs 'date'.
+      scp_to(master, "#{files_dir}/ssh_cmd_script", '/usr/local/bin/ssh_cmd_script')
+      on(master, "chmod +x /usr/local/bin/ssh_cmd_script")
+      master_os_major = fact_on(master, 'operatingsystemmajrelease')
+      hosts.each do |host|
+        cmd ="/usr/local/bin/ssh_cmd_script localadmin #{host.name} #{test_password(0)} date"
+
+        # FIXME: Workaround for SIMP-5082
+        os_major = fact_on(host, 'operatingsystemmajrelease')
+        if master_os_major.to_s == '7'
+          cmd +=" '-o MACs=hmac-sha1'" if (os_major.to_s == '6')
+        elsif master_os_major.to_s == '6'
+          cmd +=" '-o MACs=hmac-sha2-256'" if (os_major.to_s == '7')
+        end
+
+        on(master, cmd)
+      end
+    end
+
+    it 'user should be able to change password' do
+begin
+      scp_to(master, "#{files_dir}/ssh_change_password_script", '/usr/local/bin/ssh_change_password_script')
+      on(master, "chmod +x /usr/local/bin/ssh_change_password_script")
+
+      # Allow user to change the password early
+      on(hosts, 'passwd --minimum 0 localadmin')
+
+      master_os_major = fact_on(master, 'operatingsystemmajrelease')
+      hosts.each do |host|
+        cmd ="/usr/local/bin/ssh_change_password_script localadmin #{host.name} #{test_password(0)} #{test_password(1)}"
+
+        # FIXME: Workaround for SIMP-5082
+        os_major = fact_on(host, 'operatingsystemmajrelease')
+        if master_os_major.to_s == '7'
+          cmd +=" '-o MACs=hmac-sha1'" if (os_major.to_s == '6')
+        elsif master_os_major.to_s == '6'
+          cmd +=" '-o MACs=hmac-sha2-256'" if (os_major.to_s == '7')
+        end
+
+        on(master, cmd)
+      end
+rescue => e
+puts "#{e}"
+require 'pry-byebug'
+binding.pry
+end
+    end
+
+    it 'local user should be able to login with new password via ssh' do
+begin
+      master_os_major = fact_on(master, 'operatingsystemmajrelease')
+      hosts.each do |host|
+        cmd ="/usr/local/bin/ssh_cmd_script localadmin #{host.name} #{test_password(1)} date"
+
+        # FIXME: Workaround for SIMP-5082
+        os_major = fact_on(host, 'operatingsystemmajrelease')
+        if master_os_major.to_s == '7'
+          cmd +=" '-o MACs=hmac-sha1'" if (os_major.to_s == '6')
+        elsif master_os_major.to_s == '6'
+          cmd +=" '-o MACs=hmac-sha2-256'" if (os_major.to_s == '7')
+        end
+
+        on(master, cmd)
+      end
+rescue => e
+puts "#{e}"
+require 'pry-byebug'
+binding.pry
+end
+
+    end
+  end
+end

--- a/spec/acceptance/suites/install_from_tar/20_local_users_spec.rb
+++ b/spec/acceptance/suites/install_from_tar/20_local_users_spec.rb
@@ -25,73 +25,39 @@ describe 'local user access' do
       # user and then runs 'date'.
       scp_to(master, "#{files_dir}/ssh_cmd_script", '/usr/local/bin/ssh_cmd_script')
       on(master, "chmod +x /usr/local/bin/ssh_cmd_script")
-      master_os_major = fact_on(master, 'operatingsystemmajrelease')
       hosts.each do |host|
-        cmd ="/usr/local/bin/ssh_cmd_script localadmin #{host.name} #{test_password(0)} date"
+        base_cmd ="/usr/local/bin/ssh_cmd_script localadmin #{host.name} #{test_password(0)} date"
 
         # FIXME: Workaround for SIMP-5082
-        os_major = fact_on(host, 'operatingsystemmajrelease')
-        if master_os_major.to_s == '7'
-          cmd +=" '-o MACs=hmac-sha1'" if (os_major.to_s == '6')
-        elsif master_os_major.to_s == '6'
-          cmd +=" '-o MACs=hmac-sha2-256'" if (os_major.to_s == '7')
-        end
-
+        cmd = adjust_ssh_ciphers_for_expect_script(base_cmd, master, host)
         on(master, cmd)
       end
     end
 
     it 'user should be able to change password' do
-begin
       scp_to(master, "#{files_dir}/ssh_change_password_script", '/usr/local/bin/ssh_change_password_script')
       on(master, "chmod +x /usr/local/bin/ssh_change_password_script")
 
       # Allow user to change the password early
       on(hosts, 'passwd --minimum 0 localadmin')
 
-      master_os_major = fact_on(master, 'operatingsystemmajrelease')
       hosts.each do |host|
-        cmd ="/usr/local/bin/ssh_change_password_script localadmin #{host.name} #{test_password(0)} #{test_password(1)}"
+        base_cmd ="/usr/local/bin/ssh_change_password_script localadmin #{host.name} #{test_password(0)} #{test_password(1)}"
 
         # FIXME: Workaround for SIMP-5082
-        os_major = fact_on(host, 'operatingsystemmajrelease')
-        if master_os_major.to_s == '7'
-          cmd +=" '-o MACs=hmac-sha1'" if (os_major.to_s == '6')
-        elsif master_os_major.to_s == '6'
-          cmd +=" '-o MACs=hmac-sha2-256'" if (os_major.to_s == '7')
-        end
-
+        cmd = adjust_ssh_ciphers_for_expect_script(base_cmd, master, host)
         on(master, cmd)
       end
-rescue => e
-puts "#{e}"
-require 'pry-byebug'
-binding.pry
-end
     end
 
     it 'local user should be able to login with new password via ssh' do
-begin
-      master_os_major = fact_on(master, 'operatingsystemmajrelease')
       hosts.each do |host|
-        cmd ="/usr/local/bin/ssh_cmd_script localadmin #{host.name} #{test_password(1)} date"
+        base_cmd ="/usr/local/bin/ssh_cmd_script localadmin #{host.name} #{test_password(1)} date"
 
         # FIXME: Workaround for SIMP-5082
-        os_major = fact_on(host, 'operatingsystemmajrelease')
-        if master_os_major.to_s == '7'
-          cmd +=" '-o MACs=hmac-sha1'" if (os_major.to_s == '6')
-        elsif master_os_major.to_s == '6'
-          cmd +=" '-o MACs=hmac-sha2-256'" if (os_major.to_s == '7')
-        end
-
+        cmd = adjust_ssh_ciphers_for_expect_script(base_cmd, master, host)
         on(master, cmd)
       end
-rescue => e
-puts "#{e}"
-require 'pry-byebug'
-binding.pry
-end
-
     end
   end
 end

--- a/spec/acceptance/suites/install_from_tar/30_ldap_users_spec.rb
+++ b/spec/acceptance/suites/install_from_tar/30_ldap_users_spec.rb
@@ -1,0 +1,136 @@
+require 'spec_helper_tar'
+
+test_name 'LDAP user access'
+
+# There have been SIMP problems in the past in which some LDAP users
+# have not been able to login when their respective passwords have
+# been changed.  This test is to make sure that regression never occurs!
+
+describe 'LDAP user access' do
+  master_fqdn = fact_on(master, 'fqdn')
+  agents      = hosts_with_role(hosts, 'agent')
+
+  # subset of LDAP users for whom we want to execute login tests
+  ldap_users  = [ 'admin2', 'auditor1' ]
+
+  let(:files_dir) { 'spec/acceptance/common_files' }
+
+  let(:base_dn) do
+    query = "puppet lookup --environment production --node #{master_fqdn} simp_options::ldap::base_dn"
+    on(master, query).stdout.gsub('---','').gsub('...','').strip
+  end
+
+  context 'LDAP user creation' do
+
+    let(:site_module_path) {
+      '/etc/puppetlabs/code/environments/simp/modules/site'
+    }
+
+    let(:puppet_master_yaml) {
+      "/etc/puppetlabs/code/environments/simp/hieradata/hosts/#{master_fqdn}.yaml"
+    }
+
+    let(:puppet_master_hieradata) do
+      on(master, "echo -n #{test_password} > /root/slappasswd.tmp")
+      password_hash = on(master, "slappasswd -T /root/slappasswd.tmp 2>/dev/null").stdout.strip
+      on(master, 'rm -rf /root/slappasswd.tmp')
+
+      master_hiera = YAML.load(on(master, "cat #{puppet_master_yaml}").stdout)
+      master_hiera['classes'] << 'site::test_ldifs'
+      master_hiera['site::test_ldifs::user_password_hash'] = password_hash
+      master_hiera
+    end
+
+    it 'should install additional manifests and update hieradata' do
+      dest = "#{site_module_path}/manifests/test_ldifs.pp"
+      scp_to(master, "#{files_dir}/site/manifests/test_ldifs.pp", dest)
+
+      on(master, "mkdir -p #{site_module_path}/templates/ldifs")
+      dest = "#{site_module_path}/templates/ldifs/add_test_users.ldif.epp"
+      scp_to(master, "#{files_dir}/site/templates/ldifs/add_test_users.ldif.epp", dest)
+
+      dest = "#{site_module_path}/templates/ldifs/modify_test_users.ldif.epp"
+      scp_to(master, "#{files_dir}/site/templates/ldifs/modify_test_users.ldif.epp", dest)
+
+      dest = "#{site_module_path}/templates/ldifs/force_test_users_password_reset.ldif.epp"
+      scp_to(master, "#{files_dir}/site/templates/ldifs/force_test_users_password_reset.ldif.epp", dest)
+
+      on(master, "chown -R root:puppet #{site_module_path}")
+      on(master, "chmod -R g+rX #{site_module_path}")
+
+      create_remote_file(master, puppet_master_yaml, puppet_master_hieradata.to_yaml)
+    end
+
+    it 'should generate ldif files' do
+      on(master, 'puppet agent -t', :accept_all_exit_codes => true)
+      on(master, 'ls /root/ldifs/add_test_users.ldif /root/ldifs/modify_test_users.ldif /root/ldifs/force_test_users_password_reset.ldif')
+    end
+
+    it 'should create LDAP users' do
+      # add users
+      ldap_cmd = "/usr/bin/ldapadd -Z -x -w #{test_password} -D \"cn=LDAPAdmin,OU=People,#{base_dn}\" -f /root/ldifs/add_test_users.ldif"
+      on(master, ldap_cmd)
+
+      # modify some user groups
+      ldap_cmd = "/usr/bin/ldapmodify -Z -x -w #{test_password} -D \"cn=LDAPAdmin,OU=People,#{base_dn}\" -f /root/ldifs/modify_test_users.ldif"
+      on(master, ldap_cmd)
+
+      # verify existence of LDAP users we are using in this test
+      ldap_users.each do |ldap_user|
+        on(hosts, "id -u #{ldap_user}")
+      end
+    end
+  end
+
+  context 'LDAP user login' do
+
+    it 'should install expect scripts on master' do
+      # This test will use an expect script that ssh's to a host as a
+      # user and then runs 'date'.
+      scp_to(master, "#{files_dir}/ssh_cmd_script", '/usr/local/bin/ssh_cmd_script')
+      on(master, "chmod +x /usr/local/bin/ssh_cmd_script")
+
+      scp_to(master, "#{files_dir}/ssh_password_change_required_script", '/usr/local/bin/ssh_password_change_required_script')
+      on(master, "chmod +x /usr/local/bin/ssh_password_change_required_script")
+    end
+
+    ldap_users.each do |ldap_user|
+      it 'LDAP user #{ldap_user} should be able to login via ssh' do
+        hosts.each do |host|
+          base_cmd ="/usr/local/bin/ssh_cmd_script #{ldap_user} #{host.name} #{test_password(0)} date"
+
+          # FIXME: Workaround for SIMP-5082
+          cmd = adjust_ssh_ciphers_for_expect_script(base_cmd, master, host)
+          on(master, cmd)
+        end
+      end
+    end
+
+    it 'should be able to force password resets' do
+      ldap_cmd = "/usr/bin/ldapmodify -Z -x -w #{test_password} -D \"cn=LDAPAdmin,OU=People,#{base_dn}\" -f /root/ldifs/force_test_users_password_reset.ldif"
+      on(master, ldap_cmd)
+    end
+
+    ldap_users.each do |ldap_user|
+      it "LDAP user #{ldap_user} should be forced to change password upon login via ssh" do
+        base_cmd ="/usr/local/bin/ssh_password_change_required_script #{ldap_user} #{agents[0].name} #{test_password(0)} #{test_password(1)}"
+
+        # FIXME: Workaround for SIMP-5082
+        cmd = adjust_ssh_ciphers_for_expect_script(base_cmd, master, agents[0])
+        on(master, cmd)
+      end
+    end
+
+    ldap_users.each do |ldap_user|
+      it 'LDAP user #{ldap_user} should be able to login with new password via ssh' do
+        hosts.each do |host|
+          base_cmd ="/usr/local/bin/ssh_cmd_script #{ldap_user} #{host.name} #{test_password(1)} date"
+
+          # FIXME: Workaround for SIMP-5082
+          cmd = adjust_ssh_ciphers_for_expect_script(base_cmd, master, host)
+          on(master, cmd)
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/suites/install_from_tar/default.yml
+++ b/spec/acceptance/suites/install_from_tar/default.yml
@@ -1,1 +1,0 @@
-el7_server.yml

--- a/spec/spec_helper_tar.rb
+++ b/spec/spec_helper_tar.rb
@@ -4,6 +4,13 @@ require 'yaml'
 require 'simp/beaker_helpers'
 include Simp::BeakerHelpers
 
+module SimpCoreTest
+ # NOTE:  These passwords will be enclosed in single quotes when used on
+ #        the shell command line. So, to simplify the code that uses
+ #        them, these passwords should not contain single quotes.
+ TEST_PASSWORDS = [ "P@ssw0rdP@ssw0rd", "Ch@ng3d=P@ssw0r!" ]
+end
+
 unless ENV['BEAKER_provision'] == 'no'
   hosts.each do |host|
     # Install Facter for beaker helpers
@@ -23,7 +30,7 @@ def find_tarball(relver,osname)
   end
 # If it begins with https: then download it from that URL
   if tarball =~ /https/
-    filename = 'SIMP-downloaded-CentOS-7-x86_64.tar.gz'
+    filename = "SIMP-downloaded-#{osname}-#{relver}-x86_64.tar.gz"
     url = "#{tarball}"
     require 'net/http'
     Dir.exists?("spec/fixtures") || Dir.mkdir("spec/fixtures")
@@ -70,6 +77,12 @@ def internet_deprepo(host)
   reponame = ENV['BEAKER_repo']
   reponame ||= '6_X'
   on(host, "curl -s https://packagecloud.io/install/repositories/simp-project/#{reponame}_Dependencies/script.rpm.sh | bash")
+end
+
+# Returns the plain-text, test password for the index specified
+#
+def test_password(index = 0)
+  SimpCoreTest::TEST_PASSWORDS[index]
 end
 
 RSpec.configure do |c|

--- a/spec/spec_helper_tar.rb
+++ b/spec/spec_helper_tar.rb
@@ -85,6 +85,26 @@ def test_password(index = 0)
   SimpCoreTest::TEST_PASSWORDS[index]
 end
 
+# FIXME: Workaround for SIMP-5082
+# Using the (ASSUMED) optional, final command line argument in an expect
+# script, adjust ciphers used by that script to ssh from src_host to
+# dest_host, if necessary.  This ugly adjustment is needed in order to
+# deal with different cipher sets configured by SIMP for sshd for CentOS 6
+# versus CentOS 7.
+#
+# Returns the expect command
+def adjust_ssh_ciphers_for_expect_script(expect_cmd, src_host, dest_host)
+  cmd = expect_cmd.dup
+  src_os_major  = fact_on(src_host, 'operatingsystemmajrelease')
+  dest_os_major = fact_on(dest_host, 'operatingsystemmajrelease')
+  if src_os_major.to_s == '7'
+    cmd +=" '-o MACs=hmac-sha1'" if (dest_os_major.to_s == '6')
+  elsif src_os_major.to_s == '6'
+    cmd +=" '-o MACs=hmac-sha2-256'" if (dest_os_major.to_s == '7')
+  end
+  cmd
+end
+
 RSpec.configure do |c|
   # ensure that environment OS is ready on each host
   # fix_errata_on hosts


### PR DESCRIPTION
Added a rsyslog integration test to the install_from_tar
release suite.  This new test is far from complete, but
hits the highlights.

To run this test with the SIMP-6.2.0-Beta2 tar:
1) Temporarily remove spec/acceptance/suites/install_from_tar/metadata.yml
2) Execute:

BEAKER_release_tarball=https://download.simp-project.com/\
SIMP/ISO/tar_bundles/SIMP-6.2.0-Beta2.el7-CentOS-7-x86_64.tar.gz \
bundle exec rake beaker:suites[install_from_tar]

BEAKER_release_tarball=https://download.simp-project.com/\
SIMP/ISO/tar_bundles/SIMP-6.2.0-Beta2.el6-CentOS-6-x86_64.tar.gz \
bundle exec rake beaker:suites[install_from_tar,el6_server]

SIMP-5058 #close