### PR TITLE
(SIMP-5255) Fix install_from_core_module test prep

### DIFF
--- a/spec/acceptance/suites/install_from_core_module/00_simp_server_install_spec.rb
+++ b/spec/acceptance/suites/install_from_core_module/00_simp_server_install_spec.rb
@@ -52,9 +52,6 @@ describe 'install puppetserver modules from PuppetForge' do
     end
 
     it 'should install the module' do
-      # move residual PKI files that will cause puppet module install to fail
-      on(master, 'mv /etc/puppetlabs/code/environments/production/modules/pki /root/pki_backup')
-
       # install simp-simp_core and all its dependencies
       on(master, 'puppet module install /tmp/simp-simp_core*.tar.gz')
 

--- a/spec/acceptance/suites/install_from_core_module/metadata.yml
+++ b/spec/acceptance/suites/install_from_core_module/metadata.yml
@@ -1,2 +1,0 @@
----
-'default_run' : false

--- a/spec/acceptance/suites/install_from_rpm/metadata.yml
+++ b/spec/acceptance/suites/install_from_rpm/metadata.yml
@@ -1,2 +1,0 @@
----
-'default_run' : false

--- a/spec/acceptance/suites/install_from_tar/metadata.yml
+++ b/spec/acceptance/suites/install_from_tar/metadata.yml
@@ -1,2 +1,0 @@
----
-'default_run' : false


### PR DESCRIPTION
- Remove OBE PKI mv that was causing install_from_core_module to fail
  during test prep
- Remove unnecessary metadata.yml files from install_from_core_module,
  install_from_rpm, and install_from_tar, as the absense of these
  files means they won't be in the default suite, which is the
  desired behavior.  Otherwise, the user has to remove or edit
  these files to get them to run, even when beaker:suites is
  explicitly called with one of these suites.