### PR TITLE
(SIMP-4046) ISO password validation settings incorrect

### DIFF
--- a/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/auto.cfg
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/dvd/auto.cfg
@@ -291,10 +291,10 @@ usermod -aG wheel simp;
 chage -d 0 root;
 chage -d 0 simp;
 
-pam_mod="password     requisite     pam_cracklib.so try_first_pass difok=4 retry=3 minlen=14 minclass=3 maxrepeat=2 maxsequence=4 dcredit=-1 ucredit=-1 lcredit=-1 ocredit=-1 gecoscheck reject_username enforce_for_root\n"
+pam_mod="password     requisite     pam_cracklib.so try_first_pass difok=4 retry=3 minlen=15 minclass=3 maxrepeat=2 maxsequence=4 maxclassrepeat=3 dcredit=-1 ucredit=-1 lcredit=-1 ocredit=-1 gecoscheck reject_username enforce_for_root\n"
 for auth_file in password system; do
   # A double check to make sure we're not running this on a managed system...
-  if [ -f /etc/pam.d/${auth_file}-auth ] && [ ! `grep -q 'Puppet' /etc/pam.d/${auth_file}-auth` ]; then
+  if [ -f /etc/pam.d/${auth_file}-auth ] && [ -z `grep 'Puppet' /etc/pam.d/${auth_file}-auth` ]; then
     # Remove the items that will double prompt us out of the box
     sed -i "/pam_\(pwquality\|cracklib\).so/d" /etc/pam.d/${auth_file}-auth
     # Add our cracklib line

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/dvd/auto.cfg
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/dvd/auto.cfg
@@ -295,16 +295,34 @@ usermod -aG wheel simp;
 chage -d 0 root;
 chage -d 0 simp;
 
-pam_mod="password     requisite     pam_cracklib.so try_first_pass difok=4 retry=3 minlen=14 minclass=3 maxrepeat=2 maxsequence=4 dcredit=-1 ucredit=-1 lcredit=-1 ocredit=-1 gecoscheck reject_username enforce_for_root\n"
+pam_mod="password     requisite     pam_pwquality.so try_first_pass retry=3 reject_username enforce_for_root\n"
 for auth_file in password system; do
   # A double check to make sure we're not running this on a managed system...
-  if [ -f /etc/pam.d/${auth_file}-auth ] && [ ! `grep -q 'Puppet' /etc/pam.d/${auth_file}-auth` ]; then
+  if [ -f /etc/pam.d/${auth_file}-auth ] && [ -z `grep 'Puppet' /etc/pam.d/${auth_file}-auth` ]; then
     # Remove the items that will double prompt us out of the box
     sed -i "/pam_\(pwquality\|cracklib\).so/d" /etc/pam.d/${auth_file}-auth
     # Add our cracklib line
     sed -i "s/\(password.*pam_unix.so.*\)/${pam_mod}\1/" /etc/pam.d/${auth_file}-auth
   fi
 done
+
+if [ ! -f /etc/security/pwquality.conf ]  || [[ -f /etc/security/pwquality.conf  &&  -z `grep  'Puppet' /etc/security/pwquality.conf` ]]; then
+  cat <<EOF > /etc/security/pwquality.conf
+difok = 4
+minlen = 15
+dcredit = -1
+ucredit = -1
+lcredit = -1
+ocredit = -1
+minclass = 3
+maxrepeat = 2
+maxclassrepeat = 3
+maxsequence = 4
+gecoscheck = 1
+EOF
+fi
+
+chmod 0644 /etc/security/pwquality.conf
 
 simp_opt=`awk -F "simp_opt=" '{print $2}' /proc/cmdline | cut -f1 -d' '`
 


### PR DESCRIPTION
- Updated auto.cfg for el6 so that the pam_cracklib.so lines in
  /etc/pam.d/password-auth and /etc/pam.d/system-auth match the
  pupmod-simp-pam module default settings for SIMP 6.4.0.
- Updated auto.cfg for el7 so that the pam_pwquality.so lines in
  /etc/pam.d/password-auth and /etc/pam.d/system-auth and the
  corresponding configuration in /etc/security/pwquality.conf
  match the pupmod-simp-pam module default settings for SIMP 6.4.0.

SIMP-4046 #close