### PR TITLE
[WIP] (SIMP-5456) Upgrade to puppet-agent 5.5.7

### DIFF
--- a/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
@@ -243,8 +243,8 @@ pssh:
   :rpm_name: pssh-2.3.1-5.el6.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pssh-2.3.1-5.el6.noarch.rpm
 puppet-agent:
-  :rpm_name: puppet-agent-5.5.6-1.el6.x86_64.rpm
-  :source: https://yum.puppetlabs.com/puppet5/el/6/x86_64/puppet-agent-5.5.6-1.el6.x86_64.rpm
+  :rpm_name: puppet-agent-5.5.7-1.el6.x86_64.rpm
+  :source: https://yum.puppetlabs.com/puppet5/el/6/x86_64/puppet-agent-5.5.7-1.el6.x86_64.rpm
 puppet-client-tools:
   :rpm_name: puppet-client-tools-1.2.4-1.el6.x86_64.rpm
   :source: https://yum.puppetlabs.com/puppet5/el/6/x86_64/puppet-client-tools-1.2.4-1.el6.x86_64.rpm

--- a/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
@@ -231,8 +231,8 @@ pssh:
   :rpm_name: pssh-2.3.1.SIMP-5.el7.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pssh-2.3.1.SIMP-5.el7.noarch.rpm
 puppet-agent:
-  :rpm_name: puppet-agent-5.5.6-1.el7.x86_64.rpm
-  :source: https://yum.puppetlabs.com/puppet5/el/7/x86_64/puppet-agent-5.5.6-1.el7.x86_64.rpm
+  :rpm_name: puppet-agent-5.5.7-1.el7.x86_64.rpm
+  :source: https://yum.puppetlabs.com/puppet5/el/7/x86_64/puppet-agent-5.5.7-1.el7.x86_64.rpm
 puppet-client-tools:
   :rpm_name: puppet-client-tools-1.2.4-1.el7.x86_64.rpm
   :source: https://yum.puppetlabs.com/puppet5/el/7/x86_64/puppet-client-tools-1.2.4-1.el7.x86_64.rpm


### PR DESCRIPTION
This patch upgrades the package version of `puppet-agent` to 5.5.7,
fixing a bug that was introduced in 5.5.6, where every `puppet` run
was preceded by the following warnings:

```
Warning: Setting ca is deprecated.
   (location: <...>/settings.rb:1169:in `issue_deprecation_warning')
Warning: Setting ca_ttl is deprecated.
   (location: <...>/settings.rb:1169:in `issue_deprecation_warning')
```

These warnings were due to a bug ([PUP-9027][0]) specific to
`puppet-agent` 5.5.6, which could not be avoided without disabling *all*
deprecation warnings in Puppet.  The issue was fixed upstream
([PUP-9158][1]) and released in `puppet-agent` 5.5.7.

[0]: https://tickets.puppetlabs.com/browse/PUP-9027?focusedCommentId=587152#comment-587152
[1]: https://tickets.puppetlabs.com/browse/PUP-9158

SIMP-5456 #close