### PR TITLE
(SIMP-5978) Update simp-core for 6.3.1 release

### DIFF
--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -353,7 +353,7 @@ mod 'simp-postfix',
 
 mod 'simp-pupmod',
   :git => 'https://github.com/simp/pupmod-simp-pupmod',
-  :tag => '7.7.0'
+  :tag => '7.7.1'
 
 mod 'simp-resolv',
   :git => 'https://github.com/simp/pupmod-simp-resolv',

--- a/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
@@ -1,346 +1,346 @@
 ---
 chkrootkit:
   :rpm_name: chkrootkit-0.49-9.el6.x86_64.rpm
-  :source: http://mirror.cogentco.com/pub/linux/epel/6/x86_64/Packages/c/chkrootkit-0.49-9.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/chkrootkit-0.49-9.el6.x86_64.rpm
 clamav:
   :rpm_name: clamav-0.100.2-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-0.100.2-1.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/clamav-0.100.2-1.el6.x86_64.rpm
 clamav-db:
   :rpm_name: clamav-db-0.100.2-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-db-0.100.2-1.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/clamav-db-0.100.2-1.el6.x86_64.rpm
 clamav-devel:
   :rpm_name: clamav-devel-0.100.2-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-devel-0.100.2-1.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/clamav-devel-0.100.2-1.el6.x86_64.rpm
 clamav-milter:
   :rpm_name: clamav-milter-0.100.2-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-milter-0.100.2-1.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/clamav-milter-0.100.2-1.el6.x86_64.rpm
 clamav-unofficial-sigs:
   :rpm_name: clamav-unofficial-sigs-3.7.1-7.el6.noarch.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamav-unofficial-sigs-3.7.1-7.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/clamav-unofficial-sigs-3.7.1-7.el6.noarch.rpm
 clamd:
   :rpm_name: clamd-0.100.2-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamd-0.100.2-1.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/clamd-0.100.2-1.el6.x86_64.rpm
 clamsmtp:
   :rpm_name: clamsmtp-1.10-7.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamsmtp-1.10-7.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/clamsmtp-1.10-7.el6.x86_64.rpm
 fping:
   :rpm_name: fping-2.4b2-10.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/f/fping-2.4b2-10.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/fping-2.4b2-10.el6.x86_64.rpm
 fuse-sshfs:
   :rpm_name: fuse-sshfs-2.4-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/f/fuse-sshfs-2.4-1.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/fuse-sshfs-2.4-1.el6.x86_64.rpm
 ganglia:
   :rpm_name: ganglia-3.7.2-2.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/ganglia-3.7.2-2.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/ganglia-3.7.2-2.el6.x86_64.rpm
 ganglia-devel:
   :rpm_name: ganglia-devel-3.7.2-2.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/ganglia-devel-3.7.2-2.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/ganglia-devel-3.7.2-2.el6.x86_64.rpm
 ganglia-gmetad:
   :rpm_name: ganglia-gmetad-3.7.2-2.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/ganglia-gmetad-3.7.2-2.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/ganglia-gmetad-3.7.2-2.el6.x86_64.rpm
 ganglia-gmond:
   :rpm_name: ganglia-gmond-3.7.2-2.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/ganglia-gmond-3.7.2-2.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/ganglia-gmond-3.7.2-2.el6.x86_64.rpm
 ganglia-gmond-python:
   :rpm_name: ganglia-gmond-python-3.7.2-2.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/g/ganglia-gmond-python-3.7.2-2.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/ganglia-gmond-python-3.7.2-2.el6.x86_64.rpm
 gweb:
   :rpm_name: gweb-2.1.8-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/gweb-2.1.8-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/gweb-2.1.8-1.noarch.rpm
 haveged:
   :rpm_name: haveged-1.9.1-2.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/h/haveged-1.9.1-2.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/haveged-1.9.1-2.el6.x86_64.rpm
 incron:
   :rpm_name: incron-0.5.9-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/i/incron-0.5.9-1.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/incron-0.5.9-1.el6.x86_64.rpm
 leiningen:
   :rpm_name: leiningen-2.0.0-0.2preview10.el6.noarch.rpm
