### PR TITLE
(SIMP-6633) reload puppetserver if running in simp %post

### DIFF
--- a/src/assets/simp/build/simp.spec
+++ b/src/assets/simp/build/simp.spec
@@ -229,9 +229,8 @@ if [ -x '%{_usr}/local/sbin/puppetserver_clear_environment_cache' ]; then
   %{_usr}/local/sbin/puppetserver_clear_environment_cache
 fi
 
-if [ -x '%{_usr}/local/sbin/puppetserver_reload' ]; then
-  %{_usr}/local/sbin/puppetserver_reload
-else
+puppet resource service puppetserver | grep -q running
+if [ $? -eq 0 ]; then
   puppetserver reload
 fi
 


### PR DESCRIPTION
Only reload the puppetserver if the puppetserver service is
running. This prevents error messages that lack context from
being spewed during a simp RPM install, when the puppetserver
is not installed or it is installed but not running.

SIMP-6633