### PR TITLE
(SIMP-6136) Update build files for CentOS 7.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
     beaker-docker (0.5.2)
       docker-api
       stringify-hash (~> 0.0.0)
-    beaker-hostgenerator (1.1.25)
+    beaker-hostgenerator (1.1.26)
       deep_merge (~> 1.0)
       stringify-hash (~> 0.0.0)
     beaker-pe (2.0.6)
@@ -89,7 +89,6 @@ GEM
       domain_name (~> 0.5)
     in-parallel (0.1.17)
     inifile (3.0.0)
-    jaro_winkler (1.5.2)
     json (1.8.6)
     json-schema (2.8.1)
       addressable (>= 2.4)
@@ -123,10 +122,7 @@ GEM
     parallel (1.13.0)
     parallel_tests (2.24.0)
       parallel
-    parser (2.6.0.0)
-      ast (~> 2.4.0)
     pathspec (0.2.1)
-    powerpack (0.1.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -171,7 +167,6 @@ GEM
       log4r (= 1.1.10)
       multi_json (~> 1.10)
       puppet_forge (~> 2.2.8)
-    rainbow (3.0.0)
     rake (12.3.2)
     rb-readline (0.5.5)
     require_all (1.3.3)
@@ -195,21 +190,13 @@ GEM
     rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-puppet (2.7.2)
+    rspec-puppet (2.7.3)
       rspec
     rspec-puppet-facts (0.12.0)
       facter
       json
     rspec-support (3.8.0)
     rsync (1.0.9)
-    rubocop (0.57.2)
-      jaro_winkler (~> 1.5.1)
-      parallel (~> 1.10)
-      parser (>= 2.5)
-      powerpack (~> 0.1)
-      rainbow (>= 2.2.2, < 4.0)
-      ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-ll (2.1.2)
       ansi
       ast
@@ -221,7 +208,7 @@ GEM
       rspec-its
       specinfra (~> 2.72)
     sfl (2.3)
-    simp-beaker-helpers (1.13.0)
+    simp-beaker-helpers (1.13.1)
       beaker (~> 4.0)
       beaker-docker (~> 0.3)
       beaker-puppet (~> 1.0)
@@ -231,7 +218,6 @@ GEM
       highline (~> 1.6)
       net-telnet (~> 0.1.1)
       nokogiri (~> 1.8)
-      rubocop (~> 0.57.2)
     simp-build-helpers (0.1.1)
     simp-rake-helpers (5.7.1)
       bundler (~> 1.14)
@@ -262,7 +248,6 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    unicode-display_width (1.4.1)
     yard (0.9.18)
 
 PLATFORMS

--- a/build/distributions/CentOS/6/x86_64/release_mappings.yaml
+++ b/build/distributions/CentOS/6/x86_64/release_mappings.yaml
@@ -21,6 +21,25 @@ simp_releases:
             checksum: '1e15f9202d2cdd4b2bdf9d6503a8543347f0cb8cc06ba9a0dfd2df4fdef5c727'
         build_command: 'bundle exec rake build:auto[/path/to/RedHat/DVDS,6.X]'
         os_version:   '6.10'
+  6.3.2-0:
+    flavors:
+      CentOS:
+        isos:
+          - name:     'CentOS-6.10-x86_64-bin-DVD1.iso'
+            size:     3991928832
+            checksum: 'a68e46970678d4d297d46086ae2efdd3e994322d6d862ff51dcce25a0759e41c'
+          - name:     'CentOS-6.10-x86_64-bin-DVD2.iso'
+            size:     2187548672
+            checksum: '723ca530171faf29728b8fe7bb6d05ca2ceb6ba9e09d73ed89f2c0ff693e77a5'
+        build_command: 'bundle exec rake build:auto[/path/to/CentOS-6.10/DVDs,6.X]'
+        os_version:   '6.10'
+      RedHat:
+        isos:
+          - name:     'rhel-server-6.10-x86_64-dvd.iso'
+            size:     3895459840
+            checksum: '1e15f9202d2cdd4b2bdf9d6503a8543347f0cb8cc06ba9a0dfd2df4fdef5c727'
+        build_command: 'bundle exec rake build:auto[/path/to/RedHat/DVDS,6.X]'
+        os_version:   '6.10'
   6.3.0-0:
     flavors:
       CentOS:

--- a/build/distributions/CentOS/7/x86_64/DVD/7-simp_pkglist.txt
+++ b/build/distributions/CentOS/7/x86_64/DVD/7-simp_pkglist.txt
@@ -1,5 +1,5 @@
 # A list of packages required for the clean base installation of the SIMP DVD
-# based on CentOS 1611 release.
+# based on CentOS 1810 and rhel-server-7.6 releases.
 #
 # This list is simply used to keep items in the base DVD so having extra
 # packages listed here is not a problem. Anything not listed in this file will
@@ -68,7 +68,6 @@ apr-util-devel
 args4j
 arpwatch
 at
-at-spi
 at-spi2-atk
 at-spi2-core
 atk
@@ -111,6 +110,9 @@ bitmap-fixed-fonts
 bitmap-lucida-typewriter-fonts
 bluez
 bluez-libs
+bolt
+boost-iostreams
+boost-random
 boost-regex
 boost-system
 boost-thread
@@ -125,10 +127,12 @@ ca-certificates
 cairo
 cairo-gobject
 cal10n
+# caribou* only in rhel-server distribution ISO
 caribou
 caribou-gtk2-module
 caribou-gtk3-module
 cdparanoia-libs
+# centos-* only in CentOS distribution ISO
 centos-bookmarks
 centos-indexhtml
 centos-logos
@@ -149,6 +153,7 @@ color-filesystem
 colord
 colord-gtk
 colord-libs
+compat-libical1
 compat-libcogl-pango12
 compat-libcogl12
 compat-libcolord1
@@ -158,6 +163,7 @@ control-center-filesystem
 coolkey
 copy-jdk-configs
 coreutils
+# corosync* only in CentOS distribution ISO
 corosync
 corosynclib
 cpio
@@ -246,10 +252,10 @@ enchant
 espeak
 ethtool
 evolution-data-server
+evolution-data-server-langpacks
 exempi
 expat
 expat-devel
-fence-agents
 fence-virt
 festival
 festival-freebsoft-utils
@@ -266,11 +272,12 @@ firefox
 firewalld
 firewalld-filesystem
 flac-libs
+flatpak
+flatpak-libs
 flite
 fltk
 fontawesome-fonts
 fontconfig
-fontconfig-devel
 fontpackages-filesystem
 foomatic
 foomatic-db
@@ -281,6 +288,7 @@ fprintd
 fprintd-pam
 freetype
 freetype-devel
+fribidi
 fuse
 fuse-libs
 fxload
@@ -350,6 +358,7 @@ gnutls
 gnutls-dane
 gnutls-utils
 gobject-introspection
+google-noto-emoji-color-fonts
 gperftools-libs
 gpgme
 gpm
@@ -409,9 +418,15 @@ hunspell
 hunspell-en-US
 hwdata
 hyphen
+ibus
+ibus-gtk2
+ibus-gtk3
 ibus-libs
+ibus-setup
 im-chooser
 im-chooser-common
+# ima-evm-utils only in rhel-server distribution ISO
+ima-evm-utils
 imsettings
 imsettings-gsettings
 imsettings-libs
@@ -544,7 +559,6 @@ libXfixes-devel
 libXfont
 libXfont2
 libXft
-libXft-devel
 libXi
 libXi-devel
 libXinerama
@@ -569,6 +583,7 @@ libXxf86vm-devel
 libacl
 libaio
 libao
+libappstream-glib
 libarchive
 libart_lgpl
 libassuan
@@ -629,11 +644,16 @@ libfastjson
 libffi
 libfontenc
 libfprint
+libgcab1
 libgcc
 libgcrypt
 libgdata
 libgee
 libglade2
+libglvnd
+libglvnd-egl
+libglvnd-gles
+libglvnd-glx
 libgnome
 libgnome-keyring
 libgnomecanvas
@@ -718,6 +738,7 @@ libsemanage-python
 libsepol
 libsepol-devel
 libshout
+libsmartcols
 libsmbclient
 libsndfile
 libsoup
@@ -759,6 +780,7 @@ libva
 libverto
 libverto-devel
 libverto-tevent
+libvirt-bash-completion
 libvirt-client
 libvirt-libs
 libvisual
@@ -768,6 +790,7 @@ libwacom
 libwacom-data
 libwayland-client
 libwayland-cursor
+libwayland-egl
 libwayland-server
 libwbclient
 libwebp
@@ -822,7 +845,6 @@ mesa-libGLES
 mesa-libGLU
 mesa-libgbm
 mesa-libglapi
-mesa-libwayland-egl
 mesa-libxatracker
 mesa-private-llvm
 metacity
@@ -839,6 +861,7 @@ mokutil
 mozilla-filesystem
 mozjs17
 mozjs24
+mozjs52
 mpfr
 msv-msv
 msv-xsdlib
@@ -1071,6 +1094,7 @@ php-common
 php-gd
 php-xml
 pinentry
+pinentry-gtk
 pinfo
 pixman
 pkgconfig
@@ -1113,7 +1137,6 @@ pulseaudio-libs
 pulseaudio-libs-glib2
 pulseaudio-module-bluetooth
 pyOpenSSL
-pyatspi
 pycairo
 pygobject2
 pygpgme
@@ -1170,6 +1193,7 @@ python-pycurl
 python-pyudev
 python-qrcode-core
 python-requests
+# python-rhsm* only in rhel-server distribution ISO
 python-rhsm
 python-rhsm-certificates
 python-schedutils
@@ -1186,14 +1210,17 @@ python-tevent
 python-urlgrabber
 python-urllib3
 python-yubico
+# python2-caribou only in rhel-server distribution ISO
 python2-caribou
 python2-cryptography
+python2-futures
 python2-ipaclient
 python2-ipalib
 python2-ipaserver
 python2-oauthlib
 python2-pyasn1
 python2-pyasn1-modules
+python2-pyatspi
 pyusb
 pyxattr
 qdox
@@ -1212,6 +1239,7 @@ rdma-core
 readline
 realmd
 recode
+# redhat-indexhtml + redhat-logos only in rhel-server distribution ISO
 redhat-indexhtml
 redhat-logos
 redhat-lsb
@@ -1223,10 +1251,12 @@ redhat-lsb-printing
 redhat-lsb-submod-multimedia
 redhat-lsb-submod-security
 redhat-menus
+# redhat-release-server only in rhel-server distribution ISO
 redhat-release-server
 redhat-rpm-config
 regexp
 relaxngDatatype
+# resource-agents only in CentOS distribution ISO
 resource-agents
 rest
 resteasy-base-atom-provider
@@ -1331,6 +1361,7 @@ svrcore
 symlinks
 sysfsutils
 syslinux
+syslinux-tftpboot
 sysstat
 system-config-firewall-base
 systemd
@@ -1373,6 +1404,11 @@ tomcat-servlet-3.0-api
 tomcatjss
 totem-pl-parser
 tpm-tools
+# tpm2-* only in rhel-server distribution ISO
+tpm2-abrmd
+tpm2-tools
+tpm2-tss
+tpm2-tss-devel
 tracker
 tree
 trousers
@@ -1426,6 +1462,8 @@ xcb-util-image
 xcb-util-keysyms
 xcb-util-renderutil
 xcb-util-wm
+xdg-desktop-portal
+xdg-desktop-portal-gtk
 xdg-user-dirs
 xdg-user-dirs-gtk
 xdg-utils
@@ -1490,12 +1528,12 @@ yum
 yum-metadata-parser
 yum-plugin-aliases
 yum-plugin-changelog
+# yum-plugin-fastestmirro only in CentOS distribution ISO
 yum-plugin-fastestmirror
 yum-plugin-tmprepo
 yum-plugin-verify
 yum-plugin-versionlock
 yum-utils
-zd1211-firmware
 zenity
 zip
 zlib

--- a/build/distributions/CentOS/7/x86_64/release_mappings.yaml
+++ b/build/distributions/CentOS/7/x86_64/release_mappings.yaml
@@ -6,6 +6,23 @@ simp_releases:
     flavors:
       CentOS:
         isos:
+          - name:     'CentOS-7-x86_64-DVD-1810.iso'
+            size:     4588568576
+            checksum: '6d44331cc4f6c506c7bbe9feb8468fad6c51a88ca1393ca6b8b486ea04bec3c1'
+        build_command: 'bundle exec rake build:auto[CentOS-7-x86_64-DVD-1810.iso,6.X]'
+        os_version:   '7.0'
+      RedHat:
+        isos:
+          - name:     'rhel-server-7.6-x86_64-dvd.iso'
+            size:     4497342464
+            checksum: '60a0be5aeed1f08f2bb7599a578c89ec134b4016cd62a8604b29f15d543a469c'
+        build_command: 'bundle exec rake build:auto[rhel-server-7.6-x86_64-dvd.iso,6.X]'
+        os_version:   '7.6'
+
+  6.3.2:
+    flavors:
+      CentOS:
+        isos:
           - name:     'CentOS-7-x86_64-DVD-1804.iso'
             size:     4470079488
             checksum: '506e4e06abf778c3435b4e5745df13e79ebfc86565d7ea1e128067ef6b5a6345'

--- a/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
@@ -1,7 +1,7 @@
 ---
 apr-util-ldap:
   :rpm_name: apr-util-ldap-1.5.2-6.el7.x86_64.rpm
-  :source: http://vault.centos.org/7.4.1708/os/x86_64/Packages/apr-util-ldap-1.5.2-6.el7.x86_64.rpm
+  :source: http://mirror.centos.org/centos/7/os/x86_64/Packages/apr-util-ldap-1.5.2-6.el7.x86_64.rpm
 caja:
   :rpm_name: caja-1.16.6-1.el7.x86_64.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/c/caja-1.16.6-1.el7.x86_64.rpm
@@ -67,7 +67,7 @@ haveged:
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/h/haveged-1.9.1-1.el7.x86_64.rpm
 ima-evm-utils:
   :rpm_name: ima-evm-utils-1.1-2.el7.x86_64.rpm
-  :source: http://repo1.ash.innoscale.net/centos/7.5.1804/os/x86_64/Packages/ima-evm-utils-1.1-2.el7.x86_64.rpm
+  :source: http://mirror.centos.org/centos/7/os/x86_64/Packages/ima-evm-utils-1.1-2.el7.x86_64.rpm
 incron:
   :rpm_name: incron-0.5.10-8.el7.x86_64.rpm
   :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/incron-0.5.10-8.el7.x86_64.rpm
@@ -82,7 +82,7 @@ libXcompshad:
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/l/libXcompshad-3.5.99.17-1.el7.x86_64.rpm
 libarchive-devel:
   :rpm_name: libarchive-devel-3.1.2-10.el7_2.x86_64.rpm
-  :source: http://mirror.steadfast.net/centos/7.4.1708/os/x86_64/Packages/libarchive-devel-3.1.2-10.el7_2.x86_64.rpm
+  :source: http://mirror.centos.org/centos/7/os/x86_64/Packages/libarchive-devel-3.1.2-10.el7_2.x86_64.rpm
 libconfuse:
   :rpm_name: libconfuse-2.7-7.el7.x86_64.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/l/libconfuse-2.7-7.el7.x86_64.rpm
@@ -111,8 +111,8 @@ lyx-fonts:
   :rpm_name: lyx-fonts-2.2.3-1.el7.noarch.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/l/lyx-fonts-2.2.3-1.el7.noarch.rpm
 marco:
-  :rpm_name: marco-1.16.1-3.el7.x86_64.rpm
-  :source: https://download.simp-project.com/SIMP/archive/yum/6.X/EL7/dependencies/x86_64/marco-1.16.1-3.el7.x86_64.rpm
+  :rpm_name: marco-1.16.1-4.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/marco-1.16.1-4.el7.x86_64.rpm
 mate-control-center:
   :rpm_name: mate-control-center-1.16.1-1.el7.x86_64.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/mate-control-center-1.16.1-1.el7.x86_64.rpm
@@ -205,31 +205,31 @@ perl-File-BaseDir:
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/perl-File-BaseDir-0.03-14.el7.noarch.rpm
 perl-File-Which:
   :rpm_name: perl-File-Which-1.09-12.el7.noarch.rpm
-  :source: http://mirror.centos.org/centos/7.5.1804/os/x86_64/Packages/perl-File-Which-1.09-12.el7.noarch.rpm
+  :source: http://mirror.centos.org/centos/7/os/x86_64/Packages/perl-File-Which-1.09-12.el7.noarch.rpm
 perl-Switch:
   :rpm_name: perl-Switch-2.16-7.el7.noarch.rpm
-  :source: http://mirror.centos.org/centos/7.5.1804/os/x86_64/Packages/perl-Switch-2.16-7.el7.noarch.rpm
-perl-X2go-Log:
+  :source: http://mirror.centos.org/centos/7/os/x86_64/Packages/perl-Switch-2.16-7.el7.noarch.rpm
+perl-X2Go-Log:
   :rpm_name: perl-X2Go-Log-4.1.0.3-1.el7.noarch.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/perl-X2Go-Log-4.1.0.3-1.el7.noarch.rpm
-perl-X2go-Server:
+perl-X2Go-Server:
   :rpm_name: perl-X2Go-Server-4.1.0.3-1.el7.noarch.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/perl-X2Go-Server-4.1.0.3-1.el7.noarch.rpm
-perl-X2go-Server-DB:
+perl-X2Go-Server-DB:
   :rpm_name: perl-X2Go-Server-DB-4.1.0.3-1.el7.x86_64.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/perl-X2Go-Server-DB-4.1.0.3-1.el7.x86_64.rpm
 postgresql96:
-  :rpm_name: postgresql96-9.6.11-1PGDG.rhel7.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-9.6.11-1PGDG.rhel7.x86_64.rpm
+  :rpm_name: postgresql96-9.6.12-1PGDG.rhel7.x86_64.rpm
+  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-9.6.12-1PGDG.rhel7.x86_64.rpm
 postgresql96-contrib:
-  :rpm_name: postgresql96-contrib-9.6.11-1PGDG.rhel7.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-contrib-9.6.11-1PGDG.rhel7.x86_64.rpm
+  :rpm_name: postgresql96-contrib-9.6.12-1PGDG.rhel7.x86_64.rpm
+  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-contrib-9.6.12-1PGDG.rhel7.x86_64.rpm
 postgresql96-libs:
-  :rpm_name: postgresql96-libs-9.6.11-1PGDG.rhel7.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-libs-9.6.11-1PGDG.rhel7.x86_64.rpm
+  :rpm_name: postgresql96-libs-9.6.12-1PGDG.rhel7.x86_64.rpm
+  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-libs-9.6.12-1PGDG.rhel7.x86_64.rpm
 postgresql96-server:
-  :rpm_name: postgresql96-server-9.6.11-1PGDG.rhel7.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-server-9.6.11-1PGDG.rhel7.x86_64.rpm
+  :rpm_name: postgresql96-server-9.6.12-1PGDG.rhel7.x86_64.rpm
+  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-server-9.6.12-1PGDG.rhel7.x86_64.rpm
 pssh:
   :rpm_name: pssh-2.3.1.SIMP-5.el7.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pssh-2.3.1.SIMP-5.el7.noarch.rpm
@@ -257,9 +257,6 @@ pwgen:
 python-linecache2:
   :rpm_name: python-linecache2-1.0.0-1.el7.noarch.rpm
   :source: https://lug.mtu.edu/epel/7/x86_64/Packages/p/python-linecache2-1.0.0-1.el7.noarch.rpm
-python-redis:
-  :rpm_name: python-redis-2.10.3-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/python-redis-2.10.3-1.el7.noarch.rpm
 python-simplejson:
   :rpm_name: python-simplejson-3.3.3-1.el7.x86_64.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/python-simplejson-3.3.3-1.el7.x86_64.rpm
@@ -314,12 +311,6 @@ rubygem-rake:
 rubygem-rake-compiler:
   :rpm_name: rubygem-rake-compiler-0.9.3-2.el7.noarch.rpm
   :source: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/r/rubygem-rake-compiler-0.9.3-2.el7.noarch.rpm
-rubygem-stomp:
-  :rpm_name: rubygem-stomp-1.3.5-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/r/rubygem-stomp-1.3.5-1.el7.noarch.rpm
-rubygem-stomp-doc:
-  :rpm_name: rubygem-stomp-doc-1.3.5-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/r/rubygem-stomp-doc-1.3.5-1.el7.noarch.rpm
 simp-lastbind:
   :rpm_name: simp-lastbind-2.4.23-0.x86_64.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/simp-lastbind-2.4.23-0.x86_64.rpm
@@ -383,9 +374,6 @@ simp-vendored-r10k-gem-text:
 sudosh2:
   :rpm_name: sudosh2-1.0.2-2el7.x86_64.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/sudosh2-1.0.2-2el7.x86_64.rpm
-syslinux-tftpboot:
-  :rpm_name: syslinux-tftpboot-4.05-13.el7.x86_64.rpm
-  :source: http://vault.centos.org/7.4.1708/os/x86_64/Packages/syslinux-tftpboot-4.05-13.el7.x86_64.rpm
 tlog:
   :rpm_name: tlog-4-1.el7.x86_64.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/tlog-4-1.el7.x86_64.rpm

--- a/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
@@ -65,12 +65,9 @@ gweb:
 haveged:
   :rpm_name: haveged-1.9.1-1.el7.x86_64.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/h/haveged-1.9.1-1.el7.x86_64.rpm
-ima-evm-utils:
-  :rpm_name: ima-evm-utils-1.1-2.el7.x86_64.rpm
-  :source: Red Hat Optional Repository
 incron:
   :rpm_name: incron-0.5.10-8.el7.x86_64.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/i/incron-0.5.10-8.el7.x86_64.rpm
+  :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/incron-0.5.10-8.el7.x86_64.rpm
 libNX_X11:
   :rpm_name: libNX_X11-3.5.99.17-1.el7.x86_64.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/l/libNX_X11-3.5.99.17-1.el7.x86_64.rpm
@@ -111,8 +108,8 @@ lyx-fonts:
   :rpm_name: lyx-fonts-2.2.3-1.el7.noarch.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/l/lyx-fonts-2.2.3-1.el7.noarch.rpm
 marco:
-  :rpm_name: marco-1.16.1-3.el7.x86_64.rpm
-  :source: https://download.simp-project.com/SIMP/archive/yum/6.X/EL7/dependencies/x86_64/marco-1.16.1-3.el7.x86_64.rpm
+  :rpm_name: marco-1.16.1-4.el7.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/marco-1.16.1-4.el7.x86_64.rpm
 mate-control-center:
   :rpm_name: mate-control-center-1.16.1-1.el7.x86_64.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/m/mate-control-center-1.16.1-1.el7.x86_64.rpm
@@ -209,27 +206,27 @@ perl-File-Which:
 perl-Switch:
   :rpm_name: perl-Switch-2.16-7.el7.noarch.rpm
   :source: Red Hat Optional Repository
-perl-X2go-Log:
+perl-X2Go-Log:
   :rpm_name: perl-X2Go-Log-4.1.0.3-1.el7.noarch.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/perl-X2Go-Log-4.1.0.3-1.el7.noarch.rpm
-perl-X2go-Server:
+perl-X2Go-Server:
   :rpm_name: perl-X2Go-Server-4.1.0.3-1.el7.noarch.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/perl-X2Go-Server-4.1.0.3-1.el7.noarch.rpm
-perl-X2go-Server-DB:
+perl-X2Go-Server-DB:
   :rpm_name: perl-X2Go-Server-DB-4.1.0.3-1.el7.x86_64.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/perl-X2Go-Server-DB-4.1.0.3-1.el7.x86_64.rpm
 postgresql96:
-  :rpm_name: postgresql96-9.6.11-1PGDG.rhel7.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-9.6.11-1PGDG.rhel7.x86_64.rpm
+  :rpm_name: postgresql96-9.6.12-1PGDG.rhel7.x86_64.rpm
+  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-9.6.12-1PGDG.rhel7.x86_64.rpm
 postgresql96-contrib:
-  :rpm_name: postgresql96-contrib-9.6.11-1PGDG.rhel7.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-contrib-9.6.11-1PGDG.rhel7.x86_64.rpm
+  :rpm_name: postgresql96-contrib-9.6.12-1PGDG.rhel7.x86_64.rpm
+  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-contrib-9.6.12-1PGDG.rhel7.x86_64.rpm
 postgresql96-libs:
-  :rpm_name: postgresql96-libs-9.6.11-1PGDG.rhel7.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-libs-9.6.11-1PGDG.rhel7.x86_64.rpm
+  :rpm_name: postgresql96-libs-9.6.12-1PGDG.rhel7.x86_64.rpm
+  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-libs-9.6.12-1PGDG.rhel7.x86_64.rpm
 postgresql96-server:
-  :rpm_name: postgresql96-server-9.6.11-1PGDG.rhel7.x86_64.rpm
-  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-server-9.6.11-1PGDG.rhel7.x86_64.rpm
+  :rpm_name: postgresql96-server-9.6.12-1PGDG.rhel7.x86_64.rpm
+  :source: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-server-9.6.12-1PGDG.rhel7.x86_64.rpm
 pssh:
   :rpm_name: pssh-2.3.1.SIMP-5.el7.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/pssh-2.3.1.SIMP-5.el7.noarch.rpm
@@ -257,9 +254,6 @@ pwgen:
 python-linecache2:
   :rpm_name: python-linecache2-1.0.0-1.el7.noarch.rpm
   :source: https://lug.mtu.edu/epel/7/x86_64/Packages/p/python-linecache2-1.0.0-1.el7.noarch.rpm
-python-redis:
-  :rpm_name: python-redis-2.10.3-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/python-redis-2.10.3-1.el7.noarch.rpm
 python-simplejson:
   :rpm_name: python-simplejson-3.3.3-1.el7.x86_64.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/python-simplejson-3.3.3-1.el7.x86_64.rpm
@@ -290,12 +284,6 @@ rubygem-ffi:
 rubygem-highline:
   :rpm_name: rubygem-highline-1.6.11-5.el7.noarch.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/r/rubygem-highline-1.6.11-5.el7.noarch.rpm
-rubygem-puppetserver-parslet:
-  :rpm_name: rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
-rubygem-puppetserver-toml:
-  :rpm_name: rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
 rubygem-net-ldap:
   :rpm_name: rubygem-net-ldap-0.16.0-1.el7.noarch.rpm
   :source: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/r/rubygem-net-ldap-0.16.0-1.el7.noarch.rpm
@@ -308,18 +296,18 @@ rubygem-net-ping:
 rubygem-puppet-lint:
   :rpm_name: rubygem-puppet-lint-1.1.0-1.el7.noarch.rpm
   :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-puppet-lint-1.1.0-1.el7.noarch.rpm
+rubygem-puppetserver-parslet:
+  :rpm_name: rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
+rubygem-puppetserver-toml:
+  :rpm_name: rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
 rubygem-rake:
   :rpm_name: rubygem-rake-0.9.6-33.el7_4.noarch.rpm
   :source: Red Hat Optional Repository
 rubygem-rake-compiler:
   :rpm_name: rubygem-rake-compiler-0.9.3-2.el7.noarch.rpm
   :source: https://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/r/rubygem-rake-compiler-0.9.3-2.el7.noarch.rpm
-rubygem-stomp:
-  :rpm_name: rubygem-stomp-1.3.5-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/r/rubygem-stomp-1.3.5-1.el7.noarch.rpm
-rubygem-stomp-doc:
-  :rpm_name: rubygem-stomp-doc-1.3.5-1.el7.noarch.rpm
-  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/r/rubygem-stomp-doc-1.3.5-1.el7.noarch.rpm
 simp-lastbind:
   :rpm_name: simp-lastbind-2.4.23-0.x86_64.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/simp-lastbind-2.4.23-0.x86_64.rpm
@@ -383,24 +371,9 @@ simp-vendored-r10k-gem-text:
 sudosh2:
   :rpm_name: sudosh2-1.0.2-2el7.x86_64.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/sudosh2-1.0.2-2el7.x86_64.rpm
-syslinux-tftpboot:
-  :rpm_name: syslinux-tftpboot-4.05-13.el7.x86_64.rpm
-  :source: Red Hat Optional Repository
 tlog:
   :rpm_name: tlog-4-1.el7.x86_64.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/tlog-4-1.el7.x86_64.rpm
-tpm2-abrmd:
-  :rpm_name: tpm2-abrmd-1.1.0-10.el7.x86_64.rpm
-  :source: Red Hat Optional Repository
-tpm2-tools:
-  :rpm_name: tpm2-tools-3.0.4-2.el7.x86_64.rpm
-  :source: Red Hat Optional Repository
-tpm2-tss:
-  :rpm_name: tpm2-tss-1.4.0-2.el7.x86_64.rpm
-  :source: Red Hat Optional Repository
-tpm2-tss-devel:
-  :rpm_name: tpm2-tss-devel-1.4.0-2.el7.x86_64.rpm
-  :source: Red Hat Optional Repository
 unique:
   :rpm_name: unique-1.1.6-10.el7.x86_64.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/u/unique-1.1.6-10.el7.x86_64.rpm


### PR DESCRIPTION
Updated build files for CentOS/RHEL 7.6

- Updated release mappings with new distribution ISO info
- Updated packages.yaml
  - Removed packages that are available in the distribution ISOs
    - Available in CentOS-7-x86_64-DVD-1810.iso
      - syslinux-tftpboot
    - Available in rhel-server-7.6-x86_64-dvd.iso
      - ima-evm-utils
      - syslinux-tftpboot
      - tpm2-abrmd
      - tpm2-tools
      - tpm2-tss
      - tpm2-tss-devel
  - Fixed URLs
  - Removed packages that could no longer be found in EPEL
    and that were not required for repo closure
    - python-redis
    - rubygem-stomp, rubygem-stomp-doc
  - Bumped up the marco RPM version from 1.16.1-3 to 1.16.1-4
  - Bumped up the postgresql96* RPM versions from 9.6.11-1 to
    9.6.12-1
- Updated 7-simp_pkglist.txt
  - Added packages to satisfy repo closure
  - Removed packages that do not exist in either of the
    distribution ISOs
  - Removed a few 'devel' packages not required for repo closure

SIMP-6136 #close