### PR TITLE
(SIMP-5444) Remove simp-freeradius

### DIFF
--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -256,11 +256,6 @@ mod 'simp-fips',
   :git => 'https://github.com/simp/pupmod-simp-fips',
   :branch => 'master'
 
-#FIXME Does not support Puppet 5 yet
-mod 'simp-freeradius',
-  :git => 'https://github.com/simp/pupmod-simp-freeradius',
-  :branch => 'master'
-
 mod 'simp-gdm',
   :git => 'https://github.com/simp/pupmod-simp-gdm',
   :branch => 'master'

--- a/build/distributions/CentOS/6/x86_64/DVD/6-simp_pkglist.txt
+++ b/build/distributions/CentOS/6/x86_64/DVD/6-simp_pkglist.txt
@@ -224,9 +224,6 @@ foomatic-db-filesystem
 foomatic-db-ppds
 fprintd
 fprintd-pam
-freeradius
-freeradius-ldap
-freeradius-utils
 freetype
 freetype-devel
 fuse

--- a/build/distributions/CentOS/7/x86_64/DVD/7-simp_pkglist.txt
+++ b/build/distributions/CentOS/7/x86_64/DVD/7-simp_pkglist.txt
@@ -278,7 +278,6 @@ foomatic-db-ppds
 foomatic-filters
 fprintd
 fprintd-pam
-freeradius
 freetype
 freetype-devel
 fuse

--- a/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
@@ -21,32 +21,32 @@ chkrootkit:
   :rpm_name: chkrootkit-0.50-4el7.x86_64.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/chkrootkit-0.50-4el7.x86_64.rpm
 clamav:
-  :rpm_name: clamav-0.100.1-3.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-0.100.1-3.el7.x86_64.rpm
+  :rpm_name: clamav-0.100.2-2.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-0.100.2-2.el7.x86_64.rpm
 clamav-data:
-  :rpm_name: clamav-data-0.100.1-3.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-data-0.100.1-3.el7.noarch.rpm
+  :rpm_name: clamav-data-0.100.2-2.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-data-0.100.2-2.el7.noarch.rpm
 clamav-devel:
-  :rpm_name: clamav-devel-0.100.1-3.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-devel-0.100.1-3.el7.x86_64.rpm
+  :rpm_name: clamav-devel-0.100.2-2.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-devel-0.100.2-2.el7.x86_64.rpm
 clamav-filesystem:
-  :rpm_name: clamav-filesystem-0.100.1-3.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-filesystem-0.100.1-3.el7.noarch.rpm
+  :rpm_name: clamav-filesystem-0.100.2-2.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-filesystem-0.100.2-2.el7.noarch.rpm
 clamav-lib:
-  :rpm_name: clamav-lib-0.100.1-3.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-lib-0.100.1-3.el7.x86_64.rpm
+  :rpm_name: clamav-lib-0.100.2-2.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-lib-0.100.2-2.el7.x86_64.rpm
 clamav-scanner-systemd:
-  :rpm_name: clamav-scanner-systemd-0.100.1-3.el7.x86_64.rpm
-  :source: https://mirror.umd.edu/fedora/epel/7/x86_64/Packages/c/clamav-scanner-systemd-0.100.1-3.el7.x86_64.rpm
+  :rpm_name: clamav-scanner-systemd-0.100.2-2.el7.x86_64.rpm
+  :source: https://mirror.umd.edu/fedora/epel/7/x86_64/Packages/c/clamav-scanner-systemd-0.100.2-2.el7.x86_64.rpm
 clamav-server-systemd:
-  :rpm_name: clamav-server-systemd-0.100.1-3.el7.x86_64.rpm
-  :source: https://mirror.umd.edu/fedora/epel/7/x86_64/Packages/c/clamav-server-systemd-0.100.1-3.el7.x86_64.rpm
+  :rpm_name: clamav-server-systemd-0.100.2-2.el7.x86_64.rpm
+  :source: https://mirror.umd.edu/fedora/epel/7/x86_64/Packages/c/clamav-server-systemd-0.100.2-2.el7.x86_64.rpm
 clamav-update:
-  :rpm_name: clamav-update-0.100.1-3.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-update-0.100.1-3.el7.x86_64.rpm
+  :rpm_name: clamav-update-0.100.2-2.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-update-0.100.2-2.el7.x86_64.rpm
 clamd:
-  :rpm_name: clamd-0.100.1-3.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamd-0.100.1-3.el7.x86_64.rpm
+  :rpm_name: clamd-0.100.2-2.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamd-0.100.2-2.el7.x86_64.rpm
 elasticsearch:
   :rpm_name: elasticsearch-5.6.10.rpm
   :source: https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.10.rpm

