### PR TITLE
(SIMP-4944) Use simp-vendored-r10k in r10k tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ default_el6-puppet5:
   <<: *cache_bundler
   <<: *setup_bundler_env
   variables:
-    PUPPET_VERSION: '~> 5.3'
+    PUPPET_VERSION: '~> 5.5'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
   script:
     - bundle exec rake spec_clean
@@ -62,7 +62,7 @@ default_el7-puppet5:
   <<: *cache_bundler
   <<: *setup_bundler_env
   variables:
-    PUPPET_VERSION: '~> 5.3'
+    PUPPET_VERSION: '~> 5.5'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
   script:
     - bundle exec rake spec_clean
@@ -79,12 +79,28 @@ ipa_el7-puppet5:
   <<: *setup_bundler_env
   <<: *only_with_SIMP_FULL_MATRIX
   variables:
-    PUPPET_VERSION: '~> 5.3'
+    PUPPET_VERSION: '~> 5.5'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
   script:
     - bundle exec rake spec_clean
     - bundle exec rake beaker:suites[ipa,el7_server]
   retry: 1
+
+# # IPA server has issues on el6
+# ipa_el6-puppet5:
+#   stage: integration
+#  image: 'ruby:2.4'
+#   tags:
+#     - beaker
+#   <<: *cache_bundler
+#   <<: *setup_bundler_env
+#   variables:
+#     PUPPET_VERSION: '~> 5.5'
+#     BEAKER_PUPPET_COLLECTION: 'puppet5'
+#   script:
+#     - bundle exec rake beaker:suites[ipa,el6_server]
+#   retry: 1
+
 
 default_oel6-puppet5:
   stage: integration
@@ -95,7 +111,7 @@ default_oel6-puppet5:
   <<: *setup_bundler_env
   <<: *only_with_SIMP_FULL_MATRIX
   variables:
-    PUPPET_VERSION: '~> 5.3'
+    PUPPET_VERSION: '~> 5.5'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     SIMP_BEAKER_OS: 'oracle'
   script:
@@ -112,7 +128,7 @@ default_oel7-puppet5:
   <<: *setup_bundler_env
   <<: *only_with_SIMP_FULL_MATRIX
   variables:
-    PUPPET_VERSION: '~> 5.3'
+    PUPPET_VERSION: '~> 5.5'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     SIMP_BEAKER_OS: 'oracle'
   script:
@@ -129,28 +145,13 @@ ipa_oel7-puppet5:
   <<: *setup_bundler_env
   <<: *only_with_SIMP_FULL_MATRIX
   variables:
-    PUPPET_VERSION: '~> 5.3'
+    PUPPET_VERSION: '~> 5.5'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     SIMP_BEAKER_OS: 'oracle'
   script:
     - bundle exec rake spec_clean
     - bundle exec rake beaker:suites[ipa,el7_server]
   retry: 1
-
-# # IPA server has issues on el6
-# ipa_el6-puppet5:
-#   stage: integration
-#  image: 'ruby:2.4'
-#   tags:
-#     - beaker
-#   <<: *cache_bundler
-#   <<: *setup_bundler_env
-#   variables:
-#     PUPPET_VERSION: '~> 5.3'
-#     BEAKER_PUPPET_COLLECTION: 'puppet5'
-#   script:
-#     - bundle exec rake beaker:suites[ipa,el6_server]
-#   retry: 1
 
 
 rpm_el6-puppet5:
@@ -162,7 +163,7 @@ rpm_el6-puppet5:
   <<: *setup_bundler_env
   <<: *only_with_SIMP_RELEASE_TESTS
   variables:
-    PUPPET_VERSION: '~> 5.3'
+    PUPPET_VERSION: '~> 5.5'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
   script:
     - bundle exec rake spec_clean
@@ -178,7 +179,7 @@ rpm_el7-puppet5:
   <<: *setup_bundler_env
   <<: *only_with_SIMP_RELEASE_TESTS
   variables:
-    PUPPET_VERSION: '~> 5.3'
+    PUPPET_VERSION: '~> 5.5'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
   script:
     - bundle exec rake spec_clean