-  :source: http://yum.puppetlabs.com/el/6/dependencies/x86_64/leiningen-2.0.0-0.2preview10.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/leiningen-2.0.0-0.2preview10.el6.noarch.rpm
 libNX_X11:
   :rpm_name: libNX_X11-3.5.0.32-3.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/libNX_X11-3.5.0.32-3.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/libNX_X11-3.5.0.32-3.el6.x86_64.rpm
 libNX_Xcomposite:
   :rpm_name: libNX_Xcomposite-3.5.0.32-3.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/libNX_Xcomposite-3.5.0.32-3.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/libNX_Xcomposite-3.5.0.32-3.el6.x86_64.rpm
 libNX_Xdamage:
   :rpm_name: libNX_Xdamage-3.5.0.32-3.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/libNX_Xdamage-3.5.0.32-3.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/libNX_Xdamage-3.5.0.32-3.el6.x86_64.rpm
 libNX_Xdmcp:
   :rpm_name: libNX_Xdmcp-3.5.0.32-3.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/libNX_Xdmcp-3.5.0.32-3.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/libNX_Xdmcp-3.5.0.32-3.el6.x86_64.rpm
 libNX_Xext:
   :rpm_name: libNX_Xext-3.5.0.32-3.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/libNX_Xext-3.5.0.32-3.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/libNX_Xext-3.5.0.32-3.el6.x86_64.rpm
 libNX_Xfixes:
   :rpm_name: libNX_Xfixes-3.5.0.32-3.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/libNX_Xfixes-3.5.0.32-3.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/libNX_Xfixes-3.5.0.32-3.el6.x86_64.rpm
 libNX_Xinerama:
   :rpm_name: libNX_Xinerama-3.5.0.32-3.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/libNX_Xinerama-3.5.0.32-3.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/libNX_Xinerama-3.5.0.32-3.el6.x86_64.rpm
 libNX_Xpm:
   :rpm_name: libNX_Xpm-3.5.0.32-3.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/libNX_Xpm-3.5.0.32-3.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/libNX_Xpm-3.5.0.32-3.el6.x86_64.rpm
 libNX_Xrandr:
   :rpm_name: libNX_Xrandr-3.5.0.32-3.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/libNX_Xrandr-3.5.0.32-3.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/libNX_Xrandr-3.5.0.32-3.el6.x86_64.rpm
 libNX_Xrender:
   :rpm_name: libNX_Xrender-3.5.0.32-3.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/libNX_Xrender-3.5.0.32-3.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/libNX_Xrender-3.5.0.32-3.el6.x86_64.rpm
 libNX_Xtst:
   :rpm_name: libNX_Xtst-3.5.0.32-3.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/libNX_Xtst-3.5.0.32-3.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/libNX_Xtst-3.5.0.32-3.el6.x86_64.rpm
 libXcomp:
   :rpm_name: libXcomp-3.5.0.32-3.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/libXcomp-3.5.0.32-3.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/libXcomp-3.5.0.32-3.el6.x86_64.rpm
 libXcompext:
   :rpm_name: libXcompext-3.5.0.32-3.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/libXcompext-3.5.0.32-3.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/libXcompext-3.5.0.32-3.el6.x86_64.rpm
 libXcompshad:
   :rpm_name: libXcompshad-3.5.0.32-3.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/libXcompshad-3.5.0.32-3.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/libXcompshad-3.5.0.32-3.el6.x86_64.rpm
 libconfuse:
   :rpm_name: libconfuse-2.7-4.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/libconfuse-2.7-4.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/libconfuse-2.7-4.el6.x86_64.rpm
 libev:
   :rpm_name: libev-4.03-3.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/libev-4.03-3.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/libev-4.03-3.el6.x86_64.rpm
 libssh:
   :rpm_name: libssh-0.5.5-5.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/l/libssh-0.5.5-5.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/libssh-0.5.5-5.el6.x86_64.rpm
 libyaml:
   :rpm_name: libyaml-0.1.4-2.el6.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/libyaml-0.1.4-2.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/libyaml-0.1.4-2.el6.x86_64.rpm
 libyaml-devel:
   :rpm_name: libyaml-devel-0.1.4-2.el6.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/libyaml-devel-0.1.4-2.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/libyaml-devel-0.1.4-2.el6.x86_64.rpm
 mrepo:
   :rpm_name: mrepo-0.8.7-2.el6.noarch.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/m/mrepo-0.8.7-2.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/mrepo-0.8.7-2.el6.noarch.rpm
 mysql-connector-python:
   :rpm_name: mysql-connector-python-1.1.6-1.el6.noarch.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/m/mysql-connector-python-1.1.6-1.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/mysql-connector-python-1.1.6-1.el6.noarch.rpm
 nx-libs:
   :rpm_name: nx-libs-3.5.0.32-3.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/n/nx-libs-3.5.0.32-3.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/nx-libs-3.5.0.32-3.el6.x86_64.rpm
 nxagent:
   :rpm_name: nxagent-3.5.0.32-3.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/n/nxagent-3.5.0.32-3.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/nxagent-3.5.0.32-3.el6.x86_64.rpm
 nxproxy:
   :rpm_name: nxproxy-3.5.0.32-3.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/n/nxproxy-3.5.0.32-3.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/nxproxy-3.5.0.32-3.el6.x86_64.rpm
 pdsh:
   :rpm_name: pdsh-2.28-0.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-2.28-0.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/pdsh-2.28-0.x86_64.rpm
 pdsh-mod-dshgroup:
   :rpm_name: pdsh-mod-dshgroup-2.28-0.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-mod-dshgroup-2.28-0.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/pdsh-mod-dshgroup-2.28-0.x86_64.rpm
 pdsh-mod-machines:
   :rpm_name: pdsh-mod-machines-2.28-0.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-mod-machines-2.28-0.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/pdsh-mod-machines-2.28-0.x86_64.rpm
 pdsh-mod-netgroup:
   :rpm_name: pdsh-mod-netgroup-2.28-0.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-mod-netgroup-2.28-0.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/pdsh-mod-netgroup-2.28-0.x86_64.rpm
 pdsh-rcmd-exec:
   :rpm_name: pdsh-rcmd-exec-2.28-0.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-rcmd-exec-2.28-0.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/pdsh-rcmd-exec-2.28-0.x86_64.rpm
 pdsh-rcmd-ssh:
   :rpm_name: pdsh-rcmd-ssh-2.28-0.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pdsh-rcmd-ssh-2.28-0.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/pdsh-rcmd-ssh-2.28-0.x86_64.rpm
 perl-Capture-Tiny:
   :rpm_name: perl-Capture-Tiny-0.23-1.el6.noarch.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/p/perl-Capture-Tiny-0.23-1.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/perl-Capture-Tiny-0.23-1.el6.noarch.rpm
 perl-Config-Simple:
   :rpm_name: perl-Config-Simple-4.59-5.el6.noarch.rpm
-  :source: http://mirrors.lug.mtu.edu/epel/6/x86_64/Packages/p/perl-Config-Simple-4.59-5.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/perl-Config-Simple-4.59-5.el6.noarch.rpm
 perl-Crypt-DES:
   :rpm_name: perl-Crypt-DES-2.05-9.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/p/perl-Crypt-DES-2.05-9.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/perl-Crypt-DES-2.05-9.el6.x86_64.rpm
 perl-File-BaseDir:
   :rpm_name: perl-File-BaseDir-0.03-13.el6.noarch.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/p/perl-File-BaseDir-0.03-13.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/perl-File-BaseDir-0.03-13.el6.noarch.rpm
 perl-File-RsyncP:
   :rpm_name: perl-File-RsyncP-0.72-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/p/perl-File-RsyncP-0.72-1.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/perl-File-RsyncP-0.72-1.el6.x86_64.rpm
 perl-File-Which:
   :rpm_name: perl-File-Which-1.09-2.el6.noarch.rpm
-  :source: http://mirror.centos.org/centos/6/os/x86_64/Packages/perl-File-Which-1.09-2.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/perl-File-Which-1.09-2.el6.noarch.rpm
 perl-Math-Calc-Units:
   :rpm_name: perl-Math-Calc-Units-1.07-6.el6.noarch.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/p/perl-Math-Calc-Units-1.07-6.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/perl-Math-Calc-Units-1.07-6.el6.noarch.rpm
 perl-Net-FTP-AutoReconnect:
   :rpm_name: perl-Net-FTP-AutoReconnect-0.3-3.el6.noarch.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/p/perl-Net-FTP-AutoReconnect-0.3-3.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/perl-Net-FTP-AutoReconnect-0.3-3.el6.noarch.rpm
 perl-Net-FTP-RetrHandle:
   :rpm_name: perl-Net-FTP-RetrHandle-0.2-3.el6.noarch.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/p/perl-Net-FTP-RetrHandle-0.2-3.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/perl-Net-FTP-RetrHandle-0.2-3.el6.noarch.rpm
 perl-Net-SNMP:
   :rpm_name: perl-Net-SNMP-5.2.0-4.el6.noarch.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/p/perl-Net-SNMP-5.2.0-4.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/perl-Net-SNMP-5.2.0-4.el6.noarch.rpm
 perl-Sort-Versions:
   :rpm_name: perl-Sort-Versions-1.5-12.el6.noarch.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/p/perl-Sort-Versions-1.5-12.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/perl-Sort-Versions-1.5-12.el6.noarch.rpm
 perl-Time-modules:
   :rpm_name: perl-Time-modules-2006.0814-5.el6.noarch.rpm
-  :source: http://mirror.ash.fastserv.com/pub/linux/centos/6.9/os/x86_64/Packages/perl-Time-modules-2006.0814-5.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/perl-Time-modules-2006.0814-5.el6.noarch.rpm
 postgresql96:
   :rpm_name: postgresql96-9.6.10-1PGDG.rhel6.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-6.9-x86_64/postgresql96-9.6.10-1PGDG.rhel6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/postgresql96-9.6.10-1PGDG.rhel6.x86_64.rpm
 postgresql96-contrib:
   :rpm_name: postgresql96-contrib-9.6.10-1PGDG.rhel6.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-6.9-x86_64/postgresql96-contrib-9.6.10-1PGDG.rhel6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/postgresql96-contrib-9.6.10-1PGDG.rhel6.x86_64.rpm
 postgresql96-libs:
   :rpm_name: postgresql96-libs-9.6.10-1PGDG.rhel6.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-6.9-x86_64/postgresql96-libs-9.6.10-1PGDG.rhel6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/postgresql96-libs-9.6.10-1PGDG.rhel6.x86_64.rpm
 postgresql96-server:
   :rpm_name: postgresql96-server-9.6.10-1PGDG.rhel6.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-6.9-x86_64/postgresql96-server-9.6.10-1PGDG.rhel6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/postgresql96-server-9.6.10-1PGDG.rhel6.x86_64.rpm
 pssh:
   :rpm_name: pssh-2.3.1-5.el6.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/pssh-2.3.1-5.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/pssh-2.3.1-5.el6.noarch.rpm
 puppet-agent:
   :rpm_name: puppet-agent-5.5.7-1.el6.x86_64.rpm
