### PR TITLE
(SIMP-4373) Update to v3.1.1 yum module

### DIFF
--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -54,14 +54,6 @@ mod 'cristifalcas-journald',
   :git => 'https://github.com/simp/pupmod-simp-journald.git',
   :tag => '0.6.0'
 
-mod 'elastic-elasticsearch',
-  :git => 'https://github.com/simp/puppet-elasticsearch',
-  :tag => '5.5.0'
-
-mod 'elastic-logstash',
-  :git => 'https://github.com/simp/puppet-logstash',
-  :tag => '5.3.0'
-
 mod 'herculesteam-augeasproviders_apache',
   :git => 'https://github.com/simp/augeasproviders_apache',
   :tag => '3.1.1'
@@ -109,10 +101,6 @@ mod 'herculesteam-augeasproviders_sysctl',
 mod 'onyxpoint-gpasswd',
   :git => 'https://github.com/simp/puppet-gpasswd',
   :tag => '1.0.6'
-
-mod 'puppet-grafana',
-  :git => 'https://github.com/simp/puppet-grafana.git',
-  :tag => 'v4.1.1'
 
 mod 'puppetlabs-apache',
   :git => 'https://github.com/simp/puppetlabs-apache',
@@ -182,19 +170,6 @@ mod 'puppetlabs-translate',
 mod 'razorsedge-snmp',
   :git => 'https://github.com/simp/puppet-snmp',
   :tag => '3.9.0'
-
-mod 'richardc-datacat',
-  # FIXME Next datacat release.
-  # This is a bit messy.  This project has 3 tags that are
-  # all version 0.6.2, but slightly different:
-  #   '0.6.2 from the owner
-  #   'simp-0.6.2' from SIMP team for SIMP4/SIMP5
-  #   'simp6.0.0-0.6.2' from SIMP team for SIMP6
-  # We are going to use the last SIMP team release, until
-  # datacat gets updated and we can get out
-  # of this mess.
-  :git => 'https://github.com/simp/puppet-datacat',
-  :tag => 'simp6.0.0-0.6.2'
 
 mod 'saz-locales',
   :git => 'https://github.com/simp/pupmod-saz-locales',
@@ -353,7 +328,7 @@ mod 'simp-postfix',
 
 mod 'simp-pupmod',
   :git => 'https://github.com/simp/pupmod-simp-pupmod',
-  :tag => '7.8.0'
+  :branch => 'master'
 
 mod 'simp-resolv',
   :git => 'https://github.com/simp/pupmod-simp-resolv',
@@ -395,10 +370,6 @@ mod 'simp-simp_docker',
   :git => 'https://github.com/simp/pupmod-simp-simp_docker',
   :tag => '0.2.0'
 
-mod 'simp-simp_elasticsearch',
-  :git => 'https://github.com/simp/pupmod-simp-simp_elasticsearch',
-  :tag => '5.0.5'
-
 #FIXME Does not support Puppet 5 yet.  Also, needs to be tested with
 # Vox Pupuli puppet/gitlab 2.0.0, which does support Puppet 5.
 # puppet/gitlab is the new name for vshn/gitlab.  When Vox Pupuli
@@ -406,10 +377,6 @@ mod 'simp-simp_elasticsearch',
 mod 'simp-simp_gitlab',
   :git => 'https://github.com/simp/pupmod-simp-simp_gitlab',
   :tag => '0.3.4'
-
-mod 'simp-simp_grafana',
-  :git => 'https://github.com/simp/pupmod-simp-simp_grafana',
-  :tag => '1.0.6'
 
 mod 'simp-simp_ipa',
   :git => 'https://github.com/simp/pupmod-simp-simp_ipa',
@@ -421,10 +388,6 @@ mod 'simp-simp_ipa',
 # # FUTURE:  Release and add to simp.spec, to ensure packaged in ISO
 #   :git => 'https://github.com/simp/pupmod-simp-simp_kubernetes',
 #   :branch => 'master'
-
-mod 'simp-simp_logstash',
-  :git => 'https://github.com/simp/pupmod-simp-simp_logstash',
-  :tag => '5.0.2'
 
 mod 'simp-simp_nfs',
   :git => 'https://github.com/simp/pupmod-simp-simp_nfs',
@@ -505,7 +468,7 @@ mod 'simp-tlog',
 
 mod 'simp-tpm',
   :git => 'https://github.com/simp/pupmod-simp-tpm',
-  :tag => '3.1.0'
+  :branch => 'master'
 
 mod 'simp-tpm2',
   :git => 'https://github.com/simp/pupmod-simp-tpm2',
@@ -560,7 +523,7 @@ mod 'voxpupuli-posix_acl',
 
 mod 'voxpupuli-yum',
   :git => 'https://github.com/simp/voxpupuli-yum',
