### PR TITLE
(SIMP-4592) Update concat, java, puppetdb modules

### DIFF
--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -108,7 +108,7 @@ mod 'puppetlabs-apache',
 
 mod 'puppetlabs-concat',
   :git => 'https://github.com/simp/puppetlabs-concat',
-  :tag => '4.1.1'
+  :tag => '5.3.0'
 
 mod 'puppetlabs-docker',
   :git => 'https://github.com/simp/puppetlabs-docker',
@@ -124,7 +124,7 @@ mod 'puppetlabs-inifile',
 
 mod 'puppetlabs-java',
   :git => 'https://github.com/simp/puppetlabs-java',
-  :tag => '2.4.0'
+  :tag => '3.3.0'
 
 mod 'puppetlabs-motd',
   :git => 'https://github.com/simp/puppetlabs-motd',
@@ -147,7 +147,7 @@ mod 'puppetlabs-postgresql',
 
 mod 'puppetlabs-puppetdb',
   :git => 'https://github.com/simp/puppetlabs-puppetdb',
-  :tag => '6.0.2'
+  :tag => '7.1.0'
 
 mod 'puppetlabs-puppet_authorization',
   :git => 'https://github.com/simp/puppetlabs-puppet_authorization.git',
@@ -193,7 +193,7 @@ mod 'simp-auditd',
 
 mod 'simp-autofs',
   :git => 'https://github.com/simp/pupmod-simp-autofs',
-  :tag => '6.1.2'
+  :branch => 'master'
 
 mod 'simp-chkrootkit',
   :git => 'https://github.com/simp/pupmod-simp-chkrootkit',
@@ -223,13 +223,13 @@ mod 'simp-dhcp',
   :git => 'https://github.com/simp/pupmod-simp-dhcp',
   :tag => '6.1.0'
 
-mod 'simp-dirtycow',
-  :git => 'https://github.com/simp/pupmod-simp-dirtycow.git',
-  :tag => '1.0.4'
-
 mod 'simp-fips',
   :git => 'https://github.com/simp/pupmod-simp-fips',
   :tag => '0.2.0'
+
+mod 'simp-freeradius',
+  :git => 'https://github.com/simp/pupmod-simp-freeradius',
+  :branch => 'master'
 
 mod 'simp-gdm',
   :git => 'https://github.com/simp/pupmod-simp-gdm',
@@ -246,13 +246,17 @@ mod 'simp-haveged',
   :git => 'https://github.com/simp/pupmod-simp-haveged',
   :tag => '0.4.6'
 
+mod 'simp-hirs_provisioner',
+  :git => 'https://github.com/simp/pupmod-simp-hirs_provisioner',
+  :branch => 'master'
+
 mod 'simp-ima',
   :git => 'https://github.com/simp/pupmod-simp-ima',
   :tag => '0.1.0'
 
 mod 'simp-incron',
   :git => 'https://github.com/simp/pupmod-simp-incron',
-  :tag => '0.4.0'
+  :branch => 'master'
 
 mod 'simp-iptables',
   :git => 'https://github.com/simp/pupmod-simp-iptables',
@@ -296,11 +300,11 @@ mod 'simp-network',
 
 mod 'simp-nfs',
   :git => 'https://github.com/simp/pupmod-simp-nfs',
-  :tag => '6.2.0'
+  :branch => 'master'
 
 mod 'simp-ntpd',
   :git => 'https://github.com/simp/pupmod-simp-ntpd',
-  :tag => '6.2.1'
+  :branch => 'master'
 
 mod 'simp-oddjob',
   :git => 'https://github.com/simp/pupmod-simp-oddjob',
@@ -312,7 +316,7 @@ mod 'simp-openscap',
 
 mod 'simp-pam',
   :git => 'https://github.com/simp/pupmod-simp-pam',
-  :tag => '6.3.0'
+  :branch => 'master'
 
 mod 'simp-pki',
   :git => 'https://github.com/simp/pupmod-simp-pki',
