### PR TITLE
(SIMP-5419) 6.2.0-0 Build Fixes

### DIFF
--- a/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
@@ -78,11 +78,11 @@ globus-gsi-sysconfig:
   :rpm_name: globus-gsi-sysconfig-8.1-3.el6.x86_64.rpm
   :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-gsi-sysconfig-8.1-3.el6.x86_64.rpm
 globus-gss-assist:
-  :rpm_name: globus-gss-assist-11.1-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-gss-assist-11.1-1.el6.x86_64.rpm
+  :rpm_name: globus-gss-assist-11.2-1.el6.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-gss-assist-11.2-1.el6.x86_64.rpm
 globus-gssapi-gsi:
-  :rpm_name: globus-gssapi-gsi-13.8-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-gssapi-gsi-13.8-1.el6.x86_64.rpm
+  :rpm_name: globus-gssapi-gsi-13.10-1.el6.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-gssapi-gsi-13.10-1.el6.x86_64.rpm
 globus-openssl-module:
   :rpm_name: globus-openssl-module-4.8-1.el6.x86_64.rpm
   :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-openssl-module-4.8-1.el6.x86_64.rpm

--- a/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
@@ -6,32 +6,32 @@ chkrootkit:
   :rpm_name: chkrootkit-0.50-4el7.x86_64.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/chkrootkit-0.50-4el7.x86_64.rpm
 clamav:
-  :rpm_name: clamav-0.100.1-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-0.100.1-1.el7.x86_64.rpm
+  :rpm_name: clamav-0.100.1-3.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-0.100.1-3.el7.x86_64.rpm
 clamav-data:
-  :rpm_name: clamav-data-0.100.1-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-data-0.100.1-1.el7.noarch.rpm
+  :rpm_name: clamav-data-0.100.1-3.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-data-0.100.1-3.el7.noarch.rpm
 clamav-devel:
-  :rpm_name: clamav-devel-0.100.1-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-devel-0.100.1-1.el7.x86_64.rpm
+  :rpm_name: clamav-devel-0.100.1-3.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-devel-0.100.1-3.el7.x86_64.rpm
 clamav-filesystem:
-  :rpm_name: clamav-filesystem-0.100.1-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-filesystem-0.100.1-1.el7.noarch.rpm
+  :rpm_name: clamav-filesystem-0.100.1-3.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-filesystem-0.100.1-3.el7.noarch.rpm
 clamav-lib:
-  :rpm_name: clamav-lib-0.100.1-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-lib-0.100.1-1.el7.x86_64.rpm
+  :rpm_name: clamav-lib-0.100.1-3.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-lib-0.100.1-3.el7.x86_64.rpm
 clamav-scanner-systemd:
-  :rpm_name: clamav-scanner-systemd-0.100.1-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-scanner-systemd-0.100.1-1.el7.x86_64.rpm
+  :rpm_name: clamav-scanner-systemd-0.100.1-3.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-scanner-systemd-0.100.1-3.el7.x86_64.rpm
 clamav-server-systemd:
-  :rpm_name: clamav-server-systemd-0.100.1-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-server-systemd-0.100.1-1.el7.x86_64.rpm
+  :rpm_name: clamav-server-systemd-0.100.1-3.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-server-systemd-0.100.1-3.el7.x86_64.rpm
 clamav-update:
-  :rpm_name: clamav-update-0.100.1-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-update-0.100.1-1.el7.x86_64.rpm
+  :rpm_name: clamav-update-0.100.1-3.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-update-0.100.1-3.el7.x86_64.rpm
 clamd:
-  :rpm_name: clamd-0.100.1-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamd-0.100.1-1.el7.x86_64.rpm
+  :rpm_name: clamd-0.100.1-3.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamd-0.100.1-3.el7.x86_64.rpm
 elasticsearch:
   :rpm_name: elasticsearch-5.6.10.rpm
   :source: https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.10.rpm

--- a/build/distributions/RedHat/6/x86_64/yum_data/packages.yaml
+++ b/build/distributions/RedHat/6/x86_64/yum_data/packages.yaml
@@ -78,11 +78,11 @@ globus-gsi-sysconfig:
   :rpm_name: globus-gsi-sysconfig-8.1-3.el6.x86_64.rpm
   :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-gsi-sysconfig-8.1-3.el6.x86_64.rpm
 globus-gss-assist:
-  :rpm_name: globus-gss-assist-11.1-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-gss-assist-11.1-1.el6.x86_64.rpm
+  :rpm_name: globus-gss-assist-11.2-1.el6.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-gss-assist-11.2-1.el6.x86_64.rpm
 globus-gssapi-gsi:
