### PR TITLE
(SIMP-5170) Align Puppetfile versions with notes

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -362,10 +362,8 @@ simp-cli
 simp-core
 ^^^^^^^^^
 
-* Enabled GPG checking for the local filesystem repository by default
+* Enabled GPG checking for the ISO-configured local filesystem repository by default
 * Fixed errors in the ``kickstart`` scriptlets
-* EL7 kickstart files were updated to use the latest kickstart API
-* EL6 kickstart files were updated to more closely match the EL7 kickstart files
 * SSD devices are better detected by the ``diskdetect.sh`` script
 * Removed obsolete ``simp-big`` and ``simp-big-disk-crypt`` kickstart options in EL7
 * No longer install ``prelink`` at kickstart time
@@ -376,7 +374,7 @@ simp-core
 simp-doc
 ^^^^^^^^
 
-* Pinned ``reportlab`` to ``3.4.0`` due to a bug in ``3.5.0``
+* Remove OBE MCollective references
 
 simp-environment
 ^^^^^^^^^^^^^^^^
@@ -424,6 +422,14 @@ pupmod-simp-libvirt
 * Use ``kmod::load`` instead of a Ruby script to load the kernel module
 * Added a ``libvirt_br_netfilter_loaded`` fact to determine if the
   ``br_netfilter`` kernel module is loaded
