### PR TITLE
(SIMP-MAINT) Bump simp-rake-helpers to fixed ver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'puppetlabs_spec_helper'
 gem 'rake'
 gem 'ruby-progressbar'
 gem 'simp-build-helpers', ENV.fetch('SIMP_BUILD_HELPERS_VERSION', '>= 0.1.0')
-gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.3', '< 6.0'])
+gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.6.1', '< 6.0'])
 #gem 'simp-rake-helpers', :path => './src/rubygems/rubygem-simp-rake-helpers'
 
 group :system_tests do


### PR DESCRIPTION
Need to bump to at least 5.6.1 to fix the EL6 builds