### PR TITLE
(SIMP-6237) Repackage pupmod-puppetlabs-mount_providers

### DIFF
--- a/build/rpm/dependencies.yaml
+++ b/build/rpm/dependencies.yaml
@@ -85,6 +85,14 @@
     - 'pupmod-puppetlabs-stdlib'
     - 'pupmod-puppetlabs-translate'
 
+# pupmod-puppetlabs-mount_providers-1.0.0-0 has a packaging bug in which
+# simp_rpm_helper is called in %post instead of %posttrans.  Need to
+# re-release based on the latest simp-rake-helpers, in order to fix the
+# bug.
+# TODO:  Remove this entry when the version advances beyond 1.0.0.
+'mount_providers':
+  :release: '1'
+
 'postgresql':
   :requires:
     # exclude pupmod-puppetlabs-apt


### PR DESCRIPTION
A newer version of puppetlabs-mount_providers is not available.
So, to fix the packaging problem with the RPM for the latest
release (calls simp_rpm_helper in %post instead of %posttrans),
we need to re-release with a bumped release qualifier.

SIMP-6237 #close