### PR TITLE
(SIMP-6653) GPG keys not imported SIMP 6.4.0 Beta ISO

### DIFF
--- a/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/auto.cfg
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/auto.cfg
@@ -266,6 +266,23 @@ fi
 yum clean all;
 yum -y --enablerepo=flocal-$htype --enablerepo=frhbase update;
 
+# Install GPG keys packaged with the ISO
+rpm --import /var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet
+rpm --import /var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs
+rpm --import /var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP-6
+rpm --import /var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP
+rpm --import /var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-PGDG-96
+rpm --import /var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-$majrhversion
+
+if [ -n "$frhbase_gpg_file" ]; then
+  rpm --import `echo $frhbase_gpg_file | sed 's/file:\/\///'`
+fi
+
+if [ -e /var/www/yum/SIMP-Dev/GPGKEYS/RPM-GPG-KEY-SIMP-Dev ]; then
+  rpm --import /var/www/yum/SIMP-Dev/GPGKEYS/RPM-GPG-KEY-SIMP-Dev
+fi
+
+# Create 'simp' user
 pass_hash='$6$1tkixqzp$iihri50cUBpvDcIfq1ieftkj6ToRBrlQutpzP2sdGo5/h6dDfdXvFkmVtODwEJD0W2XYScmKrnkqRnnMEkaRi.'
 
 groupadd -g 1777 simp >& /dev/null;

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/dvd/auto.cfg
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/dvd/auto.cfg
@@ -270,6 +270,23 @@ fi
 yum clean all;
 yum -y --enablerepo=flocal-$htype --enablerepo=frhbase update;
 
+# Install GPG keys packaged with the ISO
+rpm --import /var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppet
+rpm --import /var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-puppetlabs
+rpm --import /var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP-6
+rpm --import /var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-SIMP
+rpm --import /var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-PGDG-96
+rpm --import /var/www/yum/SIMP/GPGKEYS/RPM-GPG-KEY-EPEL-$majrhversion
+
+if [ -n "$frhbase_gpg_file" ]; then
+  rpm --import `echo $frhbase_gpg_file | sed 's/file:\/\///'`
+fi
+
+if [ -e /var/www/yum/SIMP-Dev/GPGKEYS/RPM-GPG-KEY-SIMP-Dev ]; then
+  rpm --import /var/www/yum/SIMP-Dev/GPGKEYS/RPM-GPG-KEY-SIMP-Dev
+fi
+
+# Create 'simp' user
 pass_hash='$6$5SnplwrFxmHy4j/v$WgcZV1.W6/wQq1SJh/gnV7E5Tr1iIuJgdCFmhdlzHnCdWR927Q/Q4eKZXtFAVOY7eNRb3e30ezM5xbmP8G7t50'
 
 groupadd -g 1777 simp >& /dev/null;

--- a/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
@@ -1,4 +1,10 @@
 ---
+HIRS_Provisioner_TPM_1_2:
+  :rpm_name: HIRS_Provisioner_TPM_1_2-1.0.4-1558547257.cedc93.el7.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/HIRS_Provisioner_TPM_1_2-1.0.4-1558547257.cedc93.el7.noarch.rpm/download.rpm
+HIRS_Provisioner_TPM_2_0:
+  :rpm_name: HIRS_Provisioner_TPM_2_0-1.0.4-1.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/HIRS_Provisioner_TPM_2_0-1.0.4-1.x86_64.rpm/download.rpm
 apr-util-ldap:
   :rpm_name: apr-util-ldap-1.5.2-6.el7.x86_64.rpm
   :source: http://mirror.centos.org/centos/7/os/x86_64/Packages/apr-util-ldap-1.5.2-6.el7.x86_64.rpm
@@ -62,12 +68,6 @@ gtk2-engines:
 haveged:
   :rpm_name: haveged-1.9.1-1.el7.x86_64.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/h/haveged-1.9.1-1.el7.x86_64.rpm
