### PR TITLE
(SIMP-MAINT) acceptance tests fixes

### DIFF
--- a/spec/acceptance/common_files/simp_conf.yaml.erb
+++ b/spec/acceptance/common_files/simp_conf.yaml.erb
@@ -87,6 +87,13 @@ cli::simp::scenario: simp
 # SIMP repositories.
 cli::use_internet_simp_yum_repos: false
 
+# === grub::password ===
+# The password to access GRUB.
+#
+# The value entered is used to set the GRUB password and to generate a hash
+# stored in grub::password.
+grub::password: "<%= grub_password_hash %>"
+
 # === puppetdb::master::config::puppetdb_port ===
 # The PuppetDB server port number.
 puppetdb::master::config::puppetdb_port: 8139
@@ -98,6 +105,13 @@ puppetdb::master::config::puppetdb_server: "%{hiera('simp_options::puppet::serve
 # === simp::runlevel ===
 # The default system runlevel (1-5).
 simp::runlevel: 3
+
+# === simp_openldap::server::conf::rootpw ===
+# The salted LDAP Root password hash.
+#
+# When set via 'simp config', this password hash is generated from
+# the password entered on the command line.
+simp_openldap::server::conf::rootpw: "<%= ldap_root_password_hash %>"
 
 # === simp_options::dns::search ===
 # The DNS domain search string.

--- a/spec/acceptance/helpers/password_helper.rb
+++ b/spec/acceptance/helpers/password_helper.rb
@@ -12,6 +12,42 @@ module Acceptance
         TEST_PASSWORDS[index]
       end
 
+      # returns encrypted password appropriate for openldap
+      #
+      # lifted from rubygem-simp-cli
+      def encrypt_openldap_password(password)
+         require 'digest/sha1'
+         require 'base64'
+
+         # Ruby 1.8.7 hack to do Random.new.bytes(4):
+         salt   = salt || (x = ''; 4.times{ x += ((rand * 255).floor.chr ) }; x)
+         salt.force_encoding('UTF-8') if salt.encoding.name == 'ASCII-8BIT'
+
+         digest = Digest::SHA1.digest( password + salt )
+
+         # NOTE: Digest::SHA1.digest in Ruby 1.9+ returns a String encoding in
+         #       ASCII-8BIT, whereas all other Strings in play are UTF-8
+         digest.force_encoding('UTF-8') if digest.encoding.name == 'ASCII-8BIT'
+
+         "{SSHA}"+Base64.encode64( digest + salt ).chomp
+      end
+
+      # returns encrypted grub password
+      #
+      # lifted from rubygem-simp-cli
+      def encrypt_grub_password(host, password)
+        result   = nil
+        facts = JSON.load(on(host, 'puppet facts').stdout)
+        if facts['values']['os']['release']['major'] > "6"
+          result = on(host, "grub2-mkpasswd-pbkdf2 <<EOM\n#{password}\n#{password}\nEOM").stdout.split.last
+        else
+          require 'digest/sha2'
+          salt   = rand(36**8).to_s(36)
+          result = password.crypt("$6$" + salt)
+        end
+        result
+      end
+
     end
   end
 end

--- a/spec/acceptance/helpers/repo_helper.rb
+++ b/spec/acceptance/helpers/repo_helper.rb
@@ -13,7 +13,7 @@ module Acceptance
           puts('='*72)
           puts("Using repos defined in #{repo_filename}")
           puts('='*72)
-          scp_to(hosts, repo_filename, "/etc/yum.repos.d/#{repo_name}")
+          scp_to(host, repo_filename, "/etc/yum.repos.d/#{repo_name}")
         else
           fail("File #{repo_filename} could not be found")
         end

--- a/spec/acceptance/helpers/system_gem_helper.rb
+++ b/spec/acceptance/helpers/system_gem_helper.rb
@@ -5,7 +5,6 @@ module Acceptance
       def install_system_factor_gem(host)
         host.install_package('rubygems')
         on(host, '/usr/bin/gem install facter')
-        on(host, "cat #{host[:ssh_env_file]}")
 
         # beaker-helper fact_on() now uses '--json' on facter calls, so
         # we need to make sure the json gem is installed

--- a/spec/acceptance/suites/install_from_rpm/01_simp_server_spec.rb
+++ b/spec/acceptance/suites/install_from_rpm/01_simp_server_spec.rb
@@ -52,8 +52,10 @@ describe 'install SIMP via rpm' do
       # The following variables/methods are required by simp_conf.yaml.erb:
       #   domain
       #   gateway
+      #   grub_password_hash
       #   interface
       #   ipaddress
+      #   ldap_root_password_hash
       #   master_fqdn
       #   nameserver
       #   netmask
@@ -74,27 +76,15 @@ describe 'install SIMP via rpm' do
       nameserver = dns_nameserver(master)
       expect(nameserver).to_not be_nil
 
+      grub_password_hash = encrypt_grub_password(master, test_password)
+      ldap_root_password_hash = encrypt_openldap_password(test_password)
+
       create_remote_file(master, '/root/simp_conf.yaml', ERB.new(simp_conf_template).result(binding))
       on(master, 'cat /root/simp_conf.yaml')
     end
 
     it 'should run simp config' do
-      cmd = [
-        'simp config',
-        '-A /root/simp_conf.yaml'
-      ].join(' ')
-
-      input = [
-        'no', # do not autogenerate GRUB password
-        test_password,
-        test_password,
-        'no', # do not autogenerate LDAP Root password
-        test_password,
-        test_password,
-        ''  # make sure to end with \n
-      ].join("\n")
-
-      on(master, cmd, { :pty => true, :stdin => input } )
+      on(master, 'simp config -a /root/simp_conf.yaml')
       on(master, 'cat /root/.simp/simp_conf.yaml')
     end
 

--- a/spec/acceptance/suites/install_from_tar/01_simp_server_spec.rb
+++ b/spec/acceptance/suites/install_from_tar/01_simp_server_spec.rb
@@ -100,8 +100,10 @@ describe 'install SIMP via release tarball' do
       # The following variables/methods are required by simp_conf.yaml.erb:
       #   domain
       #   gateway
+      #   grub_password_hash
       #   interface
       #   ipaddress
+      #   ldap_root_password_hash
       #   master_fqdn
       #   nameserver
       #   netmask
@@ -122,27 +124,15 @@ describe 'install SIMP via release tarball' do
       nameserver = dns_nameserver(master)
       expect(nameserver).to_not be_nil
 
+      grub_password_hash = encrypt_grub_password(master, test_password)
+      ldap_root_password_hash = encrypt_openldap_password(test_password)
+
       create_remote_file(master, '/root/simp_conf.yaml', ERB.new(simp_conf_template).result(binding))
       on(master, 'cat /root/simp_conf.yaml')
     end
 
     it 'should run simp config' do
-      cmd = [
-        'simp config',
-        '-A /root/simp_conf.yaml'
-      ].join(' ')
-
-      input = [
-        'no', # do not autogenerate GRUB password
-        test_password,
-        test_password,
-        'no', # do not autogenerate LDAP Root password
-        test_password,
-        test_password,
-        ''  # make sure to end with \n
-      ].join("\n")
-
-      on(master, cmd, { :pty => true, :stdin => input } )
+      on(master, 'simp config -a /root/simp_conf.yaml')
       on(master, 'cat /root/.simp/simp_conf.yaml')
     end
 


### PR DESCRIPTION
- Remove use of pty input to 'simp config' in install_from_tar
  and install_from_rpm, because that randomly fails
- Remove test setup debug call that now fails (beaker gem diff?)
- Minor bug fix in repo_helper.rb