-  :source: https://yum.puppetlabs.com/puppet5/el/6/x86_64/puppet-agent-5.5.7-1.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/puppet-agent-5.5.7-1.el6.x86_64.rpm
 puppet-client-tools:
   :rpm_name: puppet-client-tools-1.2.4-1.el6.x86_64.rpm
-  :source: https://yum.puppetlabs.com/puppet5/el/6/x86_64/puppet-client-tools-1.2.4-1.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/puppet-client-tools-1.2.4-1.el6.x86_64.rpm
 puppet5-release:
   :rpm_name: puppet5-release-5.0.0-1.el6.noarch.rpm
-  :source: https://yum.puppetlabs.com/puppet5/el/6/x86_64/puppet5-release-5.0.0-1.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/puppet5-release-5.0.0-1.el6.noarch.rpm
 puppetdb:
   :rpm_name: puppetdb-5.2.4-1.el6.noarch.rpm
-  :source: https://yum.puppetlabs.com/puppet5/el/6/x86_64/puppetdb-5.2.4-1.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/puppetdb-5.2.4-1.el6.noarch.rpm
 puppetdb-termini:
   :rpm_name: puppetdb-termini-5.2.4-1.el6.noarch.rpm
-  :source: https://yum.puppetlabs.com/puppet5/el/6/x86_64/puppetdb-termini-5.2.4-1.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/puppetdb-termini-5.2.4-1.el6.noarch.rpm
 puppetserver:
   :rpm_name: puppetserver-5.3.5-1.el6.noarch.rpm
-  :source: https://yum.puppetlabs.com/puppet5/el/6/x86_64/puppetserver-5.3.5-1.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/puppetserver-5.3.5-1.el6.noarch.rpm
 pwgen:
   :rpm_name: pwgen-2.08-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/p/pwgen-2.08-1.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/pwgen-2.08-1.el6.x86_64.rpm
 python-argparse:
   :rpm_name: python-argparse-1.2.1-2.1.el6.noarch.rpm
-  :source: http://mirror.cogentco.com/pub/linux/centos/6/os/x86_64/Packages/python-argparse-1.2.1-2.1.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/python-argparse-1.2.1-2.1.el6.noarch.rpm
 python-redis:
   :rpm_name: python-redis-2.0.0-1.el6.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/python-redis-2.0.0-1.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/python-redis-2.0.0-1.el6.noarch.rpm
 python-unittest2:
   :rpm_name: python-unittest2-0.5.1-3.el6.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/python-unittest2-0.5.1-3.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/python-unittest2-0.5.1-3.el6.noarch.rpm
 qstat:
   :rpm_name: qstat-2.11-9.20080912svn311.el6.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/qstat-2.11-9.20080912svn311.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/qstat-2.11-9.20080912svn311.el6.x86_64.rpm
 radiusclient-ng:
   :rpm_name: radiusclient-ng-0.5.6-5.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/r/radiusclient-ng-0.5.6-5.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/radiusclient-ng-0.5.6-5.el6.x86_64.rpm
 rlwrap:
   :rpm_name: rlwrap-0.42-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/r/rlwrap-0.42-1.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/rlwrap-0.42-1.el6.x86_64.rpm
 rubygem-ffi:
   :rpm_name: rubygem-ffi-1.4.0-2.el6.x86_64.rpm
-  :source: http://yum.puppetlabs.com/el/6/dependencies/x86_64/rubygem-ffi-1.4.0-2.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/rubygem-ffi-1.4.0-2.el6.x86_64.rpm
 rubygem-highline:
   :rpm_name: rubygem-highline-1.6.11-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-highline-1.6.11-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/rubygem-highline-1.6.11-1.noarch.rpm
 rubygem-puppetserver-parslet:
   :rpm_name: rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
 rubygem-puppetserver-toml:
   :rpm_name: rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
 rubygem-net-ldap:
   :rpm_name: rubygem-net-ldap-0.6.1-2.el6.1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-net-ldap-0.6.1-2.el6.1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/rubygem-net-ldap-0.6.1-2.el6.1.noarch.rpm
 rubygem-net-ldap-doc:
   :rpm_name: rubygem-net-ldap-doc-0.6.1-2.el6.1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-net-ldap-doc-0.6.1-2.el6.1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/rubygem-net-ldap-doc-0.6.1-2.el6.1.noarch.rpm
 rubygem-net-ping:
   :rpm_name: rubygem-net-ping-1.6.2-1.el6.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-net-ping-1.6.2-1.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/rubygem-net-ping-1.6.2-1.el6.noarch.rpm
 rubygem-rake-compiler:
   :rpm_name: rubygem-rake-compiler-0.9.3-2.el6.noarch.rpm
