### PR TITLE
(SIMP-5881) Bump rubygem-puppetserver-toml version

### DIFF
--- a/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
@@ -246,8 +246,8 @@ rubygem-puppetserver-parslet:
   :rpm_name: rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
 rubygem-puppetserver-toml:
-  :rpm_name: rubygem-puppetserver-toml-0.2.0-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-toml-0.2.0-0.noarch.rpm
+  :rpm_name: rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
 rubygem-net-ldap:
   :rpm_name: rubygem-net-ldap-0.6.1-2.el6.1.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-net-ldap-0.6.1-2.el6.1.noarch.rpm

--- a/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
@@ -306,8 +306,8 @@ rubygem-puppetserver-parslet:
   :rpm_name: rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
 rubygem-puppetserver-toml:
-  :rpm_name: rubygem-puppetserver-toml-0.2.0-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-toml-0.2.0-0.noarch.rpm
+  :rpm_name: rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
 rubygem-rake:
   :rpm_name: rubygem-rake-0.9.6-33.el7_4.noarch.rpm
   :source: http://mirror.centos.org/centos/7/os/x86_64/Packages/rubygem-rake-0.9.6-33.el7_4.noarch.rpm

--- a/build/distributions/RedHat/6/x86_64/yum_data/packages.yaml
+++ b/build/distributions/RedHat/6/x86_64/yum_data/packages.yaml
@@ -246,8 +246,8 @@ rubygem-puppetserver-parslet:
   :rpm_name: rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
 rubygem-puppetserver-toml:
-  :rpm_name: rubygem-puppetserver-toml-0.2.0-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-toml-0.2.0-0.noarch.rpm
+  :rpm_name: rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
 rubygem-net-ldap:
   :rpm_name: rubygem-net-ldap-0.6.1-2.el6.1.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-net-ldap-0.6.1-2.el6.1.noarch.rpm

--- a/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
@@ -294,8 +294,8 @@ rubygem-puppetserver-parslet:
   :rpm_name: rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
 rubygem-puppetserver-toml:
-  :rpm_name: rubygem-puppetserver-toml-0.2.0-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-toml-0.2.0-0.noarch.rpm
+  :rpm_name: rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
 rubygem-net-ldap:
   :rpm_name: rubygem-net-ldap-0.16.0-1.el7.noarch.rpm
   :source: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/r/rubygem-net-ldap-0.16.0-1.el7.noarch.rpm

--- a/build/rpm/dependencies.yaml
+++ b/build/rpm/dependencies.yaml
@@ -89,8 +89,8 @@
     - 'pupmod-puppetlabs-stdlib'
 
 # THree adjustments required for the next 4.1.1 release:
-# (1) (NEW) Up the release qualifier to '2', since 4.1.1-1 was already
-#     released and the change from 4.1.1-1 to 4.1.1-2 is simply a
+# (1) (NEW) Up the release qualifier to '3', since 4.1.1-1 was already
+#     released and the change from 4.1.1-2 to 4.1.1-3 is simply a
 #     packaging change, (i.e., rubygem-puppetserver-toml dependency
 #     version change).
 # (2) As with 4.1.1-0 and 4.1.1-1, make sure we create an RPM that fixes
@@ -99,7 +99,7 @@
 # (3) Exclude the problematic puppet-archive module dependency.
 #
 'grafana':
-  :release: '2'
+  :release: '3'
   :obsoletes:
     'pupmod-bfraser-grafana': '2.5.0-2016.1'
   :requires:
@@ -108,7 +108,7 @@
     - 'pupmod-puppetlabs-stdlib'
   :external_dependencies:
     'rubygem-puppetserver-toml':
-      :min: '0.2.0'
+      :min: '0.2.0-1'
 
 'java':
   :requires:


### PR DESCRIPTION
Updated the dependency due to a fix in the TOML gem that was breaking
upgrades.

SIMP-5881 #comment bump rubygem-puppetserver-toml version