### PR TITLE
(SIMP-5485) Update stdlib and gitlab modules

### DIFF
--- a/Puppetfile.tracking
+++ b/Puppetfile.tracking
@@ -8,7 +8,7 @@ moduledir 'src/assets'
 
 mod 'rubygem-rubygem_simp_cli',
   :git => 'https://github.com/simp/rubygem-simp-cli',
-  :tag => '4.4.0'
+  :branch => 'master'
 
 # FIXME Doesn't have RPM packaging yet
 #mod 'rubygem-rubygem_simp_processgraph',
@@ -25,7 +25,7 @@ mod 'simp-adapter',
 
 mod 'simp-environment',
   :git => 'https://github.com/simp/simp-environment-skeleton',
-  :tag => '6.3.0'
+  :branch => 'master'
 
 mod 'simp-gpgkeys',
   :git => 'https://github.com/simp/simp-gpgkeys',
@@ -149,9 +149,13 @@ mod 'puppetlabs-puppet_authorization',
   :git => 'https://github.com/simp/puppetlabs-puppet_authorization.git',
   :tag => '0.5.0'
 
+mod 'puppetlabs-ruby_task_helper',
+  :git => 'https://github.com/simp/puppetlabs-ruby_task_helper.git',
+  :tag => '0.3.0'
+
 mod 'puppetlabs-stdlib',
   :git => 'https://github.com/simp/puppetlabs-stdlib',
-  :tag => '4.25.1'
+  :tag => '5.2.0'
 
 mod 'puppetlabs-translate',
   :git => 'https://github.com/simp/pupmod-puppetlabs-translate',
@@ -167,55 +171,55 @@ mod 'saz-timezone',
 
 mod 'simp-acpid',
   :git => 'https://github.com/simp/pupmod-simp-acpid',
-  :tag => '1.0.3'
+  :tag => '1.0.4'
 
 mod 'simp-aide',
   :git => 'https://github.com/simp/pupmod-simp-aide',
-  :tag => '6.2.0'
+  :branch => 'master'
 
 mod 'simp-at',
   :git => 'https://github.com/simp/pupmod-simp-at',
-  :tag => '0.0.5'
+  :tag => '0.0.6'
 
 mod 'simp-auditd',
   :git => 'https://github.com/simp/pupmod-simp-auditd',
-  :tag => '8.1.1'
+  :branch => 'master'
 
 mod 'simp-autofs',
   :git => 'https://github.com/simp/pupmod-simp-autofs',
-  :branch => 'master'
+  :tag => '6.1.3'
 
 mod 'simp-chkrootkit',
   :git => 'https://github.com/simp/pupmod-simp-chkrootkit',
-  :tag => '0.1.0'
+  :tag => '0.1.1'
 
 mod 'simp-clamav',
   :git => 'https://github.com/simp/pupmod-simp-clamav',
-  :tag => '6.1.0'
+  :tag => '6.1.1'
 
 mod 'simp-compliance_markup',
   :git => 'https://github.com/simp/pupmod-simp-compliance_markup',
-  :tag => '2.4.1'
+  :tag => '2.4.2'
 
 mod 'simp-cron',
   :git => 'https://github.com/simp/pupmod-simp-cron',
-  :tag => '0.1.0'
+  :tag => '0.1.1'
 
 mod 'simp-dconf',
   :git => 'https://github.com/simp/pupmod-simp-dconf',
-  :tag => '0.0.2'
+  :tag => '0.0.3'
 
 mod 'simp-deferred_resources',
   :git => 'https://github.com/simp/pupmod-simp-deferred_resources',
-  :tag => '0.1.0'
+  :tag => '0.1.1'
 
 mod 'simp-dhcp',
   :git => 'https://github.com/simp/pupmod-simp-dhcp',
-  :tag => '6.1.0'
+  :tag => '6.1.1'
 
 mod 'simp-fips',
   :git => 'https://github.com/simp/pupmod-simp-fips',
-  :tag => '0.2.0'
+  :tag => '0.2.1'
 
 mod 'simp-freeradius',
   :git => 'https://github.com/simp/pupmod-simp-freeradius',
@@ -223,18 +227,18 @@ mod 'simp-freeradius',
 
 mod 'simp-gdm',
   :git => 'https://github.com/simp/pupmod-simp-gdm',
-  :tag => '7.1.0'
+  :tag => '7.1.1'
 
 mod 'simp-gnome',
   :git => 'https://github.com/simp/pupmod-simp-gnome',
-  :tag => '8.0.0'
+  :tag => '8.0.1'
 
 # SIMP has made changes to this module that don't exist upstream
 # and owns this version.  Beginning with version 0.4.4, all module
 # changes will be done on the 'master' branch.
 mod 'simp-haveged',
   :git => 'https://github.com/simp/pupmod-simp-haveged',
-  :tag => '0.4.6'
+  :tag => '0.4.7'
 
 mod 'simp-hirs_provisioner',
   :git => 'https://github.com/simp/pupmod-simp-hirs_provisioner',
@@ -242,59 +246,59 @@ mod 'simp-hirs_provisioner',
 
 mod 'simp-ima',
   :git => 'https://github.com/simp/pupmod-simp-ima',
-  :tag => '0.1.0'
+  :tag => '0.1.1'
 
 mod 'simp-incron',
   :git => 'https://github.com/simp/pupmod-simp-incron',
-  :branch => 'master'
+  :tag => '0.4.1'
 
 mod 'simp-iptables',
   :git => 'https://github.com/simp/pupmod-simp-iptables',
-  :tag => '6.1.6'
+  :tag => '6.1.7'
 
 mod 'simp-issue',
   :git => 'https://github.com/simp/pupmod-simp-issue',