-  :source: http://http://yum.puppetlabs.com/el/6/dependencies/x86_64/rubygem-rake-compiler-0.9.3-2.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/rubygem-rake-compiler-0.9.3-2.el6.noarch.rpm
 rubygem-stomp:
   :rpm_name: rubygem-stomp-1.3.2-1.el6.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-stomp-1.3.2-1.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/rubygem-stomp-1.3.2-1.el6.noarch.rpm
 rubygem-stomp-doc:
   :rpm_name: rubygem-stomp-doc-1.3.2-1.el6.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-stomp-doc-1.3.2-1.el6.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/rubygem-stomp-doc-1.3.2-1.el6.noarch.rpm
 simp-lastbind:
   :rpm_name: simp-lastbind-2.4.23-0.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/simp-lastbind-2.4.23-0.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/simp-lastbind-2.4.23-0.x86_64.rpm
 simp-ppolicy-check-password:
   :rpm_name: simp-ppolicy-check-password-2.4.39-0.el6.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/simp-ppolicy-check-password-2.4.39-0.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/simp-ppolicy-check-password-2.4.39-0.el6.x86_64.rpm
 simp-vendored-r10k:
   :rpm_name: simp-vendored-r10k-2.6.2-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-2.6.2-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/simp-vendored-r10k-2.6.2-1.noarch.rpm
 simp-vendored-r10k-doc:
   :rpm_name: simp-vendored-r10k-doc-2.6.2-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-doc-2.6.2-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/simp-vendored-r10k-doc-2.6.2-1.noarch.rpm
 simp-vendored-r10k-gem-colored:
   :rpm_name: simp-vendored-r10k-gem-colored-1.2-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-colored-1.2-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/simp-vendored-r10k-gem-colored-1.2-1.noarch.rpm
 simp-vendored-r10k-gem-cri:
   :rpm_name: simp-vendored-r10k-gem-cri-2.6.1-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-cri-2.6.1-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/simp-vendored-r10k-gem-cri-2.6.1-1.noarch.rpm
 simp-vendored-r10k-gem-faraday:
   :rpm_name: simp-vendored-r10k-gem-faraday-0.9.2-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-faraday-0.9.2-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/simp-vendored-r10k-gem-faraday-0.9.2-1.noarch.rpm
 simp-vendored-r10k-gem-faraday_middleware:
   :rpm_name: simp-vendored-r10k-gem-faraday_middleware-0.10.1-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-faraday_middleware-0.10.1-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/simp-vendored-r10k-gem-faraday_middleware-0.10.1-1.noarch.rpm
 simp-vendored-r10k-gem-fast_gettext:
   :rpm_name: simp-vendored-r10k-gem-fast_gettext-1.1.2-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-fast_gettext-1.1.2-0.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/simp-vendored-r10k-gem-fast_gettext-1.1.2-0.noarch.rpm
 simp-vendored-r10k-gem-gettext:
   :rpm_name: simp-vendored-r10k-gem-gettext-3.2.9-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-gettext-3.2.9-0.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/simp-vendored-r10k-gem-gettext-3.2.9-0.noarch.rpm
 simp-vendored-r10k-gem-gettext-setup:
   :rpm_name: simp-vendored-r10k-gem-gettext-setup-0.30-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-gettext-setup-0.30-0.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/simp-vendored-r10k-gem-gettext-setup-0.30-0.noarch.rpm
 simp-vendored-r10k-gem-locale:
   :rpm_name: simp-vendored-r10k-gem-locale-2.1.2-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-locale-2.1.2-0.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/simp-vendored-r10k-gem-locale-2.1.2-0.noarch.rpm
 simp-vendored-r10k-gem-log4r:
   :rpm_name: simp-vendored-r10k-gem-log4r-1.1.10-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-log4r-1.1.10-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/simp-vendored-r10k-gem-log4r-1.1.10-1.noarch.rpm
 simp-vendored-r10k-gem-minitar:
   :rpm_name: simp-vendored-r10k-gem-minitar-0.6.1-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-minitar-0.6.1-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/simp-vendored-r10k-gem-minitar-0.6.1-1.noarch.rpm
 simp-vendored-r10k-gem-multi_json:
   :rpm_name: simp-vendored-r10k-gem-multi_json-1.12.1-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-multi_json-1.12.1-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/simp-vendored-r10k-gem-multi_json-1.12.1-1.noarch.rpm
 simp-vendored-r10k-gem-multipart-post:
   :rpm_name: simp-vendored-r10k-gem-multipart-post-2.0.0-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-multipart-post-2.0.0-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/simp-vendored-r10k-gem-multipart-post-2.0.0-1.noarch.rpm
 simp-vendored-r10k-gem-puppet_forge:
   :rpm_name: simp-vendored-r10k-gem-puppet_forge-2.2.8-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-puppet_forge-2.2.8-0.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/simp-vendored-r10k-gem-puppet_forge-2.2.8-0.noarch.rpm
 simp-vendored-r10k-gem-r10k:
   :rpm_name: simp-vendored-r10k-gem-r10k-2.6.2-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-r10k-2.6.2-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/simp-vendored-r10k-gem-r10k-2.6.2-1.noarch.rpm
 simp-vendored-r10k-gem-semantic_puppet:
   :rpm_name: simp-vendored-r10k-gem-semantic_puppet-1.0.2-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-semantic_puppet-1.0.2-0.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/simp-vendored-r10k-gem-semantic_puppet-1.0.2-0.noarch.rpm
 simp-vendored-r10k-gem-text:
   :rpm_name: simp-vendored-r10k-gem-text-1.3.1-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/6/simp-vendored-r10k-gem-text-1.3.1-0.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/simp-vendored-r10k-gem-text-1.3.1-0.noarch.rpm
 sudosh2:
   :rpm_name: sudosh2-1.0.2-2.el6.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/sudosh2-1.0.2-2.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/sudosh2-1.0.2-2.el6.x86_64.rpm
 tlog:
   :rpm_name: tlog-4-1.el6.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/tlog-4-1.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/tlog-4-1.el6.x86_64.rpm
 voms:
   :rpm_name: voms-2.0.14-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/v/voms-2.0.14-1.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/voms-2.0.14-1.el6.x86_64.rpm
 x2goagent:
   :rpm_name: x2goagent-3.5.0.32-3.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/x/x2goagent-3.5.0.32-3.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/x2goagent-3.5.0.32-3.el6.x86_64.rpm
 x2goclient:
   :rpm_name: x2goclient-4.0.1.4-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/x/x2goclient-4.0.1.4-1.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/x2goclient-4.0.1.4-1.el6.x86_64.rpm
 x2goserver:
   :rpm_name: x2goserver-4.0.1.20-1.el6.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/x/x2goserver-4.0.1.20-1.el6.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/6/x86_64/x2goserver-4.0.1.20-1.el6.x86_64.rpm

--- a/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
@@ -1,421 +1,421 @@
 ---
 apr-util-ldap:
   :rpm_name: apr-util-ldap-1.5.2-6.el7.x86_64.rpm
-  :source: http://vault.centos.org/7.4.1708/os/x86_64/Packages/apr-util-ldap-1.5.2-6.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/apr-util-ldap-1.5.2-6.el7.x86_64.rpm
 caja:
   :rpm_name: caja-1.16.6-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/caja-1.16.6-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/caja-1.16.6-1.el7.x86_64.rpm
 caja-extensions:
   :rpm_name: caja-extensions-1.16.6-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/caja-extensions-1.16.6-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/caja-extensions-1.16.6-1.el7.x86_64.rpm
 caja-extensions-common:
   :rpm_name: caja-extensions-common-1.16.0-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/caja-extensions-common-1.16.0-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/caja-extensions-common-1.16.0-1.el7.noarch.rpm
 caja-open-terminal:
   :rpm_name: caja-open-terminal-1.16.0-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/caja-open-terminal-1.16.0-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/caja-open-terminal-1.16.0-1.el7.x86_64.rpm
 caja-schemas:
   :rpm_name: caja-schemas-1.16.6-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/caja-schemas-1.16.6-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/caja-schemas-1.16.6-1.el7.x86_64.rpm
 chkrootkit:
   :rpm_name: chkrootkit-0.50-4el7.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/chkrootkit-0.50-4el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/chkrootkit-0.50-4el7.x86_64.rpm
 clamav:
   :rpm_name: clamav-0.101.0-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-0.101.0-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/clamav-0.101.0-1.el7.x86_64.rpm
 clamav-data:
   :rpm_name: clamav-data-0.101.0-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-data-0.101.0-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/clamav-data-0.101.0-1.el7.noarch.rpm
 clamav-devel:
   :rpm_name: clamav-devel-0.101.0-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-devel-0.101.0-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/clamav-devel-0.101.0-1.el7.x86_64.rpm
 clamav-filesystem:
   :rpm_name: clamav-filesystem-0.101.0-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-filesystem-0.101.0-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/clamav-filesystem-0.101.0-1.el7.noarch.rpm
 clamav-lib:
   :rpm_name: clamav-lib-0.101.0-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-lib-0.101.0-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/clamav-lib-0.101.0-1.el7.x86_64.rpm
 clamav-scanner-systemd:
   :rpm_name: clamav-scanner-systemd-0.101.0-1.el7.x86_64.rpm
-  :source: https://mirror.umd.edu/fedora/epel/7/x86_64/Packages/c/clamav-scanner-systemd-0.101.0-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/clamav-scanner-systemd-0.101.0-1.el7.x86_64.rpm
 clamav-server-systemd:
   :rpm_name: clamav-server-systemd-0.101.0-1.el7.x86_64.rpm