@@ -194,14 +195,14 @@ forge_install_el6-puppet5:
   <<: *setup_bundler_env
   <<: *only_with_SIMP_RELEASE_TESTS
   variables:
-    PUPPET_VERSION: '~> 5.3'
+    PUPPET_VERSION: '~> 5.5'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
   script:
     - bundle exec rake spec_clean
     - bundle exec rake beaker:suites[install_from_core_module,el6_server]
   retry: 1
 
-forge_install_el7-puppet5-puppet5:
+forge_install_el7-puppet5:
   stage: integration
   image: 'ruby:2.4'
   tags:
@@ -210,7 +211,7 @@ forge_install_el7-puppet5-puppet5:
   <<: *setup_bundler_env
   <<: *only_with_SIMP_RELEASE_TESTS
   variables:
-    PUPPET_VERSION: '~> 5.3'
+    PUPPET_VERSION: '~> 5.5'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
   script:
     - bundle exec rake spec_clean

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
       beaker-puppet (~> 1.0)
       beaker-vmpooler (~> 1.0)
       stringify-hash (~> 0.0.0)
-    beaker-puppet (1.11.0)
+    beaker-puppet (1.12.0)
       beaker (~> 4.1)
       in-parallel (~> 0.1)
       oga
@@ -136,7 +136,7 @@ GEM
       pry (~> 0.11)
       yard (~> 0.9.11)
     public_suffix (3.0.3)
-    puppet (5.5.8)
+    puppet (5.5.7)
       facter (> 2.0.1, < 4)
       fast_gettext (~> 1.1.2)
       hiera (>= 3.2.1, < 4)
@@ -279,7 +279,7 @@ DEPENDENCIES
   pry
   pry-byebug
   pry-doc
-  puppet (~> 5.5)
+  puppet (= 5.5.7)
   puppet-lint
   puppet-strings
   puppetlabs_spec_helper

--- a/build/Dockerfiles/SIMP7_Build.dockerfile
+++ b/build/Dockerfiles/SIMP7_Build.dockerfile
@@ -20,7 +20,7 @@ RUN yum install -y yum-utils
 # Prep for building against the oldest SELinux packages
 RUN yum-config-manager --disable \*
 RUN echo -e "[legacy]\nname=Legacy\nbaseurl=http://vault.centos.org/7.0.1406/os/x86_64\ngpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-7\ngpgcheck=1" > /etc/yum.repos.d/legacy.repo
-RUN cd /root; yum downgrade -x nss -x nss-pem -y *
+RUN cd /root; yum downgrade -x nss* -x libnss* -x nspr -y *
 
 # Work around bug https://bugzilla.redhat.com/show_bug.cgi?id=1217477
 # This does *not* update the SELinux packages, so it is safe

--- a/build/Dockerfiles/SIMP7_Build.dockerfile
+++ b/build/Dockerfiles/SIMP7_Build.dockerfile
@@ -20,7 +20,7 @@ RUN yum install -y yum-utils
 # Prep for building against the oldest SELinux packages
 RUN yum-config-manager --disable \*
 RUN echo -e "[legacy]\nname=Legacy\nbaseurl=http://vault.centos.org/7.0.1406/os/x86_64\ngpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-7\ngpgcheck=1" > /etc/yum.repos.d/legacy.repo
-RUN cd /root; yum downgrade -y *
+RUN cd /root; yum downgrade -x nss -x nss-pem -y *
 
 # Work around bug https://bugzilla.redhat.com/show_bug.cgi?id=1217477
 # This does *not* update the SELinux packages, so it is safe

--- a/spec/acceptance/nodesets/el6_server.yml
+++ b/spec/acceptance/nodesets/el6_server.yml
@@ -26,18 +26,6 @@ HOSTS:
     hypervisor: <%= hypervisor %>
     vagrant_memsize: 4608
     vagrant_cpus: 2
-    yum_repos:
-      simp_dependencies:
-        baseurl: 'https://packagecloud.io/simp-project/6_X_Dependencies/el/6/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
-          - https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
-          - https://yum.puppet.com/RPM-GPG-KEY-puppet
-          - https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
-          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
-          - https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   agent-el7:
     roles:
@@ -45,18 +33,6 @@ HOSTS:
     platform:   el-7-x86_64
     box:        <%= box_7 %>
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      simp_dependencies:
-        baseurl: 'https://packagecloud.io/simp-project/6_X_Dependencies/el/7/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
-          - https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
-          - https://yum.puppet.com/RPM-GPG-KEY-puppet
-          - https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
-          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
-          - https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   agent-el6:
     roles:
@@ -65,18 +41,6 @@ HOSTS:
     platform:   el-6-x86_64
     box:        <%= box_6 %>
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      simp_dependencies:
-        baseurl: 'https://packagecloud.io/simp-project/6_X_Dependencies/el/6/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
-          - https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
-          - https://yum.puppet.com/RPM-GPG-KEY-puppet
-          - https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
-          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
-          - https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/nodesets/el7_server.yml
+++ b/spec/acceptance/nodesets/el7_server.yml
@@ -26,18 +26,6 @@ HOSTS:
     hypervisor: <%= hypervisor %>
     vagrant_memsize: 4608
     vagrant_cpus: 2
-    yum_repos:
-      simp_dependencies:
-        baseurl: 'https://packagecloud.io/simp-project/6_X_Dependencies/el/7/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
-          - https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
-          - https://yum.puppet.com/RPM-GPG-KEY-puppet
-          - https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
-          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
-          - https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   agent-el7:
     roles:
@@ -46,18 +34,6 @@ HOSTS:
     platform:   el-7-x86_64
     box:        <%= box_7 %>
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      simp_dependencies:
-        baseurl: 'https://packagecloud.io/simp-project/6_X_Dependencies/el/7/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
-          - https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
-          - https://yum.puppet.com/RPM-GPG-KEY-puppet
-          - https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
-          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
-          - https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   agent-el6:
     roles:
@@ -65,18 +41,6 @@ HOSTS:
     platform:   el-6-x86_64
     box:        <%= box_6 %>
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      simp_dependencies:
-        baseurl: 'https://packagecloud.io/simp-project/6_X_Dependencies/el/6/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
-          - https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
-          - https://yum.puppet.com/RPM-GPG-KEY-puppet
-          - https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
-          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
-          - https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/suites/README.md
+++ b/spec/acceptance/suites/README.md
@@ -46,7 +46,7 @@ builds/download RPMs, and then builds the ISO.
 
 ```bash
 # to run the default suite on OEL using Puppet 5 and an OEL7 simp server
-export PUPPET_VERSION='~> 5.3'
+export PUPPET_VERSION='~> 5.5'
 export BEAKER_PUPPET_COLLECTION='puppet5'
 export SIMP_BEAKER_OS='oracle'
 bundle exec rake beaker:suites[default,el7_server]
@@ -63,13 +63,23 @@ to `el7_server`. You can also set `SIMP_BEAKER_OS` to `oracle` to run the tests 
 _Install method_: `Puppetfile.tracking` and `r10k`
 
 This test parses the current `Puppetfile.tracking` to make a Puppetfile that's
-suitable for a control repo, then uses `r10k` to install the SIMP environment.
-It does not use `simp config` or `simp bootstrap`, but instead just runs Puppet
-directly.
+suitable for a control repo, then uses `r10k` packaged by SIMP to install the
+SIMP environment.  It does not use `simp config` or `simp bootstrap`, but instead
+just runs Puppet directly.
 
 When the `Puppetfile.tracking` is set to the `master` branches of our component
 modules, this test makes sure our most up-to-date code is compatible.
 
+Use the following ENV variables to configure the test:
+
+#### `BEAKER_repo`
+
+* **unset** - If unset, the test will use the 6_X repos on PackageCloud
+* **fully qualified path** - If set to a fully qualified path, the test will
+  assume this is a repo file that contains definitions for both the SIMP
+  repo and the SIMP dependencies repo
+* **version** - If set, and does not start with `/`, the test will assume it
+  is an different version for the SIMP PackageCloud
 
 
 ### `ipa` Suite
@@ -85,6 +95,17 @@ and will not pass.
 
 When the `Puppetfile.tracking` is set to the `master` branches of our component
 modules, this test makes sure our most up-to-date code is compatible.
+
+Use the following ENV variables to configure the test:
+
+#### `BEAKER_repo`
+
+* **unset** - If unset, the test will use the 6_X repos on PackageCloud
+* **fully qualified path** - If set to a fully qualified path, the test will
+  assume this is a repo file that contains definitions for both the SIMP
+  repo and the SIMP dependencies repo
+* **version** - If set, and does not start with `/`, the test will assume it
+  is an different version for the SIMP PackageCloud
 
 
 
@@ -223,6 +244,16 @@ NOTE: If there are unreleased components referenced in the `metadata.json` of
 the `simp/simp_core` metamodule, the `puppet module install` for the module will
 fail.
 
+Use the following ENV variables to configure the test:
+
+#### `BEAKER_repo`
+
+* **unset** - If unset, the test will use the 6_X repos on PackageCloud
+* **fully qualified path** - If set to a fully qualified path, the test will
+  assume this is a repo file that contains definitions for both the SIMP
+  repo and the SIMP dependencies repo
+* **version** - If set, and does not start with `/`, the test will assume it
+  is an different version for the SIMP PackageCloud
 
 
 ### `rpm_docker` Suite

--- a/spec/acceptance/suites/ipa/nodesets/el6_server.yml
+++ b/spec/acceptance/suites/ipa/nodesets/el6_server.yml
@@ -27,18 +27,6 @@ HOSTS:
     hypervisor: <%= hypervisor %>
     vagrant_memsize: 4608
     vagrant_cpus: 2
-    yum_repos:
-      simp_dependencies:
-        baseurl: 'https://packagecloud.io/simp-project/6_X_Dependencies/el/6/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
-          - https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
-          - https://yum.puppet.com/RPM-GPG-KEY-puppet
-          - https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
-          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
-          - https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   ipa:
     roles:
@@ -49,18 +37,6 @@ HOSTS:
     hypervisor: <%= hypervisor %>
     vagrant_memsize: 2048
     vagrant_cpus: 2
-    yum_repos:
-      simp_dependencies:
-        baseurl: 'https://packagecloud.io/simp-project/6_X_Dependencies/el/6/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
-          - https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
-          - https://yum.puppet.com/RPM-GPG-KEY-puppet
-          - https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
-          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
-          - https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   agent-el7:
     roles:
@@ -69,18 +45,6 @@ HOSTS:
     platform:   el-7-x86_64
     box:        <%= box_7 %>
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      simp_dependencies:
-        baseurl: 'https://packagecloud.io/simp-project/6_X_Dependencies/el/7/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
-          - https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
-          - https://yum.puppet.com/RPM-GPG-KEY-puppet
-          - https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
-          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
-          - https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   agent-el6:
     roles:
@@ -89,18 +53,6 @@ HOSTS:
     platform:   el-6-x86_64
     box:        <%= box_6 %>
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      simp_dependencies:
-        baseurl: 'https://packagecloud.io/simp-project/6_X_Dependencies/el/6/$basearch'
-        gpgkeys:
-          - gpgkey=https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
-          - https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
-          - https://yum.puppet.com/RPM-GPG-KEY-puppet
-          - https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
-          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
-          - https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/suites/ipa/nodesets/el7_server.yml
+++ b/spec/acceptance/suites/ipa/nodesets/el7_server.yml
@@ -27,18 +27,6 @@ HOSTS:
     hypervisor: <%= hypervisor %>
     vagrant_memsize: 4608
     vagrant_cpus: 2
-    yum_repos:
-      simp_dependencies:
-        baseurl: 'https://packagecloud.io/simp-project/6_X_Dependencies/el/7/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
-          - https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
-          - https://yum.puppet.com/RPM-GPG-KEY-puppet
-          - https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
-          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
-          - https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   ipa:
     roles:
@@ -49,18 +37,6 @@ HOSTS:
     hypervisor: <%= hypervisor %>
     vagrant_memsize: 2048
     vagrant_cpus: 2
-    yum_repos:
-      simp_dependencies:
-        baseurl: 'https://packagecloud.io/simp-project/6_X_Dependencies/el/7/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
-          - https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
-          - https://yum.puppet.com/RPM-GPG-KEY-puppet
-          - https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
-          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
-          - https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   agent-el7:
     roles:
@@ -69,18 +45,6 @@ HOSTS:
     platform:   el-7-x86_64
     box:        <%= box_7 %>
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      simp_dependencies:
-        baseurl: 'https://packagecloud.io/simp-project/6_X_Dependencies/el/7/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
-          - https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
-          - https://yum.puppet.com/RPM-GPG-KEY-puppet
-          - https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
-          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
-          - https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   agent-el6:
     roles:
@@ -89,18 +53,6 @@ HOSTS:
     platform:   el-6-x86_64
     box:        <%= box_6 %>
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      simp_dependencies:
-        baseurl: 'https://packagecloud.io/simp-project/6_X_Dependencies/el/6/$basearch'
-        gpgkeys:
-          - https://raw.githubusercontent.com/NationalSecurityAgency/SIMP/master/GPGKEYS/RPM-GPG-KEY-SIMP
-          - https://download.simp-project.com/simp/GPGKEYS/RPM-GPG-KEY-SIMP-6
-          - https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
-          - https://yum.puppet.com/RPM-GPG-KEY-puppet
-          - https://apt.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG-96
-          - https://artifacts.elastic.co/GPG-KEY-elasticsearch
-          - https://grafanarel.s3.amazonaws.com/RPM-GPG-KEY-grafana
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/suites/rpm_docker/nodesets/el7.yml
+++ b/spec/acceptance/suites/rpm_docker/nodesets/el7.yml
@@ -28,7 +28,7 @@ HOSTS:
       - 'echo -e "[legacy]\nname=Legacy\nbaseurl=http://vault.centos.org/7.0.1406/os/x86_64\ngpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-7\ngpgcheck=1" > /etc/yum.repos.d/legacy.repo'
 
       # Downgrade ALL THE THINGS
-      - 'cd /root; yum downgrade -x nss -x nss-pem -y *'
+      - 'cd /root; yum downgrade -x nss* -x libnss* -x nspr -y *'
 
       # Work around bug https://bugzilla.redhat.com/show_bug.cgi?id=1217477
       # This does *not* update the SELinux packages, so it is safe

--- a/spec/acceptance/suites/rpm_docker/nodesets/el7.yml
+++ b/spec/acceptance/suites/rpm_docker/nodesets/el7.yml
@@ -28,7 +28,7 @@ HOSTS:
       - 'echo -e "[legacy]\nname=Legacy\nbaseurl=http://vault.centos.org/7.0.1406/os/x86_64\ngpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-7\ngpgcheck=1" > /etc/yum.repos.d/legacy.repo'
 
       # Downgrade ALL THE THINGS
-      - 'cd /root; yum downgrade -y *'
+      - 'cd /root; yum downgrade -x nss -x nss-pem -y *'
 
       # Work around bug https://bugzilla.redhat.com/show_bug.cgi?id=1217477
       # This does *not* update the SELinux packages, so it is safe

--- a/spec/spec_helper_integration.rb
+++ b/spec/spec_helper_integration.rb
@@ -5,6 +5,7 @@ require 'simp/beaker_helpers'
 require_relative 'acceptance/helpers'
 
 include Simp::BeakerHelpers
+include Acceptance::Helpers::RepoHelper
 include Acceptance::Helpers::Utils
 
 unless ENV['BEAKER_provision'] == 'no'


### PR DESCRIPTION
- Install simp-vendored-r10k RPMs from SIMP's packagecloud
  repo and use in lieu of r10k puppetserver gem
- Use Acceptance::Helpers::RepoHelper::set_up_simp_repos in lieu
  of repos in node sets, so that we have 1 place to maintain
  the SIMP packagecloud repo configuration

SIMP-5811 #close