-  :tag => 'v2.2.1'
+  :tag => 'v3.1.1'
 
 #FIXME vshn/gitlab does not support Puppet 5, However, puppet/gitlab
 # 2.0.0 does.  puppet/gitlab is the new name for vshn/gitlab.  When

--- a/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
@@ -251,12 +251,6 @@ rubygem-net-ldap-doc:
 rubygem-net-ping:
   :rpm_name: rubygem-net-ping-1.6.2-1.el6.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-net-ping-1.6.2-1.el6.noarch.rpm
-rubygem-puppetserver-parslet:
-  :rpm_name: rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
-rubygem-puppetserver-toml:
-  :rpm_name: rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
 rubygem-rake-compiler:
   :rpm_name: rubygem-rake-compiler-0.9.3-2.el6.noarch.rpm
   :source: http://http://yum.puppetlabs.com/el/6/dependencies/x86_64/rubygem-rake-compiler-0.9.3-2.el6.noarch.rpm

--- a/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
@@ -299,12 +299,6 @@ rubygem-net-ping:
 rubygem-puppet-lint:
   :rpm_name: rubygem-puppet-lint-1.1.0-1.el7.noarch.rpm
   :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-puppet-lint-1.1.0-1.el7.noarch.rpm
-rubygem-puppetserver-parslet:
-  :rpm_name: rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
-rubygem-puppetserver-toml:
-  :rpm_name: rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
 rubygem-rake:
   :rpm_name: rubygem-rake-0.9.6-33.el7_4.noarch.rpm
   :source: http://mirror.centos.org/centos/7/os/x86_64/Packages/rubygem-rake-0.9.6-33.el7_4.noarch.rpm

--- a/build/distributions/RedHat/6/x86_64/yum_data/packages.yaml
+++ b/build/distributions/RedHat/6/x86_64/yum_data/packages.yaml
@@ -242,12 +242,6 @@ rubygem-ffi:
 rubygem-highline:
   :rpm_name: rubygem-highline-1.6.11-1.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-highline-1.6.11-1.noarch.rpm
-rubygem-puppetserver-parslet:
-  :rpm_name: rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
-rubygem-puppetserver-toml:
-  :rpm_name: rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
 rubygem-net-ldap:
   :rpm_name: rubygem-net-ldap-0.6.1-2.el6.1.noarch.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/6/rubygem-net-ldap-0.6.1-2.el6.1.noarch.rpm

--- a/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
@@ -296,12 +296,6 @@ rubygem-net-ping:
 rubygem-puppet-lint:
   :rpm_name: rubygem-puppet-lint-1.1.0-1.el7.noarch.rpm
   :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/rubygem-puppet-lint-1.1.0-1.el7.noarch.rpm
-rubygem-puppetserver-parslet:
-  :rpm_name: rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-parslet-1.8.2-0.noarch.rpm
-rubygem-puppetserver-toml:
-  :rpm_name: rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/rubygem-puppetserver-toml-0.2.0-1.noarch.rpm
 rubygem-rake:
   :rpm_name: rubygem-rake-0.9.6-33.el7_4.noarch.rpm
   :source: Red Hat Optional Repository

--- a/build/rpm/dependencies.yaml
+++ b/build/rpm/dependencies.yaml
@@ -57,58 +57,16 @@
 # (4) This file is only used for simp-rake-helpers >= 5.3.0
 ---
 
-# This entry can be removed when the augeasproviders_nagios version
-# used advances beyond 2.0.2.
-'augeasproviders_nagios':
-  :release: '2016'
-
 'docker':
   :requires:
     # exclude pupmod-puppetlabs-apt
     - 'pupmod-puppetlabs-stdlib'
     - 'pupmod-puppetlabs-translate'
 
-# Make sure we create an RPM that fixes the obsoletes problem of
-# pupmod-elastic-elasticsearch-5.2.0-0 packaged for SIMP 6.1.0.
-# Since we are releasing a newer version, 5.4.0-0, we can fix
-# the problem by using the same obsoletes, here, but a newer
-# version of simp-rake-helpers.
-'elasticsearch':
-  :obsoletes:
-    'pupmod-elasticsearch-elasticsearch': '0.11.0-2016.1'
-  :requires:
-    # exclude pupmod-puppetlabs-apt
-    - 'pupmod-richardc-datacat'
-    - 'pupmod-puppetlabs-java'
-    - 'pupmod-puppetlabs-stdlib'
-    - 'pupmod-puppet-yum'
-
 'gitlab':
   :requires:
     # exclude pupmod-puppetlabs-apt
     - 'pupmod-puppetlabs-stdlib'
