### PR TITLE
(SIMP-6216) Update to puppetlabs-mysql 8.0.0

### DIFF
--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -151,7 +151,7 @@ mod 'puppetlabs-mount_providers',
 
 mod 'puppetlabs-mysql',
   :git => 'https://github.com/simp/puppetlabs-mysql',
-  :tag => '5.3.0'
+  :tag => '8.0.0'
 
 mod 'puppetlabs-postgresql',
   :git => 'https://github.com/simp/puppetlabs-postgresql',


### PR DESCRIPTION
This update is to the Puppetfile.tracking, only.  I explicitly
did **not** update the minimum version in the simp-extras package,
because this module is not used by any SIMP modules, this change
represents is a large version bump (5.3.0 to 8.0.0) and end users
may not be ready to deal with 3 version bumps (i.e., potentially
3 sets of breaking changes).

SIMP-6216 #close