### PR TITLE
(SIMP-5852) Update to puppet-snmp 4.1.0

### DIFF
--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -159,14 +159,6 @@ mod 'puppetlabs-translate',
   :git => 'https://github.com/simp/pupmod-puppetlabs-translate',
   :tag => '1.0.0'
 
-#FIXME Does not support Puppet 5 yet.  Support is currently being
-# added to the master branch by Vox Pupuli, who have changed the
-# name from razorsedge/snmp to puppet/snmp.
-# Required by simp-simp_snmpd
-mod 'razorsedge-snmp',
-  :git => 'https://github.com/simp/puppet-snmp',
-  :tag => '3.9.0'
-
 mod 'saz-locales',
   :git => 'https://github.com/simp/pupmod-saz-locales',
   :tag => 'v2.5.1'
@@ -423,7 +415,7 @@ mod 'simp-simp_rsyslog',
 
 mod 'simp-simp_snmpd',
   :git => 'https://github.com/simp/pupmod-simp-simp_snmpd',
-  :tag => '0.1.1'
+  :branch => 'master'
 
 mod 'simp-site',
   :git => 'https://github.com/simp/pupmod-simp-site',
@@ -532,6 +524,10 @@ mod 'trlinkin-nsswitch',
 mod 'voxpupuli-posix_acl',
   :git => 'https://github.com/simp/pupmod-voxpupuli-posix_acl',
   :tag => 'v0.1.1'
+
+mod 'voxpupuli-snmp',
+  :git => 'https://github.com/simp/puppet-snmp',
+  :tag => 'v4.1.0'
 
 mod 'voxpupuli-yum',
   :git => 'https://github.com/simp/voxpupuli-yum',

--- a/build/rpm/dependencies.yaml
+++ b/build/rpm/dependencies.yaml
@@ -98,6 +98,11 @@
     - 'pupmod-puppetlabs-postgresql'
     - 'pupmod-puppetlabs-stdlib'
 
+# Vox Pupuli has assumed ownership of the this project
+'snmp':
+  :obsoletes:
+    'pupmod-razorsedge-snmp': '3.9.0-0'
+
 # Make sure we create an RPM that fixes the obsoletes problem of
 # pupmod-simp-timezone-4.0.0-0 packaged for SIMP 6.1.0.  Since
 # we are not yet releasing a newer version, we can fix the

--- a/src/assets/simp/build/simp.spec
+++ b/src/assets/simp/build/simp.spec
@@ -128,11 +128,11 @@ Requires: pupmod-herculesteam-augeasproviders_nagios >= 2.1.1
 Requires: pupmod-herculesteam-augeasproviders_pam >= 2.2.1
 Requires: pupmod-vshn-gitlab >= 1.13.3
 Requires: pupmod-puppet-posix_acl >= 0.1.1
+Requires: pupmod-puppet-snmp >= 4.1.0
 Requires: pupmod-puppetlabs-docker >= 1.1.0
 Requires: pupmod-puppetlabs-java >= 2.4.0
 Requires: pupmod-puppetlabs-mysql >= 5.3.0
 Requires: pupmod-puppetlabs-translate >= 1.0.0
-Requires: pupmod-razorsedge-snmp >= 3.9.0
 Requires: pupmod-saz-locales >= 2.5.1
 Requires: pupmod-simp-autofs >= 6.1.2
 Requires: pupmod-simp-dconf >= 0.0.2
@@ -248,7 +248,9 @@ fi
 - Moved pupmod-puppetlabs-java from simp to simp-extras, as it is not
   required by any other packages in the simp package
 - Replaced pupmod-cristifalcas-journald with pupmod-simp-journald.
-  The SIMP project has assumed ownership of this project.
+  The SIMP org has assumed ownership of this project.
+- Replaced pupmod-razorsedge-snmp with pupmod-puppet-snmp.
+  The Vox Pupuli org has assumed ownership of this project.
 - Added the following to simp-extras
   - pupmod-simp-freeradius
   - pupmod-simp-hirs_provisioner


### PR DESCRIPTION
- Replace pupmod-razorsedge-snmp with pupmod-puppet-snmp.
  The Vox Pupuli org has taken over this project
- Update to simp-simp_snmpd version that works with puppet-snmp
  4.1.0 (on master)

SIMP-5852 #close