--- a/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
@@ -21,32 +21,32 @@ chkrootkit:
   :rpm_name: chkrootkit-0.50-4el7.x86_64.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/chkrootkit-0.50-4el7.x86_64.rpm
 clamav:
-  :rpm_name: clamav-0.100.1-3.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-0.100.1-3.el7.x86_64.rpm
+  :rpm_name: clamav-0.100.2-2.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-0.100.2-2.el7.x86_64.rpm
 clamav-data:
-  :rpm_name: clamav-data-0.100.1-3.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-data-0.100.1-3.el7.noarch.rpm
+  :rpm_name: clamav-data-0.100.2-2.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-data-0.100.2-2.el7.noarch.rpm
 clamav-devel:
-  :rpm_name: clamav-devel-0.100.1-3.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-devel-0.100.1-3.el7.x86_64.rpm
+  :rpm_name: clamav-devel-0.100.2-2.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-devel-0.100.2-2.el7.x86_64.rpm
 clamav-filesystem:
-  :rpm_name: clamav-filesystem-0.100.1-3.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-filesystem-0.100.1-3.el7.noarch.rpm
+  :rpm_name: clamav-filesystem-0.100.2-2.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-filesystem-0.100.2-2.el7.noarch.rpm
 clamav-lib:
-  :rpm_name: clamav-lib-0.100.1-3.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-lib-0.100.1-3.el7.x86_64.rpm
+  :rpm_name: clamav-lib-0.100.2-2.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-lib-0.100.2-2.el7.x86_64.rpm
 clamav-scanner-systemd:
-  :rpm_name: clamav-scanner-systemd-0.100.1-3.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-scanner-systemd-0.100.1-3.el7.x86_64.rpm
+  :rpm_name: clamav-scanner-systemd-0.100.2-2.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-scanner-systemd-0.100.2-2.el7.x86_64.rpm
 clamav-server-systemd:
-  :rpm_name: clamav-server-systemd-0.100.1-3.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-server-systemd-0.100.1-3.el7.x86_64.rpm
+  :rpm_name: clamav-server-systemd-0.100.2-2.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-server-systemd-0.100.2-2.el7.x86_64.rpm
 clamav-update:
-  :rpm_name: clamav-update-0.100.1-3.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-update-0.100.1-3.el7.x86_64.rpm
+  :rpm_name: clamav-update-0.100.2-2.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-update-0.100.2-2.el7.x86_64.rpm
 clamd:
-  :rpm_name: clamd-0.100.1-3.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamd-0.100.1-3.el7.x86_64.rpm
+  :rpm_name: clamd-0.100.2-2.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamd-0.100.2-2.el7.x86_64.rpm
 elasticsearch:
   :rpm_name: elasticsearch-5.6.10.rpm
   :source: https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.10.rpm

--- a/metadata.json
+++ b/metadata.json
@@ -163,10 +163,6 @@
       "version_requirement": ">= 0.1.4 < 1.0.0"
     },
     {
-      "name": "simp/freeradius",
-      "version_requirement": ">= 7.0.1 < 8.0.0"
-    },
-    {
       "name": "simp/haveged",
       "version_requirement": ">= 0.4.5 < 1.0.0"
     },

--- a/src/assets/simp/build/simp.spec
+++ b/src/assets/simp/build/simp.spec
@@ -59,7 +59,6 @@ Requires: pupmod-simp-cron >= 0.0.2, pupmod-simp-cron < 1.0.0
 Requires: pupmod-simp-deferred_resources >= 0.1.0, pupmod-simp-deferred_resources < 1.0.0
 Requires: pupmod-simp-dhcp >= 6.0.1, pupmod-simp-dhcp < 7.0.0
 Requires: pupmod-simp-fips >= 0.1.4, pupmod-simp-fips < 1.0.0
-Requires: pupmod-simp-freeradius >= 7.0.1, pupmod-simp-freeradius < 8.0.0
 Requires: pupmod-simp-haveged >= 0.4.5, pupmod-simp-haveged < 1.0.0
 Requires: pupmod-simp-ima >= 0.1.0, pupmod-simp-ima < 1.0.0
 Requires: pupmod-simp-incron >= 0.3.0, pupmod-simp-incron < 1.0.0


### PR DESCRIPTION
The `simp-freeradius` module has fallen behind significantly enough that
it is going to require more time to fix that we have for 6.3.0.

We will be dropping it for now and hopefully pick it back up for 6.4.0.

SIMP-5445 #close