### PR TITLE
(SIMP-5424) Bump systemd and timezone modules

### DIFF
--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -48,7 +48,7 @@ mod 'camptocamp-kmod',
 # RPM packaging (SIMP-6.4.0 or later).
 mod 'simp-systemd',
   :git => 'https://github.com/simp/puppet-systemd.git',
-  :branch => 'simp-master'
+  :branch => 'simp-2.1.0'
 
 mod 'cristifalcas-journald',
   :git => 'https://github.com/simp/pupmod-simp-journald.git',
@@ -508,9 +508,9 @@ mod 'simp-tftpboot',
 # bug WRT RPM upgrades with name changes, can't revert back
 # to saz/timezone.  We will revert when we redesign module
 # RPM packaging (SIMP-6.4.0 or later).
-mod 'saz-timezone',
+mod 'simp-timezone',
   :git => 'https://github.com/simp/pupmod-simp-timezone',
-  :branch => 'simp-master'
+  :branch => 'simp-5.0.2'
 
 mod 'simp-tlog',
   :git => 'https://github.com/simp/pupmod-simp-tlog',

--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -48,7 +48,7 @@ mod 'camptocamp-kmod',
 # RPM packaging (SIMP-6.4.0 or later).
 mod 'simp-systemd',
   :git => 'https://github.com/simp/puppet-systemd.git',
-  :branch => 'simp-2.1.0'
+  :tag => 'simp-2.1.0'
 
 mod 'cristifalcas-journald',
   :git => 'https://github.com/simp/pupmod-simp-journald.git',
@@ -510,7 +510,7 @@ mod 'simp-tftpboot',
 # RPM packaging (SIMP-6.4.0 or later).
 mod 'simp-timezone',
   :git => 'https://github.com/simp/pupmod-simp-timezone',
-  :branch => 'simp-5.0.2'
+  :tag => 'simp-5.0.2'
 
 mod 'simp-tlog',
   :git => 'https://github.com/simp/pupmod-simp-tlog',

--- a/build/rpm/dependencies.yaml
+++ b/build/rpm/dependencies.yaml
@@ -157,6 +157,8 @@
 # (packaging version 1 instead of 0) and a newer version of
 # simp-rake-helpers.
 'timezone':
+  :obsoletes:
+    -    'pupmod-saz-timezone': '3.3.0-2016.1'
   :requires:
     # exclude pupmod-stm-debconf
     - 'pupmod-puppetlabs-stdlib'

--- a/build/rpm/dependencies.yaml
+++ b/build/rpm/dependencies.yaml
@@ -158,7 +158,7 @@
 # simp-rake-helpers.
 'timezone':
   :obsoletes:
-    -    'pupmod-saz-timezone': '3.3.0-2016.1'
+    'pupmod-saz-timezone': '3.3.0-2016.1'
   :requires:
     # exclude pupmod-stm-debconf
     - 'pupmod-puppetlabs-stdlib'

--- a/build/rpm/dependencies.yaml
+++ b/build/rpm/dependencies.yaml
@@ -157,9 +157,6 @@
 # (packaging version 1 instead of 0) and a newer version of
 # simp-rake-helpers.
 'timezone':
-  :obsoletes:
-    'pupmod-saz-timezone': '3.3.0-2016.1'
-  :release: '1'
   :requires:
     # exclude pupmod-stm-debconf
     - 'pupmod-puppetlabs-stdlib'


### PR DESCRIPTION
* Update timezone to simp-5.0.2
* Update systemd to simp-2.1.0
* These are both in line with the changes made upstream and will be
  fullly reverted once we finalize the RPM update mechanism.

SIMP-5468 #close