+
+pupmod-simp-logrotate
+^^^^^^^^^^^^^^^^^^^^^
+
+* Move SIMP-specific logrotate rules to a SIMP-managed configuration
+  directory, ``/etc/logrotate.simp.d``, and ensure ``logrotate`` processes
+  that directory first. This ensures SIMP rules take priority, when duplicate
+  rules are specified (e.g., OS and SIMP rules for ``/var/log/boot.log``.
 
 pupmod-simp-nfs
 ^^^^^^^^^^^^^^^
@@ -657,11 +663,23 @@ simp-core
 ^^^^^^^^^
 
 * Add logic to auto.cfg to use OS-specific GPG keys in simp_filesystem.repo.
+* Client kickstart files were updated to use the latest ``simp::server::kickstart``
+  API and to provide support for UEFI PXE boot
+* EL6 kickstart files were updated to more closely match the EL7 kickstart files
 
 simp-doc
 ^^^^^^^^
 
+* Added SIMP 6.1.0 to 6.2.0 upgrade guide
+* Added SIMP on AWS documentation
+* Added a HOWTO for IPA client enrollment
+* Added a HOWTO for customizing settings for SSH
+* Added documentation on how to disconnect from ``puppetDB``
 * Updated the documentation for UEFI PXE booting.
+* Clarified certificate management
+* Restructured pages for better navigation
+* Updated contributors guide to description more details about the development
+  workflow
 
 simp-vendored-r10k
 ^^^^^^^^^^^^^^^^^^

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -94,6 +94,8 @@ RPM Updates
   modules.
 
 * Updated to the latest ``5.X`` release of Elasticsearch and Logstash
+* Updated the ClamAV packages to 0.100.0-2
+* Removed clamav-data-empty which is no longer used
 
 Removed Modules
 ---------------
@@ -138,6 +140,9 @@ pupmod-simp-aide
 ^^^^^^^^^^^^^^^^
 
 * Added /etc/logrotate.simp.d to default rules.
+* Ensure that the ``package`` install comes before dependent ``exec``
+  statements.
+* Allow the ``cron`` command to be customized.
 
 pupmod-simp-compliance_markup
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -186,6 +191,12 @@ pupmod-simp-named
 * Properly override the ``systemd`` service file for ``named-chroot`` instead
   of modifying the vendor provided service file.
 
+pupmod-simp-ntpd
+^^^^^^^^^^^^^^^^
+
+* Fixed a bug where ``ntpd::ntpd_options`` was not applied to ``ntpd::servers``
+  when ``ntpd::servers`` is an ``Array``
+
 pupmod-simp-pam
 ^^^^^^^^^^^^^^^
 
@@ -214,6 +225,8 @@ pupmod-simp-pupmod
   FOSS Puppet.
 * Properly disable the ``puppet`` service if running in cron mode. This was not
   disabled before and could contribute to a "thundering herd" issue.
+* Fixed the Java ``tmpdir`` path for the ``puppetserver`` which allows runs on
+  systems that have been pre-hardened
 
 pupmod-simp-rsync
 ^^^^^^^^^^^^^^^^^
@@ -230,6 +243,9 @@ pupmod-simp-rsyslog
   older versions of ``rsyslog``.
 * Fixed bug that did not allow a TLS encrypted server to be configured to forward
   to a follow-on unencrypted rsyslog server.
+* Fixed a bug where removing ``rsyslog::rule`` statements from the catalog
+  would not cause the ``rsyslog`` service to restart.
+* Clarified documentation around adding files to ``/etc/rsyslog.d``.
 
 pupmod-simp-selinux
 ^^^^^^^^^^^^^^^^^^^
@@ -271,6 +287,11 @@ pupmod-simp-simp_apache
 * Fix the ownership of the configuration files to use the ``owner`` variable
   instead of the ``group`` variable for user ownership.
 
+pupmod-simp-simp_elasticsearch
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* Add a missing ``simp/pam`` module dependency.
+
 pupmod-simp-simp_gitlab
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -278,6 +299,8 @@ pupmod-simp-simp_gitlab
 * Dropped all support for CentOS 6 due to issues that kept cropping up during
   integration and the overall lack of support from EL upstream to fix minor
   bugs.
+* Automatically opt-out of the GitLab data collection service in accordance
+  with NIST 800-53r4 AC-20(1) and SC-38.
 
 pupmod-simp-simp_nfs
 ^^^^^^^^^^^^^^^^^^^^
@@ -303,6 +326,8 @@ pupmod-simp-stunnel
   execute.
 * Only emit errors when errors occur during startup.
 * Removed the ``init.d`` script on ``systemd`` systems.
+* Ensure that the ``stunnel`` service name is set correctly in all instances so
+  that ``tcpwrappers`` functions properly.
 
 pupmod-simp-svckill
 ^^^^^^^^^^^^^^^^^^^
@@ -330,6 +355,9 @@ simp-cli
 * Improved validation and error handling.
 * Fix ``simp passgen`` processing of all password files and improved password
   generation.
+* Properly detect Puppet Enterprise on a system and avoid conflicting
+  operations.
+* Fixed some tests that were not safe to run on real operating systems.
 
 simp-core
 ^^^^^^^^^
@@ -345,6 +373,11 @@ simp-core
 * Removed EL7 references to function keys which no longer are honored
 * Fixed the boot directory when ``fips`` is enabled on the ISO
 
+simp-doc
+^^^^^^^^
+
+* Pinned ``reportlab`` to ``3.4.0`` due to a bug in ``3.5.0``
+
 simp-environment
 ^^^^^^^^^^^^^^^^
 
@@ -357,6 +390,7 @@ simp-environment
 * Fixed a bug where the ``cacertkey`` file was not being generated in the
   correct location at install time.
 * Removed ``simp_options::selinux`` from the scenario hieradata.
+* Force a run of ``fixfiles`` in the ``%post`` section of ``simp-environment``.
 
 simp-rsync
 ^^^^^^^^^^
@@ -404,12 +438,17 @@ pupmod-simp-nfs
 * Added ``nfs::client::mount::stunnel`` to allow users to dictate the
   ``stunnel`` state for individual connections.
 
-pupmod-simp-ntp
-^^^^^^^^^^^^^^^
+pupmod-simp-ntpd
+^^^^^^^^^^^^^^^^
 
 * Add optional management of the ``/etc/ntp/step-tickers`` file.
 * Add a ``$package_ensure`` parameter to control the ``ntp`` package version.
 * Add management of ``/etc/sysconfig/ntpdate``
+
+pupmod-simp-openldap
+^^^^^^^^^^^^^^^^^^^^
+
+* Ensure that ``concat`` ordering is set in ``numeric`` order.
 
 pupmod-simp-openscap
 ^^^^^^^^^^^^^^^^^^^^
@@ -542,6 +581,10 @@ pupmod-simp-simplib
   based on a supplied ``Hash``.
 * Added a ``simplib::module_exist`` function to detect the existence of a
   module.
+* Ensure that ``systemctl`` is never spawned more than once when attempting to
+  change the system ``runlevel``.
+* Fixed an issue in EL6 ``runlevel`` persistence where the line may not be
+  written to ``/etc/inittab``.
 
 pupmod-simp-ssh
 ^^^^^^^^^^^^^^^
@@ -613,7 +656,12 @@ pupmod-simp-useradd
 simp-core
 ^^^^^^^^^
 
-* Add logic to auto.cfg to use OS-specific GPG keys in simp_filesystem.repo
+* Add logic to auto.cfg to use OS-specific GPG keys in simp_filesystem.repo.
+
+simp-doc
+^^^^^^^^
+
+* Updated the documentation for UEFI PXE booting.
 
 simp-vendored-r10k
 ^^^^^^^^^^^^^^^^^^

--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -302,7 +302,7 @@ mod 'simp-nfs',
 
 mod 'simp-ntpd',
   :git => 'https://github.com/simp/pupmod-simp-ntpd',
-  :tag => '6.1.0'
+  :tag => '6.1.1'
 
 mod 'simp-oddjob',
   :git => 'https://github.com/simp/pupmod-simp-oddjob',
@@ -370,7 +370,7 @@ mod 'simp-simp_docker',
 
 mod 'simp-simp_elasticsearch',
   :git => 'https://github.com/simp/pupmod-simp-simp_elasticsearch',
-  :tag => '5.0.1'
+  :tag => '5.0.2'
 
 mod 'simp-simp_gitlab',
   :git => 'https://github.com/simp/pupmod-simp-simp_gitlab',


### PR DESCRIPTION
This bumps the versions of ntpd and simp_elasticsearch to match what was
specified in
https://simp-project.atlassian.net/wiki/spaces/SD/pages/315195398/SIMP+6.2.0

That did pull in some very minor bug fixes but both appeared worthwhile
and properly tested.

SIMP-5170 #comment align Puppetfile