-  :tag => '0.0.3'
+  :tag => '0.0.4'
 
 mod 'simp-journald',
   :git => 'https://github.com/simp/pupmod-simp-journald.git',
-  :branch => 'master'
+  :tag => '1.0.0'
 
 mod 'simp-krb5',
   :git => 'https://github.com/simp/pupmod-simp-krb5',
-  :tag => '7.0.4'
+  :tag => '7.0.5'
 
 mod 'simp-libreswan',
   :git => 'https://github.com/simp/pupmod-simp-libreswan',
-  :tag => '3.1.0'
+  :tag => '3.1.1'
 
 mod 'simp-libvirt',
   :git => 'https://github.com/simp/pupmod-simp-libvirt',
-  :tag => '5.2.0'
+  :tag => '5.2.1'
 
 mod 'simp-logrotate',
   :git => 'https://github.com/simp/pupmod-simp-logrotate',
-  :tag => '6.3.0'
+  :branch => 'master'
 
 mod 'simp-mate',
   :git => 'https://github.com/simp/pupmod-simp-mate',
-  :tag => '1.0.1'
+  :tag => '1.0.2'
 
 mod 'simp-mozilla',
   :git => 'https://github.com/simp/pupmod-simp-mozilla',
-  :tag => '5.1.0'
+  :tag => '5.1.1'
 
 mod 'simp-named',
   :git => 'https://github.com/simp/pupmod-simp-named',
-  :tag => '6.1.0'
+  :branch => 'master'
 
 mod 'simp-network',
   :git => 'https://github.com/simp/pupmod-simp-network',
-  :tag => '6.0.3'
+  :tag => '6.0.4'
 
 mod 'simp-nfs',
   :git => 'https://github.com/simp/pupmod-simp-nfs',
-  :branch => 'master'
+  :tag => '6.2.1'
 
 mod 'simp-ntpd',
   :git => 'https://github.com/simp/pupmod-simp-ntpd',
@@ -302,23 +306,23 @@ mod 'simp-ntpd',
 
 mod 'simp-oddjob',
   :git => 'https://github.com/simp/pupmod-simp-oddjob',
-  :tag => '2.1.0'
+  :tag => '2.1.1'
 
 mod 'simp-openscap',
   :git => 'https://github.com/simp/pupmod-simp-openscap',
-  :tag => '6.2.0'
+  :branch => 'master'
 
 mod 'simp-pam',
   :git => 'https://github.com/simp/pupmod-simp-pam',
-  :branch => 'master'
+  :tag => '6.4.0'
 
 mod 'simp-pki',
   :git => 'https://github.com/simp/pupmod-simp-pki',
-  :tag => '6.0.4'
+  :branch => 'master'
 
 mod 'simp-polkit',
   :git => 'https://github.com/simp/pupmod-simp-polkit',
-  :tag => '6.1.1'
+  :tag => '6.1.2'
 
 mod 'simp-postfix',
   :git => 'https://github.com/simp/pupmod-simp-postfix',
@@ -326,27 +330,27 @@ mod 'simp-postfix',
 
 mod 'simp-pupmod',
   :git => 'https://github.com/simp/pupmod-simp-pupmod',
-  :branch => 'master'
+  :tag => '7.9.0'
 
 mod 'simp-resolv',
   :git => 'https://github.com/simp/pupmod-simp-resolv',
-  :tag => '0.1.1'
+  :tag => '0.1.2'
 
-#mod 'simp-rkhunter',
-#  :git => 'https://github.com/simp/pupmod-simp-rkhunter',
-#  :branch => 'master'
+mod 'simp-rkhunter',
+  :git => 'https://github.com/simp/pupmod-simp-rkhunter',
+  :branch => 'master'
 
 mod 'simp-rsync',
   :git => 'https://github.com/simp/pupmod-simp-rsync',
-  :branch => 'master'
+  :tag => '6.1.1'
 
 mod 'simp-rsyslog',
   :git => 'https://github.com/simp/pupmod-simp-rsyslog',
-  :tag => '7.3.0'
+  :tag => '7.3.1'
 
 mod 'simp-selinux',
   :git => 'https://github.com/simp/pupmod-simp-selinux',
-  :tag => '2.3.0'
+  :tag => '2.3.1'
 
 mod 'simp-simp',
   :git => 'https://github.com/simp/pupmod-simp-simp',
@@ -354,7 +358,7 @@ mod 'simp-simp',
 
 mod 'simp-simpcat',
   :git => 'https://github.com/simp/pupmod-simp-simpcat',
-  :tag => '6.0.2'
+  :tag => '6.0.3'
 
 mod 'simp-simplib',
   :git => 'https://github.com/simp/pupmod-simp-simplib',
@@ -366,27 +370,23 @@ mod 'simp-simplib',
 
 mod 'simp-simp_apache',
   :git => 'https://github.com/simp/pupmod-simp-simp_apache',
-  :tag => '6.1.0'
+  :tag => '6.1.1'
 
 mod 'simp-simp_banners',
   :git => 'https://github.com/simp/pupmod-simp-simp_banners',
-  :tag => '0.1.0'
+  :tag => '0.1.1'
 
 mod 'simp-simp_docker',
   :git => 'https://github.com/simp/pupmod-simp-simp_docker',
-  :branch => 'master'
+  :tag => '0.2.1'
 
-#FIXME Does not support Puppet 5 yet.  Also, needs to be tested with
-# Vox Pupuli puppet/gitlab 2.0.0, which does support Puppet 5.
-# puppet/gitlab is the new name for vshn/gitlab.  When Vox Pupuli
-# took over that project, they changed the name.
 mod 'simp-simp_gitlab',
   :git => 'https://github.com/simp/pupmod-simp-simp_gitlab',