-  :source: https://mirror.umd.edu/fedora/epel/7/x86_64/Packages/c/clamav-server-systemd-0.101.0-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/clamav-server-systemd-0.101.0-1.el7.x86_64.rpm
 clamav-update:
   :rpm_name: clamav-update-0.101.0-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamav-update-0.101.0-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/clamav-update-0.101.0-1.el7.x86_64.rpm
 clamd:
   :rpm_name: clamd-0.101.0-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/clamd-0.101.0-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/clamd-0.101.0-1.el7.x86_64.rpm
 fortune-mod:
   :rpm_name: fortune-mod-1.99.1-17.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/f/fortune-mod-1.99.1-17.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/fortune-mod-1.99.1-17.el7.x86_64.rpm
 fuse-sshfs:
   :rpm_name: fuse-sshfs-2.10-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/f/fuse-sshfs-2.10-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/fuse-sshfs-2.10-1.el7.x86_64.rpm
 gtk-murrine-engine:
   :rpm_name: gtk-murrine-engine-0.98.2-10.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/g/gtk-murrine-engine-0.98.2-10.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/gtk-murrine-engine-0.98.2-10.el7.x86_64.rpm
 gtk2-engines:
   :rpm_name: gtk2-engines-2.20.2-7.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/g/gtk2-engines-2.20.2-7.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/gtk2-engines-2.20.2-7.el7.x86_64.rpm
 gweb:
   :rpm_name: gweb-2.1.8-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/gweb-2.1.8-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/gweb-2.1.8-1.noarch.rpm
 haveged:
   :rpm_name: haveged-1.9.1-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/h/haveged-1.9.1-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/haveged-1.9.1-1.el7.x86_64.rpm
 ima-evm-utils:
   :rpm_name: ima-evm-utils-1.1-2.el7.x86_64.rpm
-  :source: http://repo1.ash.innoscale.net/centos/7.5.1804/os/x86_64/Packages/ima-evm-utils-1.1-2.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/ima-evm-utils-1.1-2.el7.x86_64.rpm
 incron:
   :rpm_name: incron-0.5.10-8.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/i/incron-0.5.10-8.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/incron-0.5.10-8.el7.x86_64.rpm
 libNX_X11:
   :rpm_name: libNX_X11-3.5.99.17-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/l/libNX_X11-3.5.99.17-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/libNX_X11-3.5.99.17-1.el7.x86_64.rpm
 libXcomp:
   :rpm_name: libXcomp-3.5.99.17-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/l/libXcomp-3.5.99.17-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/libXcomp-3.5.99.17-1.el7.x86_64.rpm
 libXcompshad:
   :rpm_name: libXcompshad-3.5.99.17-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/l/libXcompshad-3.5.99.17-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/libXcompshad-3.5.99.17-1.el7.x86_64.rpm
 libarchive-devel:
   :rpm_name: libarchive-devel-3.1.2-10.el7_2.x86_64.rpm
-  :source: http://mirror.steadfast.net/centos/7.4.1708/os/x86_64/Packages/libarchive-devel-3.1.2-10.el7_2.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/libarchive-devel-3.1.2-10.el7_2.x86_64.rpm
 libconfuse:
   :rpm_name: libconfuse-2.7-7.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/l/libconfuse-2.7-7.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/libconfuse-2.7-7.el7.x86_64.rpm
 libev:
   :rpm_name: libev-4.15-3.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/l/libev-4.15-3.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/libev-4.15-3.el7.x86_64.rpm
 libmatekbd:
   :rpm_name: libmatekbd-1.16.0-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/l/libmatekbd-1.16.0-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/libmatekbd-1.16.0-1.el7.x86_64.rpm
 libmatemixer:
   :rpm_name: libmatemixer-1.16.0-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/l/libmatemixer-1.16.0-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/libmatemixer-1.16.0-1.el7.x86_64.rpm
 libmateweather:
   :rpm_name: libmateweather-1.16.1-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/l/libmateweather-1.16.1-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/libmateweather-1.16.1-1.el7.x86_64.rpm
 libmateweather-data:
   :rpm_name: libmateweather-data-1.16.1-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/l/libmateweather-data-1.16.1-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/libmateweather-data-1.16.1-1.el7.noarch.rpm
 libssh:
   :rpm_name: libssh-0.7.1-3.el7.x86_64.rpm
-  :source: http://mirror.centos.org/centos/7/extras/x86_64/Packages/libssh-0.7.1-3.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/libssh-0.7.1-3.el7.x86_64.rpm
 libwnck:
   :rpm_name: libwnck-2.31.0-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/l/libwnck-2.31.0-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/libwnck-2.31.0-1.el7.x86_64.rpm
 lyx-fonts:
   :rpm_name: lyx-fonts-2.2.3-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/l/lyx-fonts-2.2.3-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/lyx-fonts-2.2.3-1.el7.noarch.rpm
 marco:
   :rpm_name: marco-1.16.1-3.el7.x86_64.rpm