@@ -324,7 +328,7 @@ mod 'simp-polkit',
 
 mod 'simp-postfix',
   :git => 'https://github.com/simp/pupmod-simp-postfix',
-  :tag => '5.2.0'
+  :branch => 'master'
 
 mod 'simp-pupmod',
   :git => 'https://github.com/simp/pupmod-simp-pupmod',
@@ -334,9 +338,13 @@ mod 'simp-resolv',
   :git => 'https://github.com/simp/pupmod-simp-resolv',
   :tag => '0.1.1'
 
+#mod 'simp-rkhunter',
+#  :git => 'https://github.com/simp/pupmod-simp-rkhunter',
+#  :branch => 'master'
+
 mod 'simp-rsync',
   :git => 'https://github.com/simp/pupmod-simp-rsync',
-  :tag => '6.1.0'
+  :branch => 'master'
 
 mod 'simp-rsyslog',
   :git => 'https://github.com/simp/pupmod-simp-rsyslog',
@@ -348,7 +356,7 @@ mod 'simp-selinux',
 
 mod 'simp-simp',
   :git => 'https://github.com/simp/pupmod-simp-simp',
-  :tag => '4.6.0'
+  :branch => 'master'
 
 mod 'simp-simpcat',
   :git => 'https://github.com/simp/pupmod-simp-simpcat',
@@ -357,6 +365,10 @@ mod 'simp-simpcat',
 mod 'simp-simplib',
   :git => 'https://github.com/simp/pupmod-simp-simplib',
   :tag => '3.12.0'
+
+#mod 'simp-simp_ad',
+#  :git => 'https://github.com/simp/pupmod-simp-simp_ad',
+#  :branch => 'master'
 
 mod 'simp-simp_apache',
   :git => 'https://github.com/simp/pupmod-simp-simp_apache',
@@ -395,7 +407,7 @@ mod 'simp-simp_nfs',
 
 mod 'simp-simp_openldap',
   :git => 'https://github.com/simp/pupmod-simp-simp_openldap',
-  :tag => '6.3.0'
+  :branch => 'master'
 
 mod 'simp-simp_options',
   :git => 'https://github.com/simp/pupmod-simp-simp_options',
@@ -427,11 +439,11 @@ mod 'simp-sssd',
 
 mod 'simp-stunnel',
   :git => 'https://github.com/simp/pupmod-simp-stunnel',
-  :tag => '6.4.0'
+  :branch => 'master'
 
 mod 'simp-sudo',
   :git => 'https://github.com/simp/pupmod-simp-sudo',
-  :tag => '5.1.1'
+  :branch => 'master'
 
 mod 'simp-sudosh',
   :git => 'https://github.com/simp/pupmod-simp-sudosh',
@@ -439,7 +451,7 @@ mod 'simp-sudosh',
 
 mod 'simp-svckill',
   :git => 'https://github.com/simp/pupmod-simp-svckill',
-  :tag => '3.3.0'
+  :branch => 'master'
 
 mod 'simp-swap',
   :git => 'https://github.com/simp/pupmod-simp-swap',
@@ -447,7 +459,7 @@ mod 'simp-swap',
 
 mod 'simp-tcpwrappers',
   :git => 'https://github.com/simp/pupmod-simp-tcpwrappers',
-  :tag => '6.1.0'
+  :branch => 'master'
 
 mod 'simp-tftpboot',
   :git => 'https://github.com/simp/pupmod-simp-tftpboot',

--- a/Rakefile
+++ b/Rakefile
@@ -73,7 +73,8 @@ namespace :pkg do
 
     dirs_to_remove = [
       Dir.glob(File.join(distr_glob, 'SIMP*')),
-      Dir.glob(File.join(distr_glob, 'DVD_Overlay'))
+      Dir.glob(File.join(distr_glob, 'DVD_Overlay')),
+      File.join(base_dir, 'src', 'assets', 'simp', 'dist')
     ]
 
     if args[:remove_yum_cache] == 'true'