-  :tag => '0.3.4'
+  :branch => 'master'
 
 mod 'simp-simp_ipa',
   :git => 'https://github.com/simp/pupmod-simp-simp_ipa',
-  :tag => '0.0.1'
+  :tag => '0.0.2'
 
 # FIXME: This is commented out until the module is ready to be released.
 #  It has dependencies that have already been removed from the distribution.
@@ -397,7 +397,7 @@ mod 'simp-simp_ipa',
 
 mod 'simp-simp_nfs',
   :git => 'https://github.com/simp/pupmod-simp-simp_nfs',
-  :tag => '0.1.0'
+  :branch => 'master'
 
 mod 'simp-simp_openldap',
   :git => 'https://github.com/simp/pupmod-simp-simp_openldap',
@@ -405,31 +405,31 @@ mod 'simp-simp_openldap',
 
 mod 'simp-simp_options',
   :git => 'https://github.com/simp/pupmod-simp-simp_options',
-  :tag => '1.2.1'
+  :branch => 'master'
 
 mod 'simp-simp_pki_service',
   :git => 'https://github.com/simp/pupmod-simp-simp_pki_service',
-  :tag => '0.1.1'
+  :tag => '0.2.0'
 
 mod 'simp-simp_rsyslog',
   :git => 'https://github.com/simp/pupmod-simp-simp_rsyslog',
-  :tag => '0.3.0'
+  :branch => 'master'
 
 mod 'simp-simp_snmpd',
   :git => 'https://github.com/simp/pupmod-simp-simp_snmpd',
-  :branch => 'master'
+  :tag => '0.1.2'
 
 mod 'simp-site',
   :git => 'https://github.com/simp/pupmod-simp-site',
-  :tag => '2.0.5'
+  :tag => '2.0.6'
 
 mod 'simp-ssh',
   :git => 'https://github.com/simp/pupmod-simp-ssh',
-  :tag => '6.5.1'
+  :branch => 'master'
 
 mod 'simp-sssd',
   :git => 'https://github.com/simp/pupmod-simp-sssd',
-  :tag => '6.1.4'
+  :tag => '6.1.6'
 
 mod 'simp-stunnel',
   :git => 'https://github.com/simp/pupmod-simp-stunnel',
@@ -437,19 +437,19 @@ mod 'simp-stunnel',
 
 mod 'simp-sudo',
   :git => 'https://github.com/simp/pupmod-simp-sudo',
-  :branch => 'master'
+  :tag => '5.1.2'
 
 mod 'simp-sudosh',
   :git => 'https://github.com/simp/pupmod-simp-sudosh',
-  :tag => '6.1.0'
+  :tag => '6.1.1'
 
 mod 'simp-svckill',
   :git => 'https://github.com/simp/pupmod-simp-svckill',
-  :branch => 'master'
+  :tag => '3.3.1'
 
 mod 'simp-swap',
   :git => 'https://github.com/simp/pupmod-simp-swap',
-  :tag => '0.1.2'
+  :tag => '0.1.3'
 
 mod 'simp-tcpwrappers',
   :git => 'https://github.com/simp/pupmod-simp-tcpwrappers',
@@ -457,35 +457,35 @@ mod 'simp-tcpwrappers',
 
 mod 'simp-tftpboot',
   :git => 'https://github.com/simp/pupmod-simp-tftpboot',
-  :tag => '6.2.0'
+  :branch => 'master'
 
 mod 'simp-tlog',
   :git => 'https://github.com/simp/pupmod-simp-tlog',
-  :tag => '0.1.1'
+  :tag => '0.1.2'
 
 mod 'simp-tpm',
   :git => 'https://github.com/simp/pupmod-simp-tpm',
-  :branch => 'master'
+  :tag => '3.1.1'
 
 mod 'simp-tpm2',
   :git => 'https://github.com/simp/pupmod-simp-tpm2',
-  :tag => '0.1.0'
+  :tag => '0.1.1'
 
 mod 'simp-tuned',
   :git => 'https://github.com/simp/pupmod-simp-tuned',
-  :tag => '0.1.0'
+  :tag => '0.1.1'
 
 mod 'simp-upstart',
   :git => 'https://github.com/simp/pupmod-simp-upstart',
-  :tag => '6.0.3'
+  :tag => '6.0.4'
 
 mod 'simp-useradd',
   :git => 'https://github.com/simp/pupmod-simp-useradd',
-  :tag => '0.2.2'
+  :tag => '0.2.3'
 
 mod 'simp-vnc',
   :git => 'https://github.com/simp/pupmod-simp-vnc',
-  :tag => '7.0.0'
+  :branch => 'master'
 
 # We have forked voxpupuli/selinux temporarily, renaming
 # their selinux namespace to vox_selinux.  This change
@@ -500,15 +500,15 @@ mod 'simp-vox_selinux',
 
 mod 'simp-vsftpd',
   :git => 'https://github.com/simp/pupmod-simp-vsftpd',
-  :tag => '7.2.0'
+  :branch => 'master'
 
 mod 'simp-x2go',
   :git => 'https://github.com/simp/pupmod-simp-x2go',
-  :tag => '0.2.0'
+  :tag => '0.2.1'
 
 mod 'simp-xinetd',
   :git => 'https://github.com/simp/pupmod-simp-xinetd',
-  :tag => '4.1.0'
+  :tag => '4.1.1'
 
 mod 'trlinkin-nsswitch',
   :git => 'https://github.com/simp/puppet-nsswitch',
