### PR TITLE
(SIMP-5914) Add SIMP-6 GPG key to auto.cfg %post

### DIFF
--- a/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/auto.cfg
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/auto.cfg
@@ -270,6 +270,7 @@ enabled=1
 gpgcheck=1
 gpgkey=file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet
     file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs
+    file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP-6
     file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP
     file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch
     file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/dvd/auto.cfg
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/dvd/auto.cfg
@@ -274,6 +274,7 @@ enabled=1
 gpgcheck=1
 gpgkey=file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet
     file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs
+    file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP-6
     file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP
     file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-elasticsearch
     file:///var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-grafana


### PR DESCRIPTION
This commit fixes a bug where the `%post` script in simp-core's
`./build/distributions/*/*/x86_64/DVD/ks/dvd/auto.cfg` files created the
Yum repo file `/etc/yum.repos.d/simp_filesystem.repo` without
referencing the recently-created `SIMP-6` GPG key.

SIMP-5914 #close
