### PR TITLE
(SIMP-5293) Emergency fix for simplib

### DIFF
--- a/Changelog.rst
+++ b/Changelog.rst
@@ -313,7 +313,7 @@ pupmod-simp-simplib
 
 * Fixed the ``puppet_settings`` fact so that the different sections are
   appropriately filled out.
-  If not updated, this has been shown to cause the puppetserver process to be
+  If not updated, this has been shown to cause the ``puppetserver`` process to be
   unable to restart on package update.
 * Fixed ``runlevel`` enforcement so that it activates properly when called.
   Previously, no action would be taken on the running system.

--- a/Changelog.rst
+++ b/Changelog.rst
@@ -311,6 +311,10 @@ pupmod-simp-simp_nfs
 pupmod-simp-simplib
 ^^^^^^^^^^^^^^^^^^^
 
+* Fixed the ``puppet_settings`` fact so that the different sections are
+  appropriately filled out.
+  If not updated, this has been shown to cause the puppetserver process to be
+  unable to restart on package update.
 * Fixed ``runlevel`` enforcement so that it activates properly when called.
   Previously, no action would be taken on the running system.
 * Added logic to prevent respawn of systemctl isolate if already in progress.

--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -358,7 +358,7 @@ mod 'simp-simpcat',
 
 mod 'simp-simplib',
   :git => 'https://github.com/simp/pupmod-simp-simplib',
-  :ref => '3.10.1'
+  :ref => '3.11.0'
 
 mod 'simp-simp_apache',
   :git => 'https://github.com/simp/pupmod-simp-simp_apache',

--- a/metadata.json
+++ b/metadata.json
@@ -252,7 +252,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.10.1 < 4.0.0"
+      "version_requirement": ">= 3.11.0 < 4.0.0"
     },
     {
       "name": "simp/simp_apache",

--- a/src/assets/simp/build/simp.spec
+++ b/src/assets/simp/build/simp.spec
@@ -81,7 +81,7 @@ Requires: pupmod-simp-rsyslog >= 7.2.0, pupmod-simp-rsyslog < 8.0.0
 Requires: pupmod-simp-selinux >= 2.2.0, pupmod-simp-selinux < 3.0.0
 Requires: pupmod-simp-simp >= 4.5.0, pupmod-simp-simp < 5.0.0
 Requires: pupmod-simp-simpcat >= 6.0.1, pupmod-simp-simpcat < 7.0.0
-Requires: pupmod-simp-simplib >= 3.10.1, pupmod-simp-simplib < 4.0.0
+Requires: pupmod-simp-simplib >= 3.11.0, pupmod-simp-simplib < 4.0.0
 Requires: pupmod-simp-simp_apache >= 6.0.2, pupmod-simp-simp_apache < 7.0.0
 Requires: pupmod-simp-simp_openldap >= 6.2.1, pupmod-simp-simp_openldap < 7.0.0
 Requires: pupmod-simp-simp_options >= 1.2.0, pupmod-simp-simp_options < 2.0.0
@@ -222,7 +222,7 @@ fi
 # Post uninstall stuff
 
 %changelog
-* Mon Sep 17 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.2.0-0
+*  Fri Sep 28 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.2.0-0
 - Update final dependencies for 6.2.0
 - Fix paths to configuration files
 - Remove the pupmod-puppetlabs-java_ks dependency from the simp package
@@ -239,6 +239,8 @@ fi
   - pupmod-simp-dirtycow
   - pupmod-simp-simp_docker
   - pupmod-simp-simp_ipa
+- Update the pupmod-simp-simplib version due to a bug that potentially
+  permanently breaks the puppetserver configuration
 
 * Thu Mar 15 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 6.2.0-0
 - Obsolete pupmod-electrical-file_concat in simp-extras package


### PR DESCRIPTION
During upgrade testing, it was discovered that a bug that we previously
believed was fixed was not due to a bug in the `puppet_settings` fact in
`simplib`.

This has been fixed and tested.

Without this fix, it is highly likely that the user's puppetserver
process will be unable to start without manual intervention upon
updating the puppetserver RPM to a newer version.

SIMP-5293 #comment Add simplib emergency fix for 6.2.0