-
-# THree adjustments required for the next 4.1.1 release:
-# (1) (NEW) Up the release qualifier to '3', since 4.1.1-1 was already
-#     released and the change from 4.1.1-2 to 4.1.1-3 is simply a
-#     packaging change, (i.e., rubygem-puppetserver-toml dependency
-#     version change).
-# (2) As with 4.1.1-0 and 4.1.1-1, make sure we create an RPM that fixes
-#     the obsoletes problem of pupmod-puppet-grafana-3.0.0-0
-#     packaged for SIMP 6.1.0.
-# (3) Exclude the problematic puppet-archive module dependency.
-#
-'grafana':
-  :release: '3'
-  :obsoletes:
-    'pupmod-bfraser-grafana': '2.5.0-2016.1'
-  :requires:
-    # Exclude the problematic puppet-archive module.
-    # ('puppet generate types' fails with puppet-archive).
-    - 'pupmod-puppetlabs-stdlib'
-  :external_dependencies:
-    'rubygem-puppetserver-toml':
-      :min: '0.2.0-1'
 
 'java':
   :requires:
@@ -116,23 +74,9 @@
     # ('puppet generate types' fails with puppet-archive).
     - 'pupmod-puppetlabs-stdlib'
 
-# Make sure we create an RPM that fixes the obsoletes problem of
-# pupmod-elastic-logstash-5.2.1-0 packaged for SIMP 6.1.0.
-# Since we are releasing a newer version, 5.3.0-0, we can fix
-# the problem by using the same obsoletes, here, but a newer
-# version of simp-rake-helpers.
-'logstash':
-  :obsoletes:
-    'pupmod-elasticsearch-logstash': '2.0.0-2016'
-
 'motd':
   :requires:
     # exclude pupmod-puppetlabs-registry
-    - 'pupmod-puppetlabs-stdlib'
-
-'mysql':
-  :requires:
-    # exclude pupmod-puppet-staging
     - 'pupmod-puppetlabs-stdlib'
     - 'pupmod-puppetlabs-translate'
 

