### PR TITLE
(SIMP-5325) Rubygem file updates

### DIFF
--- a/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
@@ -242,6 +242,12 @@ rubygem-ffi:
 rubygem-highline:
   :rpm_name: rubygem-highline-1.6.11-1.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-highline-1.6.11-1.noarch.rpm
+rubygem-puppetserver-parslet:
+  :rpm_name: rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
+rubygem-puppetserver-toml:
+  :rpm_name: rubygem-puppetserver-toml-0.2.0-0.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-toml-0.2.0-0.noarch.rpm
 rubygem-net-ldap:
   :rpm_name: rubygem-net-ldap-0.6.1-2.el6.1.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-net-ldap-0.6.1-2.el6.1.noarch.rpm

--- a/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
@@ -287,6 +287,12 @@ rubygem-ffi:
 rubygem-highline:
   :rpm_name: rubygem-highline-1.6.11-5.el7.noarch.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/r/rubygem-highline-1.6.11-5.el7.noarch.rpm
+rubygem-puppetserver-parslet:
+  :rpm_name: rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
+rubygem-puppetserver-toml:
+  :rpm_name: rubygem-puppetserver-toml-0.2.0-0.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-toml-0.2.0-0.noarch.rpm
 rubygem-net-ldap:
   :rpm_name: rubygem-net-ldap-0.16.0-1.el7.noarch.rpm
   :source: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/r/rubygem-net-ldap-0.16.0-1.el7.noarch.rpm

--- a/build/distributions/RedHat/6/x86_64/yum_data/packages.yaml
+++ b/build/distributions/RedHat/6/x86_64/yum_data/packages.yaml
@@ -239,6 +239,12 @@ rubygem-ffi:
 rubygem-highline:
   :rpm_name: rubygem-highline-1.6.11-1.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-highline-1.6.11-1.noarch.rpm
+rubygem-puppetserver-parslet:
+  :rpm_name: rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
+rubygem-puppetserver-toml:
+  :rpm_name: rubygem-puppetserver-toml-0.2.0-0.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-toml-0.2.0-0.noarch.rpm
 rubygem-net-ldap:
   :rpm_name: rubygem-net-ldap-0.6.1-2.el6.1.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-net-ldap-0.6.1-2.el6.1.noarch.rpm

--- a/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
@@ -287,6 +287,12 @@ rubygem-ffi:
 rubygem-highline:
   :rpm_name: rubygem-highline-1.6.11-5.el7.noarch.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/r/rubygem-highline-1.6.11-5.el7.noarch.rpm
+rubygem-puppetserver-parslet:
+  :rpm_name: rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
+rubygem-puppetserver-toml:
+  :rpm_name: rubygem-puppetserver-toml-0.2.0-0.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-toml-0.2.0-0.noarch.rpm
 rubygem-net-ldap:
   :rpm_name: rubygem-net-ldap-0.16.0-1.el7.noarch.rpm
   :source: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/r/rubygem-net-ldap-0.16.0-1.el7.noarch.rpm

--- a/build/rpm/dependencies.yaml
+++ b/build/rpm/dependencies.yaml
@@ -106,10 +106,9 @@
     # Exclude the problematic puppet-archive module.
     # ('puppet generate types' fails with puppet-archive).
     - 'pupmod-puppetlabs-stdlib'
-# FIXME
-#  :external_dependencies:
-#    'rubygem-puppetserver-toml':
-#      :min: '0.1.2'
+  :external_dependencies:
+    'rubygem-puppetserver-toml':
+      :min: '0.2.0'
 
 'java':
   :requires:


### PR DESCRIPTION
- The rubygem-puppetserver-toml and rubygem-puppetserver-parser
  RPMs were updated to use Puppet 5 and pushed to package cloud.
  This PR puts them back in the packages.yaml with the new version numbers
  uncomments the dependency in the rpm/dependencied file.

SIMP-5325 #close