-  :source: https://download.simp-project.com/SIMP/archive/yum/6.X/EL7/dependencies/x86_64/marco-1.16.1-3.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/marco-1.16.1-3.el7.x86_64.rpm
 mate-control-center:
   :rpm_name: mate-control-center-1.16.1-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/mate-control-center-1.16.1-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/mate-control-center-1.16.1-1.el7.x86_64.rpm
 mate-control-center-filesystem:
   :rpm_name: mate-control-center-filesystem-1.16.1-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/mate-control-center-filesystem-1.16.1-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/mate-control-center-filesystem-1.16.1-1.el7.x86_64.rpm
 mate-desktop:
   :rpm_name: mate-desktop-1.16.2-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/mate-desktop-1.16.2-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/mate-desktop-1.16.2-1.el7.x86_64.rpm
 mate-desktop-libs:
   :rpm_name: mate-desktop-libs-1.16.2-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/mate-desktop-libs-1.16.2-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/mate-desktop-libs-1.16.2-1.el7.x86_64.rpm
 mate-icon-theme:
   :rpm_name: mate-icon-theme-1.16.2-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/mate-icon-theme-1.16.2-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/mate-icon-theme-1.16.2-1.el7.noarch.rpm
 mate-menus:
   :rpm_name: mate-menus-1.16.0-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/mate-menus-1.16.0-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/mate-menus-1.16.0-1.el7.x86_64.rpm
 mate-menus-libs:
   :rpm_name: mate-menus-libs-1.16.0-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/mate-menus-libs-1.16.0-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/mate-menus-libs-1.16.0-1.el7.x86_64.rpm
 mate-notification-daemon:
   :rpm_name: mate-notification-daemon-1.16.1-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/mate-notification-daemon-1.16.1-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/mate-notification-daemon-1.16.1-1.el7.x86_64.rpm
 mate-panel:
   :rpm_name: mate-panel-1.16.2-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/mate-panel-1.16.2-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/mate-panel-1.16.2-1.el7.x86_64.rpm
 mate-panel-libs:
   :rpm_name: mate-panel-libs-1.16.2-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/mate-panel-libs-1.16.2-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/mate-panel-libs-1.16.2-1.el7.x86_64.rpm
 mate-polkit:
   :rpm_name: mate-polkit-1.16.0-2.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/mate-polkit-1.16.0-2.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/mate-polkit-1.16.0-2.el7.x86_64.rpm
 mate-power-manager:
   :rpm_name: mate-power-manager-1.16.2-2.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/mate-power-manager-1.16.2-2.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/mate-power-manager-1.16.2-2.el7.x86_64.rpm
 mate-screensaver:
   :rpm_name: mate-screensaver-1.16.1-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/mate-screensaver-1.16.1-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/mate-screensaver-1.16.1-1.el7.x86_64.rpm
 mate-session-manager:
   :rpm_name: mate-session-manager-1.16.1-3.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/mate-session-manager-1.16.1-3.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/mate-session-manager-1.16.1-3.el7.x86_64.rpm
 mate-settings-daemon:
   :rpm_name: mate-settings-daemon-1.16.2-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/mate-settings-daemon-1.16.2-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/mate-settings-daemon-1.16.2-1.el7.x86_64.rpm
 mate-themes:
   :rpm_name: mate-themes-3.22.18-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/mate-themes-3.22.18-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/mate-themes-3.22.18-1.el7.noarch.rpm
 mate-user-guide:
   :rpm_name: mate-user-guide-1.16.0-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/mate-user-guide-1.16.0-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/mate-user-guide-1.16.0-1.el7.noarch.rpm
 nx-libs:
   :rpm_name: nx-libs-3.5.99.17-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/n/nx-libs-3.5.99.17-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/nx-libs-3.5.99.17-1.el7.x86_64.rpm
 nxagent:
   :rpm_name: nxagent-3.5.99.17-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/n/nxagent-3.5.99.17-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/nxagent-3.5.99.17-1.el7.x86_64.rpm
 nxproxy:
   :rpm_name: nxproxy-3.5.99.17-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/n/nxproxy-3.5.99.17-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/nxproxy-3.5.99.17-1.el7.x86_64.rpm
 pdsh:
   :rpm_name: pdsh-2.29-1el7.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-2.29-1el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/pdsh-2.29-1el7.x86_64.rpm
 pdsh-debuginfo:
   :rpm_name: pdsh-debuginfo-2.29-1el7.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-debuginfo-2.29-1el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/pdsh-debuginfo-2.29-1el7.x86_64.rpm
 pdsh-mod-dshgroup:
   :rpm_name: pdsh-mod-dshgroup-2.29-1el7.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-mod-dshgroup-2.29-1el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/pdsh-mod-dshgroup-2.29-1el7.x86_64.rpm
 pdsh-mod-machines:
   :rpm_name: pdsh-mod-machines-2.29-1el7.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-mod-machines-2.29-1el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/pdsh-mod-machines-2.29-1el7.x86_64.rpm
 pdsh-mod-netgroup:
   :rpm_name: pdsh-mod-netgroup-2.29-1el7.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-mod-netgroup-2.29-1el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/pdsh-mod-netgroup-2.29-1el7.x86_64.rpm
 pdsh-rcmd-exec:
   :rpm_name: pdsh-rcmd-exec-2.29-1el7.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-rcmd-exec-2.29-1el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/pdsh-rcmd-exec-2.29-1el7.x86_64.rpm
 pdsh-rcmd-ssh:
   :rpm_name: pdsh-rcmd-ssh-2.29-1el7.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pdsh-rcmd-ssh-2.29-1el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/pdsh-rcmd-ssh-2.29-1el7.x86_64.rpm
 perl-Capture-Tiny:
   :rpm_name: perl-Capture-Tiny-0.24-1.el7.noarch.rpm
-  :source: http://mirror.centos.org/centos/7/os/x86_64/Packages/perl-Capture-Tiny-0.24-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/perl-Capture-Tiny-0.24-1.el7.noarch.rpm
 perl-Config-Simple:
   :rpm_name: perl-Config-Simple-4.59-15.el7.noarch.rpm
-  :source: http://mirror.centos.org/centos/7/os/x86_64/Packages/perl-Config-Simple-4.59-15.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/perl-Config-Simple-4.59-15.el7.noarch.rpm
 perl-File-BaseDir:
   :rpm_name: perl-File-BaseDir-0.03-14.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/perl-File-BaseDir-0.03-14.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/perl-File-BaseDir-0.03-14.el7.noarch.rpm
 perl-File-Which:
   :rpm_name: perl-File-Which-1.09-12.el7.noarch.rpm
-  :source: http://mirror.centos.org/centos/7.5.1804/os/x86_64/Packages/perl-File-Which-1.09-12.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/perl-File-Which-1.09-12.el7.noarch.rpm
 perl-Switch:
   :rpm_name: perl-Switch-2.16-7.el7.noarch.rpm
-  :source: http://mirror.centos.org/centos/7.5.1804/os/x86_64/Packages/perl-Switch-2.16-7.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/perl-Switch-2.16-7.el7.noarch.rpm
 perl-X2go-Log:
   :rpm_name: perl-X2Go-Log-4.1.0.3-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/perl-X2Go-Log-4.1.0.3-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/perl-X2Go-Log-4.1.0.3-1.el7.noarch.rpm
 perl-X2go-Server:
   :rpm_name: perl-X2Go-Server-4.1.0.3-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/perl-X2Go-Server-4.1.0.3-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/perl-X2Go-Server-4.1.0.3-1.el7.noarch.rpm
 perl-X2go-Server-DB:
   :rpm_name: perl-X2Go-Server-DB-4.1.0.3-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/perl-X2Go-Server-DB-4.1.0.3-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/perl-X2Go-Server-DB-4.1.0.3-1.el7.x86_64.rpm
 postgresql96:
   :rpm_name: postgresql96-9.6.11-1PGDG.rhel7.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-9.6.11-1PGDG.rhel7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/postgresql96-9.6.11-1PGDG.rhel7.x86_64.rpm
 postgresql96-contrib:
   :rpm_name: postgresql96-contrib-9.6.11-1PGDG.rhel7.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-contrib-9.6.11-1PGDG.rhel7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/postgresql96-contrib-9.6.11-1PGDG.rhel7.x86_64.rpm
 postgresql96-libs:
   :rpm_name: postgresql96-libs-9.6.11-1PGDG.rhel7.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-libs-9.6.11-1PGDG.rhel7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/postgresql96-libs-9.6.11-1PGDG.rhel7.x86_64.rpm
 postgresql96-server:
   :rpm_name: postgresql96-server-9.6.11-1PGDG.rhel7.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-server-9.6.11-1PGDG.rhel7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/postgresql96-server-9.6.11-1PGDG.rhel7.x86_64.rpm
 pssh:
   :rpm_name: pssh-2.3.1.SIMP-5.el7.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pssh-2.3.1.SIMP-5.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/pssh-2.3.1.SIMP-5.el7.noarch.rpm
 puppet-agent:
   :rpm_name: puppet-agent-5.5.7-1.el7.x86_64.rpm
-  :source: https://yum.puppetlabs.com/puppet5/el/7/x86_64/puppet-agent-5.5.7-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/puppet-agent-5.5.7-1.el7.x86_64.rpm
 puppet-client-tools:
   :rpm_name: puppet-client-tools-1.2.4-1.el7.x86_64.rpm
-  :source: https://yum.puppetlabs.com/puppet5/el/7/x86_64/puppet-client-tools-1.2.4-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/puppet-client-tools-1.2.4-1.el7.x86_64.rpm
 puppet5-release:
   :rpm_name: puppet5-release-5.0.0-1.el7.noarch.rpm