--- a/metadata.json
+++ b/metadata.json
@@ -64,7 +64,7 @@
     },
     {
       "name": "puppet/yum",
-      "version_requirement": ">= 2.2.1 < 3.0.0"
+      "version_requirement": ">= 3.1.1 < 4.0.0"
     },
     {
       "name": "puppetlabs/apache",

--- a/src/assets/simp/build/simp.spec
+++ b/src/assets/simp/build/simp.spec
@@ -33,7 +33,7 @@ Requires: pupmod-herculesteam-augeasproviders_shellvar >= 3.1.0, pupmod-hercules
 Requires: pupmod-herculesteam-augeasproviders_ssh >= 3.2.1, pupmod-herculesteam-augeasproviders_ssh < 4.0.0
 Requires: pupmod-herculesteam-augeasproviders_sysctl >= 2.3.1, pupmod-herculesteam-augeasproviders_sysctl < 3.0.0
 Requires: pupmod-onyxpoint-gpasswd >= 1.0.6, pupmod-onyxpoint-gpasswd < 2.0.0
-Requires: pupmod-puppet-yum >= 2.2.1, pupmod-puppet-yum < 3.0.0
+Requires: pupmod-puppet-yum >= 3.1.1, pupmod-puppet-yum < 4.0.0
 Requires: pupmod-puppetlabs-apache >= 3.0.0, pupmod-puppetlabs-apache < 5.0.0
 Requires: pupmod-puppetlabs-concat >= 4.1.1, pupmod-puppetlabs-concat < 5.0.0
 Requires: pupmod-puppetlabs-hocon >= 1.0.1, pupmod-puppetlabs-hocon < 2.0.0
@@ -111,21 +111,29 @@ Requires: simp-utils >= 6.1.2, simp-utils < 7.0.0
 %package extras
 Summary: Extra Packages for SIMP
 License: Apache-2.0
+
+# These 7 lines are required for upgrades from simp-6.[1-3].X to simp-6.4+.
+# Otherwise, we will have conflicting, derived dependencies caused by obsolete
+# ELG-related packages.
+Obsoletes: pupmod-elastic-elasticsearch <= 5.5.0
+Obsoletes: pupmod-elastic-logstash <= 5.3.0
+Obsoletes: pupmod-simp-simp_elasticsearch <= 5.0.5
+Obsoletes: pupmod-simp-simp_logstash <= 5.0.2
+Obsoletes: pupmod-richardc-datacat <= 0.6.2
+Obsoletes: pupmod-puppet-grafana <= 4.1.1
+Obsoletes: pupmod-simp-simp_grafana <= 1.0.6
+
 Requires: simp-adapter >= 0.1.1, simp-adapter < 1.0.0
 Requires: pupmod-cristifalcas-journald >= 0.6.0
-Requires: pupmod-elastic-elasticsearch >= 5.5.0
-Requires: pupmod-elastic-logstash >= 5.3.0
 Requires: pupmod-herculesteam-augeasproviders_mounttab >= 2.1.1
 Requires: pupmod-herculesteam-augeasproviders_nagios >= 2.1.1
 Requires: pupmod-herculesteam-augeasproviders_pam >= 2.2.1
 Requires: pupmod-vshn-gitlab >= 1.13.3
-Requires: pupmod-puppet-grafana >= 4.1.1
 Requires: pupmod-puppet-posix_acl >= 0.1.1
 Requires: pupmod-puppetlabs-docker >= 1.1.0
 Requires: pupmod-puppetlabs-mysql >= 5.3.0
 Requires: pupmod-puppetlabs-translate >= 1.0.0
 Requires: pupmod-razorsedge-snmp >= 3.9.0
-Requires: pupmod-richardc-datacat >= 0.6.2
 Requires: pupmod-saz-locales >= 2.5.1
 Requires: pupmod-simp-autofs >= 6.1.2
 Requires: pupmod-simp-dconf >= 0.0.2
@@ -142,15 +150,12 @@ Requires: pupmod-simp-network >= 6.0.3
 Requires: pupmod-simp-nfs >= 6.2.0
 Requires: pupmod-simp-openscap >= 6.2.0
 Requires: pupmod-simp-simp_docker >= 0.2.0
-Requires: pupmod-simp-simp_elasticsearch >= 5.0.5
 Requires: pupmod-simp-simp_gitlab >= 0.3.4
-Requires: pupmod-simp-simp_grafana >= 1.0.6
 Requires: pupmod-simp-simp_ipa >= 0.0.1
-Requires: pupmod-simp-simp_logstash >= 5.0.2
 Requires: pupmod-simp-simp_nfs >= 0.1.0
 Requires: pupmod-simp-simp_pki_service >= 0.1.1
 Requires: pupmod-simp-simp_snmpd >= 0.1.1
-Requires: pupmod-simp-tpm >= 3.1.0
+Requires: pupmod-simp-tpm >= 3.1.1
 Requires: pupmod-simp-tpm2 >= 0.1.0
 Requires: pupmod-simp-vnc >= 7.0.0
 Requires: pupmod-simp-vsftpd >= 7.2.0
@@ -246,11 +251,22 @@ fi
   - pupmod-herculesteam-augeasproviders_shellvar
   - pupmod-herculesteam-augeasproviders_ssh
   - pupmod-herculesteam-augeasproviders_sysctl
+  - pupmod-puppet-yum
   - pupmod-puppetlabs-apache
   - pupmod-puppetlabs-hocon
   - pupmod-puppetlabs-inifile
   - pupmod-puppetlabs-postgresql
   - pupmod-puppetlabs-puppet_authorization
+  - pupmod-simp-tpm
+- Removed the following from simp-extras because the
+  versions supported are EOL
+  - pupmod-elastic-elasticsearch
+  - pupmod-elastic-logstash
+  - pupmod-simp-simp_elasticsearch
+  - pupmod-simp-simp_logstash
+  - pupmod-richardc-datacat
+  - pupmod-puppet-grafana
+  - pupmod-simp-simp_grafana
 
 * Tue Feb 19 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.4.0-0
 - Added pupmod-puppet-posix_acl to the simp-extras package
@@ -288,12 +304,6 @@ fi
   - pupmod-simp-mate
   - pupmod-simp-simp_pki_service
   - pupmod-simp-x2go
-- Removed the following dependencies from the simp-extras
-  package, as they have not yet been updated to Puppet 5
-  - pupmod-elastic-elasticsearch
-  - pupmod-elastic-logstash
-  - pupmod-simp-simp_elasticsearch
-  - pupmod-simp-simp_logstash
 
 *  Fri Sep 28 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.2.0-0
 - Update final dependencies for 6.2.0


### PR DESCRIPTION
Changes related to yum 3.1.1
- Updated yum Puppet module version references to 3.1.1
- Updated to the tpm module version that allows yum < 4 (on master)
- Removed ELG stack because of repo closure failures caused
  the newer yum version and the newer stdlib and concat versions
  that will be coming in follow-on PRs.
- Removed rubygem-puppetserver-toml and rubygem-puppetserver-parslet
  RPM entries in all packages.yaml files, because they were required
  by OBE pupmod-puppet-grafana

Changes missed in earlier PRs
- Updated to the pupmod module version that works with inifile
  2.5.0 (on master)
- Removed 'mysql' entry in dependencies.yaml, as it is no longer
  required (pupmod-puppet-staging is not longer a dep of mysql 8.0.0)
- Removed OBE 'augeasproviders_nagios' entry (advanced beyond 2.0.2)
- Added missing pupmod-puppetlabs-translate dependency for 'motd'
- Remove erroneous info about removing ELG in an earlier changelog
  entry. (We removed it, changed our minds, added it back in during
  an earlier release cycle.)

SIMP-4373 #close
SIMP-6225 #close