@@ -518,6 +518,10 @@ mod 'voxpupuli-posix_acl',
   :git => 'https://github.com/simp/pupmod-voxpupuli-posix_acl',
   :tag => 'v0.1.1'
 
+mod 'voxpupuli-gitlab',
+  :git => 'https://github.com/simp/puppet-gitlab.git',
+  :tag => 'v3.0.2'
+
 mod 'voxpupuli-snmp',
   :git => 'https://github.com/simp/puppet-snmp',
   :tag => 'v4.1.0'
@@ -525,12 +529,5 @@ mod 'voxpupuli-snmp',
 mod 'voxpupuli-yum',
   :git => 'https://github.com/simp/voxpupuli-yum',
   :tag => 'v3.1.1'
-
-#FIXME vshn/gitlab does not support Puppet 5, However, puppet/gitlab
-# 2.0.0 does.  puppet/gitlab is the new name for vshn/gitlab.  When
-# Vox Pupuli took over that project, they changed the name.
-mod 'vshn-gitlab',
-  :git => 'https://github.com/simp/puppet-gitlab.git',
-  :tag => 'v1.13.3'
 
 # vi:syntax=ruby

--- a/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
@@ -266,6 +266,9 @@ python-traceback2:
 python-unittest2:
   :rpm_name: python-unittest2-1.1.0-4.el7.noarch.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/python-unittest2-1.1.0-4.el7.noarch.rpm
+rkhunter:
+  :rpm_name: rkhunter-1.4.6-1.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/r/rkhunter-1.4.6-1.el7.noarch.rpm
 ruby-augeas:
   :rpm_name: ruby-augeas-0.4.1-3.el7.x86_64.rpm
   :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/ruby-augeas-0.4.1-3.el7.x86_64.rpm

--- a/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
@@ -263,6 +263,9 @@ python-traceback2:
 python-unittest2:
   :rpm_name: python-unittest2-1.1.0-4.el7.noarch.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/p/python-unittest2-1.1.0-4.el7.noarch.rpm
+rkhunter:
+  :rpm_name: rkhunter-1.4.6-1.el7.noarch.rpm
+  :source: http://lug.mtu.edu/epel/7/x86_64/Packages/r/rkhunter-1.4.6-1.el7.noarch.rpm
 ruby-augeas:
   :rpm_name: ruby-augeas-0.4.1-3.el7.x86_64.rpm
   :source: http://yum.puppetlabs.com/el/7/dependencies/x86_64/ruby-augeas-0.4.1-3.el7.x86_64.rpm

--- a/build/rpm/dependencies.yaml
+++ b/build/rpm/dependencies.yaml
@@ -66,7 +66,10 @@
     - 'pupmod-puppetlabs-stdlib'
     - 'pupmod-puppetlabs-translate'
 
+# Vox Pupuli has assumed ownership of the this project
 'gitlab':
+  :obsoletes:
+    'pupmod-vshn-gitlab': '1.13.3-2016.1'
   :requires:
     # exclude pupmod-puppetlabs-apt
     - 'pupmod-puppetlabs-stdlib'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_core",
-  "version": "6.3.2",
+  "version": "6.4.0",
   "author": "SIMP Team",
   "summary": "A Metamodule for SIMP",
   "license": "Apache-2.0",