-  :source: https://yum.puppetlabs.com/puppet5/el/7/x86_64/puppet5-release-5.0.0-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/puppet5-release-5.0.0-1.el7.noarch.rpm
 puppetdb:
   :rpm_name: puppetdb-5.2.4-1.el7.noarch.rpm
-  :source: https://yum.puppetlabs.com/puppet5/el/7/x86_64/puppetdb-5.2.4-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/puppetdb-5.2.4-1.el7.noarch.rpm
 puppetdb-termini:
   :rpm_name: puppetdb-termini-5.2.4-1.el7.noarch.rpm
-  :source: https://yum.puppetlabs.com/puppet5/el/7/x86_64/puppetdb-termini-5.2.4-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/puppetdb-termini-5.2.4-1.el7.noarch.rpm
 puppetserver:
   :rpm_name: puppetserver-5.3.5-1.el7.noarch.rpm
-  :source: https://yum.puppetlabs.com/puppet5/el/7/x86_64/puppetserver-5.3.5-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/puppetserver-5.3.5-1.el7.noarch.rpm
 pwgen:
   :rpm_name: pwgen-2.08-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/pwgen-2.08-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/pwgen-2.08-1.el7.x86_64.rpm
 python-linecache2:
   :rpm_name: python-linecache2-1.0.0-1.el7.noarch.rpm
-  :source: https://lug.mtu.edu/epel/7/x86_64/Packages/p/python-linecache2-1.0.0-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/python-linecache2-1.0.0-1.el7.noarch.rpm
 python-redis:
   :rpm_name: python-redis-2.10.3-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/python-redis-2.10.3-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/python-redis-2.10.3-1.el7.noarch.rpm
 python-simplejson:
   :rpm_name: python-simplejson-3.3.3-1.el7.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/python-simplejson-3.3.3-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/python-simplejson-3.3.3-1.el7.x86_64.rpm
 python-traceback2:
   :rpm_name: python-traceback2-1.4.0-2.el7.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/python-traceback2-1.4.0-2.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/python-traceback2-1.4.0-2.el7.noarch.rpm
 python-unittest2:
   :rpm_name: python-unittest2-1.1.0-4.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/python-unittest2-1.1.0-4.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/python-unittest2-1.1.0-4.el7.noarch.rpm
 ruby-augeas:
   :rpm_name: ruby-augeas-0.4.1-3.el7.x86_64.rpm
-  :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/ruby-augeas-0.4.1-3.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/ruby-augeas-0.4.1-3.el7.x86_64.rpm
 ruby-ldap:
   :rpm_name: ruby-ldap-0.9.16-1.el7.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/ruby-ldap-0.9.16-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/ruby-ldap-0.9.16-1.el7.x86_64.rpm
 ruby-rgen:
   :rpm_name: ruby-rgen-0.6.5-2.el7.noarch.rpm
-  :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/ruby-rgen-0.6.5-2.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/ruby-rgen-0.6.5-2.el7.noarch.rpm
 ruby-shadow:
   :rpm_name: ruby-shadow-2.2.0-2.el7.x86_64.rpm
-  :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/ruby-shadow-2.2.0-2.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/ruby-shadow-2.2.0-2.el7.x86_64.rpm
 rubygem-deep_merge:
   :rpm_name: rubygem-deep_merge-1.0.0-2.el7.noarch.rpm
-  :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-deep_merge-1.0.0-2.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/rubygem-deep_merge-1.0.0-2.el7.noarch.rpm
 rubygem-ffi:
   :rpm_name: rubygem-ffi-1.4.0-2.el7.x86_64.rpm
-  :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-ffi-1.4.0-2.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/rubygem-ffi-1.4.0-2.el7.x86_64.rpm
 rubygem-highline:
   :rpm_name: rubygem-highline-1.6.11-5.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/r/rubygem-highline-1.6.11-5.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/rubygem-highline-1.6.11-5.el7.noarch.rpm
 rubygem-net-ldap:
   :rpm_name: rubygem-net-ldap-0.16.0-1.el7.noarch.rpm
-  :source: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/r/rubygem-net-ldap-0.16.0-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/rubygem-net-ldap-0.16.0-1.el7.noarch.rpm
 rubygem-net-ldap-doc:
   :rpm_name: rubygem-net-ldap-doc-0.16.0-1.el7.noarch.rpm
-  :source: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/r/rubygem-net-ldap-doc-0.16.0-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/rubygem-net-ldap-doc-0.16.0-1.el7.noarch.rpm
 rubygem-net-ping:
   :rpm_name: rubygem-net-ping-1.6.2-1.el7.noarch.rpm
-  :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-net-ping-1.6.2-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/rubygem-net-ping-1.6.2-1.el7.noarch.rpm
 rubygem-puppet-lint:
   :rpm_name: rubygem-puppet-lint-1.1.0-1.el7.noarch.rpm
-  :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-puppet-lint-1.1.0-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/rubygem-puppet-lint-1.1.0-1.el7.noarch.rpm
 rubygem-puppetserver-parslet:
   :rpm_name: rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
 rubygem-puppetserver-toml:
   :rpm_name: rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
 rubygem-rake:
   :rpm_name: rubygem-rake-0.9.6-33.el7_4.noarch.rpm
-  :source: http://mirror.centos.org/centos/7/os/x86_64/Packages/rubygem-rake-0.9.6-33.el7_4.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/rubygem-rake-0.9.6-33.el7_4.noarch.rpm
 rubygem-rake-compiler:
   :rpm_name: rubygem-rake-compiler-0.9.3-2.el7.noarch.rpm
