### PR TITLE
(SIMP-MAINT) Match SIMP release tags properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ jobs:
         - bundle exec rake spec
       before_deploy:
         - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
-        - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+        - '[[ "${TRAVIS_TAG}" =~ ^simp-${PUPMOD_METADATA_VERSION}(-.+)?$|^${PUPMOD_METADATA_VERSION}(-.+)?$ ]]'
       deploy:
         - provider: puppetforge
           user: simp


### PR DESCRIPTION
SIMP releases may have the 'release' qualifier tacked on since they may
have RPM-only updates.

In the interest of not breaking things horribly, the release regex was
modified. Newer matching releases won't overwrite upstream ones for
publication so there should be no issues in general.