### PR TITLE
(SIMP-6652) Add `puppetserver` to ISO install

### DIFF
--- a/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/include/common_ks_base
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/include/common_ks_base
@@ -76,7 +76,8 @@ vlock
 git
 puppet-agent
 rsync
-simp-adapter-foss
+simp-adapter
+puppetserver
 
 # SIMP Server Complete Load
 elinks

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/dvd/include/common_ks_base
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/dvd/include/common_ks_base
@@ -61,8 +61,9 @@ git
 rsync
 
 # Puppet Server Complete Load
-#Make sure adapter for open source puppet is installed
-simp-adapter-foss
+# Make open source puppetserver is installed
+simp-adapter
+puppetserver
 simp
 elinks
 mkisofs


### PR DESCRIPTION
`simp-adapter-foss` no longer requires `puppetserver` (and is no longer
any different from `simp-adapter`), so fresh SIMP ISO installs must now
explicitly include the FOSS `puppetserver` package.

SIMP-6652 #close