@@ -104,7 +104,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.1 < 5.0.0"
+      "version_requirement": ">= 5.2.0 < 6.0.0"
     },
     {
       "name": "saz/timezone",
@@ -112,7 +112,7 @@
     },
     {
       "name": "simp/acpid",
-      "version_requirement": ">= 1.0.3 < 2.0.0"
+      "version_requirement": ">= 1.0.4 < 2.0.0"
     },
     {
       "name": "simp/aide",
@@ -120,7 +120,7 @@
     },
     {
       "name": "simp/at",
-      "version_requirement": ">= 0.0.5 < 1.0.0"
+      "version_requirement": ">= 0.0.6 < 1.0.0"
     },
     {
       "name": "simp/auditd",
@@ -128,47 +128,47 @@
     },
     {
       "name": "simp/chkrootkit",
-      "version_requirement": ">= 0.1.0 < 1.0.0"
+      "version_requirement": ">= 0.1.1 < 1.0.0"
     },
     {
       "name": "simp/clamav",
-      "version_requirement": ">= 6.1.0 < 7.0.0"
+      "version_requirement": ">= 6.1.1 < 7.0.0"
     },
     {
       "name": "simp/compliance_markup",
-      "version_requirement": ">= 2.4.1 < 3.0.0"
+      "version_requirement": ">= 2.4.2 < 3.0.0"
     },
     {
       "name": "simp/cron",
-      "version_requirement": ">= 0.1.0 < 1.0.0"
+      "version_requirement": ">= 0.1.1 < 1.0.0"
     },
     {
       "name": "simp/deferred_resources",
-      "version_requirement": ">= 0.1.0 < 1.0.0"
+      "version_requirement": ">= 0.1.1 < 1.0.0"
     },
     {
       "name": "simp/dhcp",
-      "version_requirement": ">= 6.1.0 < 7.0.0"
+      "version_requirement": ">= 6.1.1 < 7.0.0"
     },
     {
       "name": "simp/fips",
-      "version_requirement": ">= 0.2.0 < 1.0.0"
+      "version_requirement": ">= 0.2.1 < 1.0.0"
     },
     {
       "name": "simp/haveged",
-      "version_requirement": ">= 0.4.6 < 1.0.0"
+      "version_requirement": ">= 0.4.7 < 1.0.0"
     },
     {
       "name": "simp/incron",
-      "version_requirement": ">= 0.4.0 < 1.0.0"
+      "version_requirement": ">= 0.4.1 < 1.0.0"
     },
     {
       "name": "simp/iptables",
-      "version_requirement": ">= 6.1.6 < 7.0.0"
+      "version_requirement": ">= 6.1.7 < 7.0.0"
     },
     {
       "name": "simp/issue",
-      "version_requirement": ">= 0.0.3 < 1.0.0"
+      "version_requirement": ">= 0.0.4 < 1.0.0"
     },
     {
       "name": "simp/logrotate",
@@ -184,11 +184,11 @@
     },
     {
       "name": "simp/oddjob",
-      "version_requirement": ">= 2.1.0 < 3.0.0"
+      "version_requirement": ">= 2.1.1 < 3.0.0"
     },
     {
       "name": "simp/pam",
-      "version_requirement": ">= 6.3.0 < 7.0.0"
+      "version_requirement": ">= 6.4.0 < 7.0.0"
     },
     {
       "name": "simp/pki",
@@ -196,7 +196,7 @@
     },
     {
       "name": "simp/polkit",
-      "version_requirement": ">= 6.1.1 < 7.0.0"
+      "version_requirement": ">= 6.1.2 < 7.0.0"
     },
     {
       "name": "simp/postfix",
@@ -204,23 +204,27 @@
     },
     {
       "name": "simp/pupmod",
-      "version_requirement": ">= 7.8.0 < 8.0.0"
+      "version_requirement": ">= 7.9.0 < 8.0.0"
     },
     {
       "name": "simp/resolv",
-      "version_requirement": ">= 0.1.1 < 1.0.0"
+      "version_requirement": ">= 0.1.2 < 1.0.0"
+    },
+    {
+      "name": "simp/rkhunter",
+      "version_requirement": ">= 0.0.1 < 1.0.0"
     },
     {
       "name": "simp/rsync",
-      "version_requirement": ">= 6.1.0 < 7.0.0"
+      "version_requirement": ">= 6.1.1 < 7.0.0"
     },
     {
       "name": "simp/rsyslog",
-      "version_requirement": ">= 7.3.0 < 8.0.0"
+      "version_requirement": ">= 7.3.1 < 8.0.0"
     },
     {
       "name": "simp/selinux",
-      "version_requirement": ">= 2.3.0 < 3.0.0"
+      "version_requirement": ">= 2.3.1 < 3.0.0"
     },
     {
       "name": "simp/simp",
@@ -228,7 +232,7 @@
     },
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 6.0.2 < 7.0.0"
+      "version_requirement": ">= 6.0.3 < 7.0.0"
     },
     {
       "name": "simp/simplib",
@@ -236,11 +240,11 @@
     },
     {
       "name": "simp/simp_apache",
-      "version_requirement": ">= 6.1.0 < 7.0.0"
+      "version_requirement": ">= 6.1.1 < 7.0.0"
     },
     {
       "name": "simp/simp_banners",
-      "version_requirement": ">= 0.1.0 < 1.0.0"
+      "version_requirement": ">= 0.1.1 < 1.0.0"
     },
     {
       "name": "simp/simp_openldap",
@@ -256,7 +260,7 @@
     },
     {
       "name": "simp/site",
-      "version_requirement": ">= 2.0.5 < 3.0.0"
+      "version_requirement": ">= 2.0.6 < 3.0.0"
     },
     {
       "name": "simp/ssh",
@@ -264,7 +268,7 @@
     },
     {
       "name": "simp/sssd",
-      "version_requirement": ">= 6.1.4 < 7.0.0"
+      "version_requirement": ">= 6.1.6 < 7.0.0"
     },
     {
       "name": "simp/stunnel",
@@ -272,19 +276,19 @@
     },
     {
       "name": "simp/sudo",
-      "version_requirement": ">= 5.1.1 < 6.0.0"
+      "version_requirement": ">= 5.1.2 < 6.0.0"
     },
     {
       "name": "simp/sudosh",
-      "version_requirement": ">= 6.1.0 < 7.0.0"
+      "version_requirement": ">= 6.1.1 < 7.0.0"
     },
     {
       "name": "simp/svckill",
-      "version_requirement": ">= 3.3.0 < 4.0.0"
+      "version_requirement": ">= 3.3.1 < 4.0.0"
     },
     {
       "name": "simp/swap",
-      "version_requirement": ">= 0.1.2 < 1.0.0"
+      "version_requirement": ">= 0.1.3 < 1.0.0"
     },
     {
       "name": "simp/tcpwrappers",
@@ -296,19 +300,19 @@
     },
     {
       "name": "simp/tlog",
-      "version_requirement": ">= 0.1.1 < 1.0.0"
+      "version_requirement": ">= 0.1.2 < 1.0.0"
     },
     {
       "name": "simp/tuned",
-      "version_requirement": ">= 0.1.0 < 1.0.0"
+      "version_requirement": ">= 0.1.1 < 1.0.0"
     },
     {
       "name": "simp/upstart",
-      "version_requirement": ">= 6.0.3 < 7.0.0"
+      "version_requirement": ">= 6.0.4 < 7.0.0"
     },
     {
       "name": "simp/useradd",
-      "version_requirement": ">= 0.2.2 < 1.0.0"
+      "version_requirement": ">= 0.2.3 < 1.0.0"
     },
     {
       "name": "simp/vox_selinux",
@@ -316,7 +320,7 @@
     },
     {
       "name": "simp/xinetd",
-      "version_requirement": ">= 4.1.0 < 5.0.0"
+      "version_requirement": ">= 4.1.1 < 5.0.0"
     },
     {
       "name": "trlinkin/nsswitch",

--- a/src/assets/simp/build/simp.spec
+++ b/src/assets/simp/build/simp.spec
@@ -43,60 +43,61 @@ Requires: pupmod-puppetlabs-mount_providers >= 1.0.0, pupmod-puppetlabs-mount_pr
 Requires: pupmod-puppetlabs-postgresql >= 5.12.1, pupmod-puppetlabs-postgresql < 6.0.0
 Requires: pupmod-puppetlabs-puppetdb >= 7.1.0, pupmod-puppetlabs-puppetdb < 8.0.0
 Requires: pupmod-puppetlabs-puppet_authorization >= 0.5.0, pupmod-puppetlabs-puppet_authorization < 1.0.0
-Requires: pupmod-puppetlabs-stdlib >= 4.25.1, pupmod-puppetlabs-stdlib < 5.0.0
+Requires: pupmod-puppetlabs-stdlib >= 5.2.0, pupmod-puppetlabs-stdlib < 6.0.0
 Requires: pupmod-saz-timezone >= 5.1.1, pupmod-saz-timezone < 6.0.0
-Requires: pupmod-simp-acpid >= 1.0.3, pupmod-simp-acpid < 2.0.0
+Requires: pupmod-simp-acpid >= 1.0.4, pupmod-simp-acpid < 2.0.0
 Requires: pupmod-simp-aide >= 6.2.0, pupmod-simp-aide < 7.0.0
-Requires: pupmod-simp-at >= 0.0.5, pupmod-simp-at < 1.0.0
+Requires: pupmod-simp-at >= 0.0.6, pupmod-simp-at < 1.0.0
 Requires: pupmod-simp-auditd >= 8.1.1, pupmod-simp-auditd < 9.0.0
-Requires: pupmod-simp-chkrootkit >= 0.1.0, pupmod-simp-chkrootkit < 1.0.0
-Requires: pupmod-simp-clamav >= 6.1.0, pupmod-simp-clamav < 7.0.0
-Requires: pupmod-simp-compliance_markup >= 2.4.1, pupmod-simp-compliance_markup < 3.0.0
-Requires: pupmod-simp-cron >= 0.1.0, pupmod-simp-cron < 1.0.0
-Requires: pupmod-simp-deferred_resources >= 0.1.0, pupmod-simp-deferred_resources < 1.0.0
-Requires: pupmod-simp-dhcp >= 6.1.0, pupmod-simp-dhcp < 7.0.0
-Requires: pupmod-simp-fips >= 0.2.0, pupmod-simp-fips < 1.0.0
-Requires: pupmod-simp-haveged >= 0.4.6, pupmod-simp-haveged < 1.0.0
-Requires: pupmod-simp-incron >= 0.4.0, pupmod-simp-incron < 1.0.0
-Requires: pupmod-simp-iptables >= 6.1.6, pupmod-simp-iptables < 7.0.0
-Requires: pupmod-simp-issue >= 0.0.3, pupmod-simp-issue < 1.0.0
+Requires: pupmod-simp-chkrootkit >= 0.1.1, pupmod-simp-chkrootkit < 1.0.0
+Requires: pupmod-simp-clamav >= 6.1.1, pupmod-simp-clamav < 7.0.0
+Requires: pupmod-simp-compliance_markup >= 2.4.2, pupmod-simp-compliance_markup < 3.0.0
+Requires: pupmod-simp-cron >= 0.1.1, pupmod-simp-cron < 1.0.0
+Requires: pupmod-simp-deferred_resources >= 0.1.1, pupmod-simp-deferred_resources < 1.0.0
+Requires: pupmod-simp-dhcp >= 6.1.1, pupmod-simp-dhcp < 7.0.0
+Requires: pupmod-simp-fips >= 0.2.1, pupmod-simp-fips < 1.0.0
+Requires: pupmod-simp-haveged >= 0.4.7, pupmod-simp-haveged < 1.0.0
+Requires: pupmod-simp-incron >= 0.4.1, pupmod-simp-incron < 1.0.0
+Requires: pupmod-simp-iptables >= 6.1.7, pupmod-simp-iptables < 7.0.0
+Requires: pupmod-simp-issue >= 0.0.4, pupmod-simp-issue < 1.0.0
 Requires: pupmod-simp-logrotate >= 6.3.0, pupmod-simp-logrotate < 7.0.0
 Requires: pupmod-simp-named >= 6.1.0, pupmod-simp-named < 7.0.0
 Requires: pupmod-simp-ntpd >= 6.2.1, pupmod-simp-ntpd < 7.0.0
-Requires: pupmod-simp-oddjob >= 2.1.0, pupmod-simp-oddjob < 3.0.0
-Requires: pupmod-simp-pam >= 6.3.0, pupmod-simp-pam < 7.0.0
+Requires: pupmod-simp-oddjob >= 2.1.1, pupmod-simp-oddjob < 3.0.0
+Requires: pupmod-simp-pam >= 6.4.0, pupmod-simp-pam < 7.0.0
 Requires: pupmod-simp-pki >= 6.0.4, pupmod-simp-pki < 7.0.0
-Requires: pupmod-simp-polkit >= 6.1.1, pupmod-simp-polkit < 7.0.0
+Requires: pupmod-simp-polkit >= 6.1.2, pupmod-simp-polkit < 7.0.0
 Requires: pupmod-simp-postfix >= 5.2.0, pupmod-simp-postfix < 6.0.0
-Requires: pupmod-simp-pupmod >= 7.8.0, pupmod-simp-pupmod < 8.0.0
-Requires: pupmod-simp-resolv >= 0.1.1, pupmod-simp-resolv < 1.0.0
-Requires: pupmod-simp-rsync >= 6.1.0, pupmod-simp-rsync < 7.0.0
-Requires: pupmod-simp-rsyslog >= 7.3.0, pupmod-simp-rsyslog < 8.0.0
-Requires: pupmod-simp-selinux >= 2.3.0, pupmod-simp-selinux < 3.0.0
+Requires: pupmod-simp-pupmod >= 7.9.0, pupmod-simp-pupmod < 8.0.0
+Requires: pupmod-simp-resolv >= 0.1.2, pupmod-simp-resolv < 1.0.0
+Requires: pupmod-simp-rkhunter >= 0.0.1, pupmod-simp-rkhunter < 1.0.0
+Requires: pupmod-simp-rsync >= 6.1.1, pupmod-simp-rsync < 7.0.0
+Requires: pupmod-simp-rsyslog >= 7.3.1, pupmod-simp-rsyslog < 8.0.0
+Requires: pupmod-simp-selinux >= 2.3.1, pupmod-simp-selinux < 3.0.0
 Requires: pupmod-simp-simp >= 4.6.0, pupmod-simp-simp < 5.0.0
-Requires: pupmod-simp-simpcat >= 6.0.2, pupmod-simp-simpcat < 7.0.0
+Requires: pupmod-simp-simpcat >= 6.0.3, pupmod-simp-simpcat < 7.0.0
 Requires: pupmod-simp-simplib >= 3.12.0, pupmod-simp-simplib < 4.0.0
-Requires: pupmod-simp-simp_apache >= 6.1.0, pupmod-simp-simp_apache < 7.0.0
-Requires: pupmod-simp-simp_banners >= 0.1.0, pupmod-simp-simp_banners < 1.0.0
+Requires: pupmod-simp-simp_apache >= 6.1.1, pupmod-simp-simp_apache < 7.0.0
+Requires: pupmod-simp-simp_banners >= 0.1.1, pupmod-simp-simp_banners < 1.0.0
 Requires: pupmod-simp-simp_openldap >= 6.3.0, pupmod-simp-simp_openldap < 7.0.0
 Requires: pupmod-simp-simp_options >= 1.2.1, pupmod-simp-simp_options < 2.0.0
 Requires: pupmod-simp-simp_rsyslog >= 0.3.0, pupmod-simp-simp_rsyslog < 1.0.0
 Requires: pupmod-simp-site >= 2.0.5, pupmod-simp-site < 3.0.0
 Requires: pupmod-simp-ssh >= 6.5.1, pupmod-simp-ssh < 7.0.0
-Requires: pupmod-simp-sssd >= 6.1.4, pupmod-simp-sssd < 7.0.0
+Requires: pupmod-simp-sssd >= 6.1.6, pupmod-simp-sssd < 7.0.0
 Requires: pupmod-simp-stunnel >= 6.4.0, pupmod-simp-stunnel < 7.0.0
-Requires: pupmod-simp-sudo >= 5.1.1, pupmod-simp-sudo < 6.0.0
-Requires: pupmod-simp-sudosh >= 6.1.0, pupmod-simp-sudosh < 7.0.0
-Requires: pupmod-simp-svckill >= 3.3.0, pupmod-simp-svckill < 4.0.0
-Requires: pupmod-simp-swap >= 0.1.2, pupmod-simp-swap < 1.0.0
+Requires: pupmod-simp-sudo >= 5.1.2, pupmod-simp-sudo < 6.0.0
+Requires: pupmod-simp-sudosh >= 6.1.1, pupmod-simp-sudosh < 7.0.0
+Requires: pupmod-simp-svckill >= 3.3.1, pupmod-simp-svckill < 4.0.0
+Requires: pupmod-simp-swap >= 0.1.3, pupmod-simp-swap < 1.0.0
 Requires: pupmod-simp-tcpwrappers >= 6.1.0, pupmod-simp-tcpwrappers < 7.0.0
 Requires: pupmod-simp-tftpboot >= 6.2.0, pupmod-simp-tftpboot < 7.0.0
-Requires: pupmod-simp-tlog >= 0.1.1, pupmod-simp-tlog < 1.0.0
-Requires: pupmod-simp-tuned >= 0.1.0, pupmod-simp-tuned < 1.0.0
-Requires: pupmod-simp-upstart >= 6.0.3, pupmod-simp-upstart < 7.0.0
-Requires: pupmod-simp-useradd >= 0.2.2, pupmod-simp-useradd < 1.0.0
+Requires: pupmod-simp-tlog >= 0.1.2, pupmod-simp-tlog < 1.0.0
+Requires: pupmod-simp-tuned >= 0.1.1, pupmod-simp-tuned < 1.0.0
+Requires: pupmod-simp-upstart >= 6.0.4, pupmod-simp-upstart < 7.0.0
+Requires: pupmod-simp-useradd >= 0.2.3, pupmod-simp-useradd < 1.0.0
 Requires: pupmod-simp-vox_selinux >= 1.6.1, pupmod-simp-vox_selinux < 2.0.0
-Requires: pupmod-simp-xinetd >= 4.1.0, pupmod-simp-xinetd < 5.0.0
+Requires: pupmod-simp-xinetd >= 4.1.1, pupmod-simp-xinetd < 5.0.0
 Requires: pupmod-trlinkin-nsswitch >= 2.1.0, pupmod-trlinkin-nsswitch < 3.0.0
 Requires: rubygem-simp-cli >= 4.4.0, rubygem-simp-cli < 5.0.0
 Requires: rubygem-simp-cli-doc >= 4.4.0, rubygem-simp-cli-doc < 5.0.0
@@ -126,41 +127,42 @@ Requires: simp-adapter >= 0.1.1, simp-adapter < 1.0.0
 Requires: pupmod-herculesteam-augeasproviders_mounttab >= 2.1.1
 Requires: pupmod-herculesteam-augeasproviders_nagios >= 2.1.1
 Requires: pupmod-herculesteam-augeasproviders_pam >= 2.2.1
-Requires: pupmod-vshn-gitlab >= 1.13.3
+Requires: pupmod-puppet-gitlab >= 3.0.2
 Requires: pupmod-puppet-posix_acl >= 0.1.1
 Requires: pupmod-puppet-snmp >= 4.1.0
 Requires: pupmod-puppetlabs-docker >= 3.5.0
 Requires: pupmod-puppetlabs-java >= 2.4.0
 Requires: pupmod-puppetlabs-mysql >= 5.3.0
+Requires: pupmod-puppetlabs-ruby_task_helper >= 0.3.0
 Requires: pupmod-puppetlabs-translate >= 1.2.0
 Requires: pupmod-saz-locales >= 2.5.1
-Requires: pupmod-simp-autofs >= 6.1.2
-Requires: pupmod-simp-dconf >= 0.0.2
+Requires: pupmod-simp-autofs >= 6.1.3
+Requires: pupmod-simp-dconf >= 0.0.3
 Requires: pupmod-simp-freeradius >= 8.0.0
-Requires: pupmod-simp-gdm >= 7.1.0
-Requires: pupmod-simp-gnome >= 8.0.0
+Requires: pupmod-simp-gdm >= 7.1.1
+Requires: pupmod-simp-gnome >= 8.0.1
 Requires: pupmod-simp-hirs_provisioner >= 0.1.0
-Requires: pupmod-simp-ima >= 0.1.0
+Requires: pupmod-simp-ima >= 0.1.1
 Requires: pupmod-simp-journald >= 1.0.0
-Requires: pupmod-simp-krb5 >= 7.0.4
-Requires: pupmod-simp-libreswan >= 3.1.0
-Requires: pupmod-simp-libvirt >= 5.2.0
-Requires: pupmod-simp-mate >= 1.0.1
-Requires: pupmod-simp-mozilla >= 5.1.0
-Requires: pupmod-simp-network >= 6.0.3
-Requires: pupmod-simp-nfs >= 6.2.0
+Requires: pupmod-simp-krb5 >= 7.0.5
+Requires: pupmod-simp-libreswan >= 3.1.1
+Requires: pupmod-simp-libvirt >= 5.2.1
+Requires: pupmod-simp-mate >= 1.0.2
+Requires: pupmod-simp-mozilla >= 5.1.1
+Requires: pupmod-simp-network >= 6.0.4
+Requires: pupmod-simp-nfs >= 6.2.1
 Requires: pupmod-simp-openscap >= 6.2.0
-Requires: pupmod-simp-simp_docker >= 0.2.0
+Requires: pupmod-simp-simp_docker >= 0.2.1
 Requires: pupmod-simp-simp_gitlab >= 0.3.4
-Requires: pupmod-simp-simp_ipa >= 0.0.1
+Requires: pupmod-simp-simp_ipa >= 0.0.2
 Requires: pupmod-simp-simp_nfs >= 0.1.0
-Requires: pupmod-simp-simp_pki_service >= 0.1.1
-Requires: pupmod-simp-simp_snmpd >= 0.1.1
+Requires: pupmod-simp-simp_pki_service >= 0.2.0
+Requires: pupmod-simp-simp_snmpd >= 0.1.2
 Requires: pupmod-simp-tpm >= 3.1.1
-Requires: pupmod-simp-tpm2 >= 0.1.0
+Requires: pupmod-simp-tpm2 >= 0.1.1
 Requires: pupmod-simp-vnc >= 7.0.0
 Requires: pupmod-simp-vsftpd >= 7.2.0
-Requires: pupmod-simp-x2go >= 0.2.0
+Requires: pupmod-simp-x2go >= 0.2.1
 
 # The following line ensures the OBE pupmod-electrical-file_concat
 # package is removed when the simp-extras package is upgraded from
@@ -243,7 +245,7 @@ fi
 # Post uninstall stuff
 
 %changelog
-* Fri Mar 01 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.4.0-0
+* Fri Mar 22 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.4.0-0
 - Updated package versions
 - Moved pupmod-puppetlabs-java from simp to simp-extras, as it is not
   required by any other packages in the simp package
@@ -252,7 +254,12 @@ fi
 - Replaced pupmod-razorsedge-snmp with pupmod-puppet-snmp.
   The Vox Pupuli org has assumed ownership of this project.
 - Replaced pupmod-simp-timezone with pupmod-saz-timezone.
+- Replaced pupmod-vshn-gitlab with pupmod-puppet-gitlab.
+  The Vox Pupuli org has assumed ownership of this project.
+- Added the following to simp
+  - pupmod-simp-rkhunter
 - Added the following to simp-extras
+  - pupmod-puppetlabs-ruby_task_helper
   - pupmod-simp-freeradius
   - pupmod-simp-hirs_provisioner
 - Removed the following from simp-extras because the


### PR DESCRIPTION
- Updated to puppetlabs-stdlib 5.2.0
- Replaced vshn-gitlab 1.13.3 with puppet-gitlab 3.0.2.  Vox Pupuli has
  taken over that module.
- Added pupmod-simp-rkhunter
- Added pupmod-puppetlabs-ruby_task_helper to simp-extras.  This is now
  needed by pupmod-simp-simp_ipa.
- Updated SIMP module versions, primarily to pick up versions that allow
  stdlib 5.2.0.  Some updates are for other bug fixes/new features since
  the last release.

SIMP-4265 #close
SIMP-6238 #close
SIMP-5485 #close