### PR TITLE
(SIMP-5198) Workaround cipher issue LDAP test

### DIFF
--- a/spec/acceptance/suites/install_from_tar/01_simp_server_spec.rb
+++ b/spec/acceptance/suites/install_from_tar/01_simp_server_spec.rb
@@ -28,6 +28,21 @@ describe 'install SIMP via release tarball' do
       'rsyslog::enable_tls_logging' => true,
       'simp_rsyslog::forward_logs'  => true
     } )
+
+    # Work around 128-bit cipher problems
+    # TODO:  Once SIMP-5507 is addressed, this workaround is *only*
+    # required when the el6 LDAP server is not in FIPS mode.
+    if master.host_hash[:platform] =~ /el-6/
+      hiera.merge!( {
+        'simp_openldap::server::conf::security' => [
+          'ssf=128',
+          'tls=128',
+          'update_ssf=128',
+          'simple_bind=128',
+          'update_tls=128',
+        ]
+      } )
+    end
     hiera
   }
 

--- a/spec/acceptance/suites/install_from_tar/10_rsyslog_integration_spec.rb
+++ b/spec/acceptance/suites/install_from_tar/10_rsyslog_integration_spec.rb
@@ -114,15 +114,12 @@ describe 'Validation of rsyslog forwarding' do
     '/etc/puppetlabs/code/environments/simp/modules/site'
   }
 
+  let(:original_default_hieradata) {
+    YAML.load(on(master, "cat #{default_yaml_filename}").stdout)
+  }
+
   let(:default_hieradata) {
-    # hieradata that allows beaker operations access
-    beaker_hiera = YAML.load(File.read("#{files_dir}/beaker_hiera.yaml"))
-
-    hiera        = beaker_hiera.merge( {
-      'simp::rsync_stunnel'         => master_fqdn,
-      'rsyslog::enable_tls_logging' => true,
-      'simp_rsyslog::forward_logs'  => true,
-
+    hiera = original_default_hieradata.merge( {
       # to ensure all hosts have a cron that runs every minute for a test below
       'swap::cron_step'             => 1,
 
@@ -419,7 +416,7 @@ describe 'Validation of rsyslog forwarding' do
 
     # turn off audit forwarding for future tests, as it can be prolific
     it 'should disable audit log forwarding' do
-      create_remote_file(master, default_yaml_filename, default_hieradata.to_yaml)
+      create_remote_file(master, default_yaml_filename, original_default_hieradata.to_yaml)
       on(hosts, 'puppet agent -t', :accept_all_exit_codes => true)
 
       # FIXME: Workaround for SIMP-5161 bug


### PR DESCRIPTION
Adjust the slapd TLS settings to allow 128-bit ciphers,
when the LDAP server is on an el6 server.

SIMP-5198 #close