-HIRS_Provisioner_TPM_1_2:
-  :rpm_name: HIRS_Provisioner_TPM_1_2-1.0.4-1558547257.cedc93.el7.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/HIRS_Provisioner_TPM_1_2-1.0.4-1558547257.cedc93.el7.noarch.rpm/download.rpm
-HIRS_Provisioner_TPM_2_0:
-  :rpm_name: HIRS_Provisioner_TPM_2_0-1.0.4-1.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/HIRS_Provisioner_TPM_2_0-1.0.4-1.x86_64.rpm/download.rpm
 ima-evm-utils:
   :rpm_name: ima-evm-utils-1.1-2.el7.x86_64.rpm
   :source: http://mirror.centos.org/centos/7/os/x86_64/Packages/ima-evm-utils-1.1-2.el7.x86_64.rpm
@@ -347,9 +347,6 @@ sudosh2:
 tlog:
   :rpm_name: tlog-4-1.el7.x86_64.rpm
   :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/tlog-4-1.el7.x86_64.rpm/download.rpm
-tpm_module:
-  :rpm_name: tpm_module-1.0.4-1558547257.cedc93.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/tpm_module-1.0.4-1558547257.cedc93.x86_64.rpm/download.rpm
 tpm2-abrmd:
   :rpm_name: tpm2-abrmd-1.1.0-10.el7.x86_64.rpm
   :source: http://mirror.centos.org/centos/7/os/x86_64/Packages/tpm2-abrmd-1.1.0-10.el7.x86_64.rpm
@@ -362,6 +359,9 @@ tpm2-tss:
 tpm2-tss-devel:
   :rpm_name: tpm2-tss-devel-1.4.0-2.el7.x86_64.rpm
   :source: http://mirror.centos.org/centos/7/os/x86_64/Packages/tpm2-tss-devel-1.4.0-2.el7.x86_64.rpm
+tpm_module:
+  :rpm_name: tpm_module-1.0.4-1558547257.cedc93.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/tpm_module-1.0.4-1558547257.cedc93.x86_64.rpm/download.rpm
 unhide:
   :rpm_name: unhide-20130526-1.el7.x86_64.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/u/unhide-20130526-1.el7.x86_64.rpm

--- a/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
@@ -1,4 +1,10 @@
 ---
+HIRS_Provisioner_TPM_1_2:
+  :rpm_name: HIRS_Provisioner_TPM_1_2-1.0.4-1558547257.cedc93.el7.noarch.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/HIRS_Provisioner_TPM_1_2-1.0.4-1558547257.cedc93.el7.noarch.rpm/download.rpm
+HIRS_Provisioner_TPM_2_0:
+  :rpm_name: HIRS_Provisioner_TPM_2_0-1.0.4-1.x86_64.rpm
+  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/HIRS_Provisioner_TPM_2_0-1.0.4-1.x86_64.rpm/download.rpm
 apr-util-ldap:
   :rpm_name: apr-util-ldap-1.5.2-6.el7.x86_64.rpm
   :source: Red Hat Optional Repository
@@ -62,12 +68,6 @@ gtk2-engines:
 haveged:
   :rpm_name: haveged-1.9.1-1.el7.x86_64.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/h/haveged-1.9.1-1.el7.x86_64.rpm
-HIRS_Provisioner_TPM_1_2:
-  :rpm_name: HIRS_Provisioner_TPM_1_2-1.0.4-1558547257.cedc93.el7.noarch.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/HIRS_Provisioner_TPM_1_2-1.0.4-1558547257.cedc93.el7.noarch.rpm/download.rpm
-HIRS_Provisioner_TPM_2_0:
-  :rpm_name: HIRS_Provisioner_TPM_2_0-1.0.4-1.x86_64.rpm
-  :source: https://packagecloud.io/simp-project/6_X_Dependencies/packages/el/7/HIRS_Provisioner_TPM_2_0-1.0.4-1.x86_64.rpm/download.rpm
 incron:
   :rpm_name: incron-0.5.10-8.el7.x86_64.rpm
   :source: https://download.simp-project.com/simp/packages/CentOS/el/7/x86_64/incron-0.5.10-8.el7.x86_64.rpm


### PR DESCRIPTION
- Import the GPG keys delivered with the SIMP ISO during
  the installation
- Updated el7 packages.yaml to order the HIRS RPMs in the
  same fashion as simp-rake-helpers expects (and 'fixes').
  Did not do this for el6 packages.yaml files, because
  simp-rake-helpers removes the HIRS entries instead
  of reordering!

SIMP-6653 #close