-  :source: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/r/rubygem-rake-compiler-0.9.3-2.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/rubygem-rake-compiler-0.9.3-2.el7.noarch.rpm
 rubygem-stomp:
   :rpm_name: rubygem-stomp-1.3.5-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/r/rubygem-stomp-1.3.5-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/rubygem-stomp-1.3.5-1.el7.noarch.rpm
 rubygem-stomp-doc:
   :rpm_name: rubygem-stomp-doc-1.3.5-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/r/rubygem-stomp-doc-1.3.5-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/rubygem-stomp-doc-1.3.5-1.el7.noarch.rpm
 simp-lastbind:
   :rpm_name: simp-lastbind-2.4.23-0.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/simp-lastbind-2.4.23-0.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/simp-lastbind-2.4.23-0.x86_64.rpm
 simp-ppolicy-check-password:
   :rpm_name: simp-ppolicy-check-password-2.4.39-0el7.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/simp-ppolicy-check-password-2.4.39-0el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/simp-ppolicy-check-password-2.4.39-0el7.x86_64.rpm
 simp-vendored-r10k:
   :rpm_name: simp-vendored-r10k-2.6.2-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-2.6.2-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/simp-vendored-r10k-2.6.2-1.noarch.rpm
 simp-vendored-r10k-doc:
   :rpm_name: simp-vendored-r10k-doc-2.6.2-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-doc-2.6.2-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/simp-vendored-r10k-doc-2.6.2-1.noarch.rpm
 simp-vendored-r10k-gem-colored:
   :rpm_name: simp-vendored-r10k-gem-colored-1.2-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-colored-1.2-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/simp-vendored-r10k-gem-colored-1.2-1.noarch.rpm
 simp-vendored-r10k-gem-cri:
   :rpm_name: simp-vendored-r10k-gem-cri-2.6.1-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-cri-2.6.1-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/simp-vendored-r10k-gem-cri-2.6.1-1.noarch.rpm
 simp-vendored-r10k-gem-faraday:
   :rpm_name: simp-vendored-r10k-gem-faraday-0.9.2-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-faraday-0.9.2-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/simp-vendored-r10k-gem-faraday-0.9.2-1.noarch.rpm
 simp-vendored-r10k-gem-faraday_middleware:
   :rpm_name: simp-vendored-r10k-gem-faraday_middleware-0.10.1-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-faraday_middleware-0.10.1-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/simp-vendored-r10k-gem-faraday_middleware-0.10.1-1.noarch.rpm
 simp-vendored-r10k-gem-fast_gettext:
   :rpm_name: simp-vendored-r10k-gem-fast_gettext-1.1.2-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-fast_gettext-1.1.2-0.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/simp-vendored-r10k-gem-fast_gettext-1.1.2-0.noarch.rpm
 simp-vendored-r10k-gem-gettext:
   :rpm_name: simp-vendored-r10k-gem-gettext-3.2.9-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-gettext-3.2.9-0.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/simp-vendored-r10k-gem-gettext-3.2.9-0.noarch.rpm
 simp-vendored-r10k-gem-gettext-setup:
   :rpm_name: simp-vendored-r10k-gem-gettext-setup-0.30-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-gettext-setup-0.30-0.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/simp-vendored-r10k-gem-gettext-setup-0.30-0.noarch.rpm
 simp-vendored-r10k-gem-locale:
   :rpm_name: simp-vendored-r10k-gem-locale-2.1.2-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-locale-2.1.2-0.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/simp-vendored-r10k-gem-locale-2.1.2-0.noarch.rpm
 simp-vendored-r10k-gem-log4r:
   :rpm_name: simp-vendored-r10k-gem-log4r-1.1.10-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-log4r-1.1.10-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/simp-vendored-r10k-gem-log4r-1.1.10-1.noarch.rpm
 simp-vendored-r10k-gem-minitar:
   :rpm_name: simp-vendored-r10k-gem-minitar-0.6.1-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-minitar-0.6.1-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/simp-vendored-r10k-gem-minitar-0.6.1-1.noarch.rpm
 simp-vendored-r10k-gem-multi_json:
   :rpm_name: simp-vendored-r10k-gem-multi_json-1.12.1-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-multi_json-1.12.1-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/simp-vendored-r10k-gem-multi_json-1.12.1-1.noarch.rpm
 simp-vendored-r10k-gem-multipart-post:
   :rpm_name: simp-vendored-r10k-gem-multipart-post-2.0.0-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-multipart-post-2.0.0-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/simp-vendored-r10k-gem-multipart-post-2.0.0-1.noarch.rpm
 simp-vendored-r10k-gem-puppet_forge:
   :rpm_name: simp-vendored-r10k-gem-puppet_forge-2.2.8-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-puppet_forge-2.2.8-0.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/simp-vendored-r10k-gem-puppet_forge-2.2.8-0.noarch.rpm
 simp-vendored-r10k-gem-r10k:
   :rpm_name: simp-vendored-r10k-gem-r10k-2.6.2-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-r10k-2.6.2-1.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/simp-vendored-r10k-gem-r10k-2.6.2-1.noarch.rpm
 simp-vendored-r10k-gem-semantic_puppet:
   :rpm_name: simp-vendored-r10k-gem-semantic_puppet-1.0.2-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-semantic_puppet-1.0.2-0.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/simp-vendored-r10k-gem-semantic_puppet-1.0.2-0.noarch.rpm
 simp-vendored-r10k-gem-text:
   :rpm_name: simp-vendored-r10k-gem-text-1.3.1-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X/packages/el/7/simp-vendored-r10k-gem-text-1.3.1-0.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/simp-vendored-r10k-gem-text-1.3.1-0.noarch.rpm
 sudosh2:
   :rpm_name: sudosh2-1.0.2-2el7.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/sudosh2-1.0.2-2el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/sudosh2-1.0.2-2el7.x86_64.rpm
 syslinux-tftpboot:
   :rpm_name: syslinux-tftpboot-4.05-13.el7.x86_64.rpm
-  :source: http://vault.centos.org/7.4.1708/os/x86_64/Packages/syslinux-tftpboot-4.05-13.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/syslinux-tftpboot-4.05-13.el7.x86_64.rpm
 tlog:
   :rpm_name: tlog-4-1.el7.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/tlog-4-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/tlog-4-1.el7.x86_64.rpm
 tpm2-abrmd:
   :rpm_name: tpm2-abrmd-1.1.0-10.el7.x86_64.rpm
-  :source: http://mirror.centos.org/centos/7/os/x86_64/Packages/tpm2-abrmd-1.1.0-10.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/tpm2-abrmd-1.1.0-10.el7.x86_64.rpm
 tpm2-tools:
   :rpm_name: tpm2-tools-3.0.4-2.el7.x86_64.rpm
-  :source: http://mirror.centos.org/centos/7/os/x86_64/Packages/tpm2-tools-3.0.4-2.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/tpm2-tools-3.0.4-2.el7.x86_64.rpm
 tpm2-tss:
   :rpm_name: tpm2-tss-1.4.0-2.el7.x86_64.rpm
-  :source: http://mirror.centos.org/centos/7/os/x86_64/Packages/tpm2-tss-1.4.0-2.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/tpm2-tss-1.4.0-2.el7.x86_64.rpm
 tpm2-tss-devel:
   :rpm_name: tpm2-tss-devel-1.4.0-2.el7.x86_64.rpm
-  :source: http://mirror.centos.org/centos/7/os/x86_64/Packages/tpm2-tss-devel-1.4.0-2.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/tpm2-tss-devel-1.4.0-2.el7.x86_64.rpm
 unique:
   :rpm_name: unique-1.1.6-10.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/u/unique-1.1.6-10.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/unique-1.1.6-10.el7.x86_64.rpm
 x2goagent:
   :rpm_name: x2goagent-4.1.0.3-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/x/x2goagent-4.1.0.3-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/x2goagent-4.1.0.3-1.el7.x86_64.rpm
 x2goclient:
   :rpm_name: x2goclient-4.1.1.1-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/x/x2goclient-4.1.1.1-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/x2goclient-4.1.1.1-1.el7.x86_64.rpm
 x2goserver:
   :rpm_name: x2goserver-4.1.0.3-1.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/x/x2goserver-4.1.0.3-1.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/x2goserver-4.1.0.3-1.el7.x86_64.rpm
 x2goserver-common:
   :rpm_name: x2goserver-common-4.1.0.3-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/x/x2goserver-common-4.1.0.3-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/x2goserver-common-4.1.0.3-1.el7.noarch.rpm
 x2goserver-xsession:
   :rpm_name: x2goserver-xsession-4.1.0.3-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/x/x2goserver-xsession-4.1.0.3-1.el7.noarch.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/x2goserver-xsession-4.1.0.3-1.el7.noarch.rpm

--- a/src/assets/simp/build/simp.spec
+++ b/src/assets/simp/build/simp.spec
@@ -1,6 +1,6 @@
 Summary: SIMP Full Install
 Name: simp
-Version: 6.3.0
+Version: 6.3.1
 Release: 0%{?dist}%{?snapshot_release}
 License: Apache License, Version 2.0
 Group: Applications/System


### PR DESCRIPTION
- Update pupmod-simp-pupmod version to 7.7.1 where generate_types is disabled by default

#SIMP-5978 #close