--- a/metadata.json
+++ b/metadata.json
@@ -72,7 +72,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 4.1.1 < 5.0.0"
+      "version_requirement": ">= 5.3.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/hocon",
@@ -81,10 +81,6 @@
     {
       "name": "puppetlabs/inifile",
       "version_requirement": ">= 2.5.0 < 3.0.0"
-    },
-    {
-      "name": "puppetlabs/java",
-      "version_requirement": ">= 2.4.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/motd",
@@ -100,7 +96,7 @@
     },
     {
       "name": "puppetlabs/puppetdb",
-      "version_requirement": ">= 6.0.2 < 7.0.0"
+      "version_requirement": ">= 7.1.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/puppet_authorization",

--- a/src/assets/simp/build/simp.spec
+++ b/src/assets/simp/build/simp.spec
@@ -35,14 +35,13 @@ Requires: pupmod-herculesteam-augeasproviders_sysctl >= 2.3.1, pupmod-herculeste
 Requires: pupmod-onyxpoint-gpasswd >= 1.0.6, pupmod-onyxpoint-gpasswd < 2.0.0
 Requires: pupmod-puppet-yum >= 3.1.1, pupmod-puppet-yum < 4.0.0
 Requires: pupmod-puppetlabs-apache >= 3.0.0, pupmod-puppetlabs-apache < 5.0.0
-Requires: pupmod-puppetlabs-concat >= 4.1.1, pupmod-puppetlabs-concat < 5.0.0
+Requires: pupmod-puppetlabs-concat >= 5.3.0, pupmod-puppetlabs-concat < 6.0.0
 Requires: pupmod-puppetlabs-hocon >= 1.0.1, pupmod-puppetlabs-hocon < 2.0.0
 Requires: pupmod-puppetlabs-inifile >= 2.5.0, pupmod-puppetlabs-inifile < 3.0.0
-Requires: pupmod-puppetlabs-java >= 2.4.0, pupmod-puppetlabs-java < 3.0.0
 Requires: pupmod-puppetlabs-motd >= 2.0.0, pupmod-puppetlabs-motd < 3.0.0
 Requires: pupmod-puppetlabs-mount_providers >= 1.0.0, pupmod-puppetlabs-mount_providers < 2.0.0
 Requires: pupmod-puppetlabs-postgresql >= 5.12.1, pupmod-puppetlabs-postgresql < 6.0.0
-Requires: pupmod-puppetlabs-puppetdb >= 6.0.2, pupmod-puppetlabs-puppetdb < 7.0.0
+Requires: pupmod-puppetlabs-puppetdb >= 7.1.0, pupmod-puppetlabs-puppetdb < 8.0.0
 Requires: pupmod-puppetlabs-puppet_authorization >= 0.5.0, pupmod-puppetlabs-puppet_authorization < 1.0.0
 Requires: pupmod-puppetlabs-stdlib >= 4.25.1, pupmod-puppetlabs-stdlib < 5.0.0
 Requires: pupmod-simp-acpid >= 1.0.3, pupmod-simp-acpid < 2.0.0
@@ -131,15 +130,17 @@ Requires: pupmod-herculesteam-augeasproviders_pam >= 2.2.1
 Requires: pupmod-vshn-gitlab >= 1.13.3
 Requires: pupmod-puppet-posix_acl >= 0.1.1
 Requires: pupmod-puppetlabs-docker >= 1.1.0
+Requires: pupmod-puppetlabs-java >= 2.4.0
 Requires: pupmod-puppetlabs-mysql >= 5.3.0
 Requires: pupmod-puppetlabs-translate >= 1.0.0
 Requires: pupmod-razorsedge-snmp >= 3.9.0
 Requires: pupmod-saz-locales >= 2.5.1
 Requires: pupmod-simp-autofs >= 6.1.2
 Requires: pupmod-simp-dconf >= 0.0.2
-Requires: pupmod-simp-dirtycow >= 1.0.4
+Requires: pupmod-simp-freeradius >= 8.0.0
 Requires: pupmod-simp-gdm >= 7.1.0
 Requires: pupmod-simp-gnome >= 8.0.0
+Requires: pupmod-simp-hirs_provisioner >= 0.1.0
 Requires: pupmod-simp-ima >= 0.1.0
 Requires: pupmod-simp-krb5 >= 7.0.4
 Requires: pupmod-simp-libreswan >= 3.1.0
@@ -238,26 +239,12 @@ fi
 
 %changelog
 * Fri Mar 01 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.4.0-0
-- Updated the following packages
-  - pupmod-camptocamp-kmod
-  - pupmod-herculesteam-augeasproviders_apache
-  - pupmod-herculesteam-augeasproviders_core
-  - pupmod-herculesteam-augeasproviders_grub
-  - pupmod-herculesteam-augeasproviders_mounttab
-  - pupmod-herculesteam-augeasproviders_nagios
-  - pupmod-herculesteam-augeasproviders_pam
-  - pupmod-herculesteam-augeasproviders_postgresql
-  - pupmod-herculesteam-augeasproviders_puppet
-  - pupmod-herculesteam-augeasproviders_shellvar
-  - pupmod-herculesteam-augeasproviders_ssh
-  - pupmod-herculesteam-augeasproviders_sysctl
-  - pupmod-puppet-yum
-  - pupmod-puppetlabs-apache
-  - pupmod-puppetlabs-hocon
-  - pupmod-puppetlabs-inifile
-  - pupmod-puppetlabs-postgresql
-  - pupmod-puppetlabs-puppet_authorization
-  - pupmod-simp-tpm
+- Updated package versions
+- Moved pupmod-puppetlabs-java from simp to simp-extras, as it is not
+  required by any other packages in the simp package
+- Added the following to simp-extras
+  - pupmod-simp-freeradius
+  - pupmod-simp-hirs_provisioner
 - Removed the following from simp-extras because the
   versions supported are EOL
   - pupmod-elastic-elasticsearch
@@ -267,6 +254,7 @@ fi
   - pupmod-richardc-datacat
   - pupmod-puppet-grafana
   - pupmod-simp-simp_grafana
+- Removed OBE pupmod-simp-dirtycow from simp-extras
 
 * Tue Feb 19 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.4.0-0
 - Added pupmod-puppet-posix_acl to the simp-extras package

--- a/src/assets/simp/build/simp.spec
+++ b/src/assets/simp/build/simp.spec
@@ -163,9 +163,14 @@ Requires: pupmod-simp-vsftpd >= 7.2.0
 Requires: pupmod-simp-x2go >= 0.2.0
 
 # The following line ensures the OBE pupmod-electrical-file_concat
-# package is removed when simp-extras package is upgraded from
+# package is removed when the simp-extras package is upgraded from
 # 6.0.0 or 6.1.0.
 Obsoletes: pupmod-electrical-file_concat <= 1.0.1-2016
+
+# The following line ensures the OBE pupmod-simp-dirtycow
+# package is removed when the simp-extras package is upgraded from
+# 6.[2-3].X to 6.4+
+Obsoletes: pupmod-simp-dirtycow <= 1.0.4
 
 %description
 Metapackage for installing everything needed for a full SIMP system


### PR DESCRIPTION
- Update to concat 5.3.0
- Update to module versions that allows concat < 6 (on master)
  - autofs
  - incron
  - nfs
  - ntpd
  - pam
  - postfix
  - rsync
  - simp_openldap
  - stunnel
  - sudo
  - svckill
  - tcpwrappers
- Move pupmod-simp-java from simp to simp-extras, because it is
  not used by any of the modules in the simp package
- Update to java 3.3.0, but allow >- 2.4.0 in simp-extras RPM
  requires, in case any of the changes impact users
- Update to puppetdb module 7.1.0
- Update to the simp module version that allows puppetdb < 8 (on master)
- Add the following modules to simp-extras
  - pupmod-simp-freeradius
  - pupmod-simp-hirs_provisioner
- Removed dirtycow module

SIMP-4592 #close
SIMP-5486 #close
SIMP-6217 #close