-  :rpm_name: globus-gssapi-gsi-13.8-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-gssapi-gsi-13.8-1.el6.x86_64.rpm
+  :rpm_name: globus-gssapi-gsi-13.10-1.el6.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-gssapi-gsi-13.10-1.el6.x86_64.rpm
 globus-openssl-module:
   :rpm_name: globus-openssl-module-4.8-1.el6.x86_64.rpm
   :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/globus-openssl-module-4.8-1.el6.x86_64.rpm

--- a/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
@@ -6,32 +6,32 @@ chkrootkit:
   :rpm_name: chkrootkit-0.50-4el7.x86_64.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/chkrootkit-0.50-4el7.x86_64.rpm
 clamav:
-  :rpm_name: clamav-0.100.1-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-0.100.1-1.el7.x86_64.rpm
+  :rpm_name: clamav-0.100.1-3.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-0.100.1-3.el7.x86_64.rpm
 clamav-data:
-  :rpm_name: clamav-data-0.100.1-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-data-0.100.1-1.el7.noarch.rpm
+  :rpm_name: clamav-data-0.100.1-3.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-data-0.100.1-3.el7.noarch.rpm
 clamav-devel:
-  :rpm_name: clamav-devel-0.100.1-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-devel-0.100.1-1.el7.x86_64.rpm
+  :rpm_name: clamav-devel-0.100.1-3.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-devel-0.100.1-3.el7.x86_64.rpm
 clamav-filesystem:
-  :rpm_name: clamav-filesystem-0.100.1-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-filesystem-0.100.1-1.el7.noarch.rpm
+  :rpm_name: clamav-filesystem-0.100.1-3.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-filesystem-0.100.1-3.el7.noarch.rpm
 clamav-lib:
-  :rpm_name: clamav-lib-0.100.1-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-lib-0.100.1-1.el7.x86_64.rpm
+  :rpm_name: clamav-lib-0.100.1-3.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-lib-0.100.1-3.el7.x86_64.rpm
 clamav-scanner-systemd:
-  :rpm_name: clamav-scanner-systemd-0.100.1-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-scanner-systemd-0.100.1-1.el7.x86_64.rpm
+  :rpm_name: clamav-scanner-systemd-0.100.1-3.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-scanner-systemd-0.100.1-3.el7.x86_64.rpm
 clamav-server-systemd:
-  :rpm_name: clamav-server-systemd-0.100.1-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-server-systemd-0.100.1-1.el7.x86_64.rpm
+  :rpm_name: clamav-server-systemd-0.100.1-3.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-server-systemd-0.100.1-3.el7.x86_64.rpm
 clamav-update:
-  :rpm_name: clamav-update-0.100.1-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-update-0.100.1-1.el7.x86_64.rpm
+  :rpm_name: clamav-update-0.100.1-3.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-update-0.100.1-3.el7.x86_64.rpm
 clamd:
-  :rpm_name: clamd-0.100.1-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamd-0.100.1-1.el7.x86_64.rpm
+  :rpm_name: clamd-0.100.1-3.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamd-0.100.1-3.el7.x86_64.rpm
 elasticsearch:
   :rpm_name: elasticsearch-5.6.10.rpm
   :source: https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.10.rpm

--- a/src/assets/simp/build/simp.spec
+++ b/src/assets/simp/build/simp.spec
@@ -107,7 +107,7 @@ Requires: rubygem-simp-cli >= 4.2.0, rubygem-simp-cli < 5.0.0
 Requires: rubygem-simp-cli-doc >= 4.2.0, rubygem-simp-cli-doc < 5.0.0
 Requires: simp-adapter >= 0.0.6, simp-adapter < 1.0.0
 Requires: simp-environment >= 6.2.10, simp-environment < 7.0.0
-Requires: simp-gpgkeys >= 3.0.3-0%{?dist}, simp-gpgkeys < 4.0.0
+Requires: simp-gpgkeys >= 3.0.3, simp-gpgkeys < 4.0.0
 Requires: simp-rsync >= 6.2.1-0%{?dist}, simp-rsync < 7.0.0
 Requires: simp-utils >= 6.1.1, simp-utils < 7.0.0
 


### PR DESCRIPTION
Fixes the following issues with release builds:
- Clam* version change from 0.100.1-1 to 0.100.1-3 for EL7
- globus-gss-assist version change from 11.1-1 to 11.2-1 for EL6
- globus-gssapi-gsi version change from 13.8-1 to 13.10.1 for EL6
- Fix simp.spec to remove '{?dist}' from require for simp-gpgkeys

SIMP-5419 #close