### PR TITLE
(SIMP-6712) Get ipa acceptance test working

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,6 +39,12 @@ image: 'ruby:2.4'
     variables:
       - $SIMP_FULL_MATRIX
 
+.only_with_SIMP_FULL_MATRIX_or_SIMP_IPA_TEST: &only_with_SIMP_FULL_MATRIX_or_SIMP_IPA_TEST
+  only:
+    variables:
+      - $SIMP_FULL_MATRIX
+      - $SIMP_IPA_TEST
+
 default_el6-puppet5:
   stage: integration
   image: 'ruby:2.4'
@@ -77,7 +83,7 @@ ipa_el7-puppet5:
     - beaker
   <<: *cache_bundler
   <<: *setup_bundler_env
-  <<: *only_with_SIMP_FULL_MATRIX
+  <<: *only_with_SIMP_FULL_MATRIX_or_SIMP_IPA_TEST
   variables:
     PUPPET_VERSION: '~> 5.5'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
@@ -94,6 +100,7 @@ ipa_el7-puppet5:
 #     - beaker
 #   <<: *cache_bundler
 #   <<: *setup_bundler_env
+#   <<: *only_with_SIMP_FULL_MATRIX_or_SIMP_IPA_TEST
 #   variables:
 #     PUPPET_VERSION: '~> 5.5'
 #     BEAKER_PUPPET_COLLECTION: 'puppet5'
@@ -143,7 +150,7 @@ ipa_oel7-puppet5:
     - beaker
   <<: *cache_bundler
   <<: *setup_bundler_env
-  <<: *only_with_SIMP_FULL_MATRIX
+  <<: *only_with_SIMP_FULL_MATRIX_or_SIMP_IPA_TEST
   variables:
     PUPPET_VERSION: '~> 5.5'
     BEAKER_PUPPET_COLLECTION: 'puppet5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
       hocon (~> 1.0)
       require_all (~> 1.3.2)
       stringify-hash (~> 0.0.0)
-    beaker-docker (0.5.3)
+    beaker-docker (0.5.4)
       docker-api
       stringify-hash (~> 0.0.0)
     beaker-hostgenerator (1.1.32)
@@ -39,7 +39,7 @@ GEM
       beaker-puppet (~> 1.0)
       beaker-vmpooler (~> 1.0)
       stringify-hash (~> 0.0.0)
-    beaker-puppet (1.18.5)
+    beaker-puppet (1.18.6)
       beaker (~> 4.1)
       in-parallel (~> 0.1)
       oga
@@ -239,7 +239,7 @@ GEM
       json (~> 1)
       rspec-puppet-facts (~> 0)
     spdx-licenses (1.2.0)
-    specinfra (2.78.2)
+    specinfra (2.79.0)
       net-scp
       net-ssh (>= 2.7)
       net-telnet (= 0.1.1)
@@ -267,7 +267,7 @@ DEPENDENCIES
   pry
   pry-byebug
   pry-doc
-  puppet (~> 5.5)
+  puppet (= 5.5.14)
   puppet-lint
   puppet-strings
   puppetlabs_spec_helper

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
       beaker-puppet (~> 1.0)
       beaker-vmpooler (~> 1.0)
       stringify-hash (~> 0.0.0)
-    beaker-puppet (1.18.6)
+    beaker-puppet (1.18.7)
       beaker (~> 4.1)
       in-parallel (~> 0.1)
       oga
@@ -69,7 +69,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.4)
     excon (0.64.0)
-    facter (2.5.4)
+    facter (2.5.5)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.12.2)
@@ -144,7 +144,7 @@ GEM
       puppet (>= 2.7.16)
       rest-client (~> 1.8.0)
     puppet-lint (2.3.6)
-    puppet-strings (2.2.0)
+    puppet-strings (2.3.0)
       rgen
       yard (~> 0.9.5)
     puppet-syntax (2.5.0)

--- a/spec/acceptance/common_files/simp_conf.yaml_no_ldap.erb
+++ b/spec/acceptance/common_files/simp_conf.yaml_no_ldap.erb
@@ -1,0 +1,242 @@
+#========================================================================
+# simp config answers
+#
+# Generated for 'simp' scenario on 2019-05-23 20:42:35
+#------------------------------------------------------------------------
+# You can use these answers to quickly configure subsequent
+# simp installations by running the command:
+#
+#   simp config -A /PATH/TO/THIS/FILE
+#
+# simp config will prompt for any missing items.
+#
+# NOTE:
+# - All YAML keys that begin with 'cli::' are used by
+#   simp config, internally, and are not Puppet hieradata.
+#========================================================================
+---
+# === cli::version ===
+# The version of simp-cli used to generate this file.
+cli::version: "5.0.0"
+
+# === cli::is_simp_ldap_server ===
+# Whether the SIMP server will also be a SIMP-provided LDAP server.
+#
+# Enter 'yes' if want to use SIMP-provided LDAP and have the SIMP
+# server also be the LDAP server.
+#
+# Enter 'no' if you do not want to use LDAP, you want to use some other
+# LDAP implementation, or you want to set up SIMP-provided LDAP in a
+# different configuration.  In these cases, you will need to set up
+# appropriate central authentication services manually before or
+# after bootstrapping.
+cli::is_simp_ldap_server: false
+
+# === cli::network::gateway ===
+# The default gateway.
+# TODO Remove this when SIMP-6625 is completed.  This value is not actually
+# required by simp config when cli::set_up_nic is false.
+cli::network::gateway: 1.2.3.4
+
+# === cli::network::hostname ===
+# The Fully Qualified Domain Name (FQDN) of the system.
+#
+# This *MUST* contain a domain. Simple hostnames are not allowed.
+cli::network::hostname: <%= master_fqdn %>
+
+# === cli::network::interface ===
+# The network interface to use to connect the SIMP server to the network.
+cli::network::interface: <%= interface %>
+
+# === cli::network::ipaddress ===
+# The IP address of the system.
+cli::network::ipaddress: <%= ipaddress %>
+
+# === cli::network::netmask ===
+# The netmask of the system.
+cli::network::netmask: <%= netmask %>
+
+# === cli::network::set_up_nic ===
+# Whether to configure and activate this NIC now. A properly configured
+# NIC with associated hostname is required for SIMP to be bootstrapped.
+#
+# If you enter 'yes', this will immediately, with appropriate prompts for
+# networking information, do the following:
+# - Configure the NIC for static or DHCP operation
+# - Set the hostname associated with the NIC
+# - **RESET** the interface to ensure proper activation of the NIC.
+#
+# If you enter 'no', this will prompt you to enter all the NIC's networking
+# information, including the hostname, and `simp config` will **ASSUME** the
+# network has been configured and activated.
+#
+# You should enter 'yes' if the interface has not yet been configured.
+# You may want to enter 'yes', if you want to reconfigure it and are **NOT**
+# logged into the server via this interface.
+#
+cli::network::set_up_nic: false
+
+# === cli::set_grub_password ===
+# Whether to set the GRUB password on this system.
+cli::set_grub_password: true
+
+# === cli::simp::scenario ===
+# The SIMP scenario: Predetermined set of security features to apply.
+#
+# 'simp'      = Settings for a full SIMP system. Both the SIMP server
+#               (this host) and all clients will be running with
+#               all security features enabled.
+# 'simp_lite' = Settings for a SIMP system in which some security features
+#               are disabled for SIMP clients.  The SIMP server will
+#               be running with all security features enabled.
+# 'poss'      = Settings for a SIMP system in which all security features
+#               for the SIMP clients are disabled.  The SIMP server will
+#               be running with all security features enabled.
+#
+# NOTE:  If your site has different needs than provided by the predetermined
+# scenarios, you can always fine-tune the security settings after you have
+# bootstrapped your SIMP server.
+cli::simp::scenario: simp
+
+# === cli::use_internet_simp_yum_repos ===
+# Whether to configure SIMP nodes to use internet SIMP and
+# SIMP dependency YUM repositories.
+#
+# When this option is enabled, Puppet-managed, YUM repository
+# configurations will be created for both the SIMP server and
+# SIMP clients. These configurations will point to official
+# SIMP repositories.
+cli::use_internet_simp_yum_repos: false
+
+# === grub::password ===
+# The password to access GRUB.
+#
+# The value entered is used to set the GRUB password and to generate a hash
+# stored in grub::password.
+grub::password: "<%= grub_password_hash %>"
+
+# === puppetdb::master::config::puppetdb_port ===
+# The PuppetDB server port number.
+puppetdb::master::config::puppetdb_port: 8139
+
+# === puppetdb::master::config::puppetdb_server ===
+# The DNS name or IP of the PuppetDB server.
+puppetdb::master::config::puppetdb_server: "%{hiera('simp_options::puppet::server')}"
+
+# === simp::runlevel ===
+# The default system runlevel (1-5).
+simp::runlevel: 3
+
+
+# === simp_options::dns::search ===
+# The DNS domain search string.
+#
+# Remember to put these in the appropriate order for your environment!
+simp_options::dns::search: [ <%= domain %> ]
+
+# === simp_options::dns::servers ===
+# A list of DNS servers for the managed hosts.
+#
+# If the first entry of this list is set to '127.0.0.1', then
+# all clients will configure themselves as caching DNS servers
+# pointing to the other entries in the list.
+#
+# If you have a system that's including the 'named' class and
+# is *not* in this list, then you'll need to set a variable at
+# the top of that node entry called $named_server to 'true'.
+# This will get around the convenience logic that was put in
+# place to handle the caching entries and will not attempt to
+# convert your system to a caching DNS server. You'll know
+# that you have this situation if you end up with a duplicate
+# definition for File['/etc/named.conf'].
+simp_options::dns::servers: [ <%= nameserver %> ]
+
+
+# === simp_options::ntpd::servers ===
+# Your network's NTP time servers.
+#
+# A consistent time source is critical to a functioning public key
+# infrastructure, and thus your site security. **DO NOT** attempt to
+# run multiple production systems using individual hardware clocks!
+#
+# For many networks, the default gateway (10.0.2.2) provides an NTP server.
+simp_options::ntpd::servers:
+- 0.pool.ntp.org
+- 1.pool.ntp.org
+- 2.pool.ntp.org
+- 3.pool.ntp.org
+
+# === simp_options::puppet::ca ===
+# The Puppet Certificate Authority.
+simp_options::puppet::ca: <%= master_fqdn %>
+
+# === simp_options::puppet::ca_port ===
+# The port on which the Puppet Certificate Authority will listen
+# (8141 by default).
+simp_options::puppet::ca_port: 8141
+
+# === simp_options::puppet::server ===
+# The Hostname or FQDN of the Puppet server.
+simp_options::puppet::server: <%= master_fqdn %>
+
+# === simp_options::syslog::failover_log_servers ===
+# Failover log server(s) in case your log servers(s) fail.
+simp_options::syslog::failover_log_servers: []
+
+# === simp_options::syslog::log_servers ===
+# The log server(s) to receive forwarded logs.
+#
+# No log forwarding is enabled when this list is empty.  Only use hostnames
+# here if at all possible.
+simp_options::syslog::log_servers: <%= (syslog_server_fqdns.nil? or syslog_server_fqdns.empty?) ? '[]': '[ ' + syslog_server_fqdns.join(', ') + ' ]' %>
+
+# === simp_options::trusted_nets ===
+# A list of subnets to permit, in CIDR notation.
+#
+# If you need this to be more (or less) restrictive for a given class,
+# you can override it in Hiera.
+simp_options::trusted_nets: <%= (trusted_nets.nil? or trusted_nets.empty?) ? '[]': '[ ' + trusted_nets.join(', ') + ' ]' %>
+
+# === sssd::domains ===
+# A list of domains for SSSD to use.
+#
+# * When you are using SIMP-provided LDAP, this field should include `LDAP`,
+#   the name of the SSSD domain SIMP creates.
+# * Otherwise, this field must be a valid domain ('Local' and/or a custom
+#   domain) or the sssd service will fail to start.
+#
+sssd::domains:
+- Local
+
+# === svckill::mode ===
+# Strategy svckill should use when it encounters undeclared services.
+#
+# 'enforcing' = Shut down and disable all services not listed in your
+#               manifests or the exclusion file
+# 'warning'   = Only report what undeclared services should be shut
+#               down and disabled, without actually making the changes
+#               to the system
+#
+# NOTICE: svckill is the mechanism that SIMP uses to comply with the
+# requirement that no unauthorized services are running on your system.
+# If you are fully aware of all services that need to be running on the
+# system, including any custom applications, use 'enforcing'.  If you
+# first need to ascertain which services should be running on the system,
+# use 'warning'.
+svckill::mode: warning
+
+# === useradd::securetty ===
+# A list of TTYs for which the root user can login.
+#
+# When useradd::securetty is an empty list, the system will satisfy FISMA
+# regulations, which require root login via any TTY (including the console)
+# to be disabled.  For some systems, the inability to login as root via the
+# console is problematic.  In that case, you may wish to include at least
+# tty0 to the list of allowed TTYs, despite the security risk.
+#
+useradd::securetty:
+- tty0
+- tty1
+- tty2
+- tty3
+

--- a/spec/acceptance/common_files/site/manifests/ipa.pp
+++ b/spec/acceptance/common_files/site/manifests/ipa.pp
@@ -1,0 +1,12 @@
+class site::ipa(
+) {
+
+  # Open up ports for IPA
+  iptables::listen::udp { 'allow_ipa_server_connections':
+    dports => [ 53, 88, 123, 464 ]
+  }
+
+  iptables::listen::tcp_stateful { 'allow_ipa_server_connections':
+    dports => [ 53, 80, 88, 389, 443, 464, 636 ]
+  }
+}

--- a/spec/acceptance/helpers/ipa_helper.rb
+++ b/spec/acceptance/helpers/ipa_helper.rb
@@ -1,0 +1,37 @@
+module Acceptance
+  module Helpers
+    module IpaHelper
+
+      # NOTE:  The passwords below will be enclosed in single quotes when used
+      #        on the shell command line. So, to simplify the code that uses
+      #        them, these passwords should not contain single quotes.
+
+      # returns IPA 'admin' password
+      def ipa_admin_password
+        'ipA=@dm1n=P@ssw0r!'
+      end
+
+      # returns IPA directory service password
+      def ipa_directory_service_password
+        'd1r3ct0ry=P@ssw0r!'
+      end
+
+      # returns one-time enrollment passwords assigned to all hosts
+      def ipa_bulk_enroll_password
+        'en0llm3nt=p@ssWor^'
+      end
+
+      # execute an IPA command with 'admin' privileges
+      # +host+: the IPA Host object
+      # +cmd+:  the command to be executed
+      def run_ipa_cmd(host, cmd)
+        on(host, "echo \"#{ipa_admin_password}\" | kinit admin")
+        result = on(host, cmd)
+        on(host, 'kdestroy')
+
+        result
+      end
+
+    end
+  end
+end

--- a/spec/acceptance/suites/default/40_simp_cli_spec.rb
+++ b/spec/acceptance/suites/default/40_simp_cli_spec.rb
@@ -76,16 +76,15 @@ describe 'simp cli operations' do
       # the puppetserver!)
     end
 
-    it 'agents should still communicate with the puppetserver' do
+    it 'should re-establish connectivity' do
       agents.each do |agent|
         # FIXME For some reason, beaker's ssh connection can die on the first
         # puppet agent run for a client, even though logs on the client show
-        # no problems and puppet does not detect any changes. For the purposes
-        # of this test, we really only care that any puppet agent run after
-        # the re-bootstrap works. So, we'll retry up to 3 times.
+        # no problems and puppet does not detect any changes.  So, we'll retry
+        # up to 3 times.
         tries = 3
         begin
-          on(agent, 'puppet agent -t')
+          on(agent, 'uptime')
         rescue Beaker::Host::CommandFailure => e
           if e.message.include?('connection failure') && (tries > 0)
             puts "Retrying due to << #{e.message.strip} >>"
@@ -96,6 +95,10 @@ describe 'simp cli operations' do
           end
         end
       end
+    end
+
+    it 'agents should still communicate with the puppetserver' do
+      on(agents, 'puppet agent -t', :catch_failures => true)
     end
   end
 

--- a/spec/acceptance/suites/install_from_rpm/00_simp_server_install_spec.rb
+++ b/spec/acceptance/suites/install_from_rpm/00_simp_server_install_spec.rb
@@ -35,7 +35,6 @@ describe 'Install SIMP modules and assets via RPM from internet repos' do
     end
 
     it 'should install simp module and asset RPMs and create local Git module repos' do
-      master.install_package('simp-adapter')
       master.install_package('simp')
     end
   end

--- a/spec/acceptance/suites/install_from_tar/00_simp_server_install_spec.rb
+++ b/spec/acceptance/suites/install_from_tar/00_simp_server_install_spec.rb
@@ -43,7 +43,6 @@ describe 'Install SIMP modules and assets via release tarball' do
     end
 
     it 'should install simp module and asset RPMs and create local Git module repos' do
-      master.install_package('simp-adapter')
       master.install_package('simp')
     end
   end

--- a/spec/acceptance/suites/ipa/01_simp_server_bootstrap_spec.rb
+++ b/spec/acceptance/suites/ipa/01_simp_server_bootstrap_spec.rb
@@ -1,1 +1,41 @@
-../default/01_simp_server_bootstrap_spec.rb
+require 'spec_helper_integration'
+
+test_name 'Configure and bootstrap SIMP puppetserver'
+
+# facts gathered here are executed when the file first loads and
+# use the factor gem temporarily installed into system ruby
+master              = only_host_with_role(hosts, 'master')
+master_fqdn         = fact_on(master, 'fqdn')
+syslog_servers      = hosts_with_role(hosts, 'syslog_server')
+syslog_server_fqdns = syslog_servers.map { |server| fact_on(server, 'fqdn') }
+domain              = fact_on(master, 'domain')
+
+describe 'Configure and bootstrap SIMP puppetserver with pre-populated SIMP OMNI env & excluding SIMP LDAP server' do
+
+  config = {
+    :domain                 => domain,
+    :master_fqdn            => master_fqdn,
+    :syslog_server_fqdns    => syslog_server_fqdns,
+
+    # we've already created the environment and deployed the modules
+    :simp_config_extra_args => [ '--force-config' ],
+
+    # we're going to use IPA for user accounts
+    :simp_ldap_server       => false,
+    :other_hieradata        => {
+      # We have to turn on LDAP support manually.  It is not
+      # enabled by default in the 'simp' or 'simp_lite' scenarios.
+      'simp_options::ldap'            => true,
+
+      # The following parameters are required by simp_options::ldap, even
+      # though they are **not** # currently used. (IPA doesn't come with
+      # native BIND or SYNC DNs.)
+      'simp_options::ldap::bind_hash' => '{SSHA}zzIihXlCUh9ejl6mGhIPyvIfG8I8yTsL',
+      'simp_options::ldap::bind_pw'   => 'm-Y2PFhrUE6Y.dx0joLicL%IUm5I9TtO',
+      'simp_options::ldap::sync_hash' => '{SSHA}oeKnIem05NR8lTVonEdj+TBIryxdhNal',
+      'simp_options::ldap::sync_pw'   => 'OLIffaIr5pkZgvLYfqR%2W6+VtQvlAjy'
+    }
+  }
+
+  include_examples 'SIMP server bootstrap', master, config
+end

--- a/spec/acceptance/suites/ipa/10_ipa_server_spec.rb
+++ b/spec/acceptance/suites/ipa/10_ipa_server_spec.rb
@@ -9,7 +9,6 @@ describe 'set up an IPA server' do
   ipa_server = hosts_with_role(hosts, 'ipa_server').first
   domain     = fact_on(master, 'domain')
 
-  admin_password = '@dm1n=P@ssw0r'
   ipa_domain     = domain
   ipa_realm      = ipa_domain.upcase
   ipa_fqdn       = fact_on(ipa_server, 'fqdn')
@@ -37,9 +36,10 @@ describe 'set up an IPA server' do
     end
 
     it 'should make sure the hostname is fully qualified' do
+      # TODO Is this additional configuration required?  We already set
+      #   the hostname in the basic setup.  This does more by replacing
+      #   the entire contents of the /etc/sysconfig/network file.
       fqdn = "#{ipa_server}.#{domain}"
-      on(ipa_server, "hostname #{fqdn}")
-      create_remote_file(ipa_server, '/etc/hostname', fqdn)
       create_remote_file(ipa_server, '/etc/sysconfig/network', <<-EOF.gsub(/^\s+/,'')
           NETWORKING=yes
           HOSTNAME=#{fqdn}
@@ -59,10 +59,25 @@ describe 'set up an IPA server' do
     end
   end
 
-  context 'classify nodes' do
-    it 'modify the existing hieradata' do
-      hiera = YAML.load(on(master, 'cat /etc/puppetlabs/code/environments/production/data/default.yaml').stdout)
-      default_yaml = hiera.merge(
+  context 'configure nodes for the IPA services' do
+    let(:files_dir) { 'spec/acceptance/common_files' }
+    let(:site_module_path) {
+      '/etc/puppetlabs/code/environments/production/modules/site'
+    }
+
+    let(:default_yaml_filename) {
+      '/etc/puppetlabs/code/environments/production/data/default.yaml'
+    }
+
+    it 'should install a manifest to allow ports for IPA services' do
+      # grab the whole site module even though we will only use site::ipa
+      rsync_to(master, "#{files_dir}/site", site_module_path)
+      on(master, 'simp environment fix production --no-secondary-env --no-writable-env')
+    end
+
+    it 'should update default hiera to use IPA for DNS, to use IPA domain in sssd, to allow ports for IPA services' do
+      hiera = YAML.load(on(master, "cat #{default_yaml_filename}").stdout)
+      updated_hiera = hiera.merge( {
         'simp_options::sssd'           => true,
         'simp_options::ldap'           => true,
         'simp_options::dns::servers'   => [ipa_ip],
@@ -70,46 +85,19 @@ describe 'set up an IPA server' do
         'sssd::domains'                => ['LOCAL',ipa_domain],
         'resolv::named_autoconf'       => false,
         'resolv::caching'              => false,
-        'resolv::resolv_domain'        => ipa_domain,
-        'pam::access::users'           => {
-          'defaults'   => {
-            'origins'    => ['ALL'],
-            'permission' => '+'
-          },
-          'vagrant'      => nil,
-          'testuser'     => nil,
-          '(posixusers)' => nil,
-        },
-        'ssh::server::conf::passwordauthentication' => true,
-        'sudo::user_specifications' => {
-          'vagrant_sudo_nopasswd' => {
-            'user_list' => ['vagrant'],
-            'cmnd'      => ['ALL'],
-            'runas'     => 'root',
-            'passwd'    => false,
-          }
-        }
-      ).to_yaml
-      create_remote_file(master, '/etc/puppetlabs/code/environments/production/data/default.yaml', default_yaml)
+        'resolv::resolv_domain'        => ipa_domain
+      } )
+
+      # open up ports in iptables for IPA services
+      updated_hiera['classes'] = [] unless updated_hiera.has_key?('classes')
+      updated_hiera['classes'] << 'site::ipa'
+
+      default_yaml = updated_hiera.to_yaml
+      create_remote_file(master, default_yaml_filename, default_yaml)
+      on(master, "cat #{default_yaml_filename}")
     end
 
-    it 'should open ports' do
-      pp = <<-EOF
-        iptables::listen::udp { 'ipa server':
-          dports => [53,88,123,464]
-        }
-        iptables::listen::tcp_stateful { 'ipa server':
-          dports => [53,80,88,389,443,464,636]
-        }
-      EOF
-      create_remote_file(master, '/etc/puppetlabs/code/environments/production/manifests/ipa-iptables.pp', pp)
-      on(master, 'chown root.puppet /etc/puppetlabs/code/environments/production/manifests/*')
-      on(master, 'chmod g+rX /etc/puppetlabs/code/environments/production/manifests/*')
-    end
-  end
-
-  context 'should run puppet to apply above changes' do
-    it 'set up and run puppet' do
+    it 'should apply the configuration' do
       block_on(agents, :run_in_parallel => false) do |agent|
         retry_on(agent, 'puppet agent -t',
           :desired_exit_codes => [0],
@@ -122,7 +110,7 @@ describe 'set up an IPA server' do
   end
 
   context 'IPA server prep' do
-    it 'should bootstrap the IPA server' do
+    it 'should bootstrap the IPA server that will also provide DNS' do
       # remove existing ldap client configuration
       on(ipa_server, 'mv /etc/openldap/ldap.conf{,.bak}', :accept_all_exit_codes => true)
       on(ipa_server, 'mv /root/.ldaprc{,.bak}', :accept_all_exit_codes => true)
@@ -138,8 +126,8 @@ describe 'set up an IPA server' do
       cmd << '--auto-reverse' if ipa_server.host_hash[:platform] =~ /el-7/
       cmd << "--hostname=#{ipa_fqdn}"
       cmd << "--ip-address=#{ipa_ip}"
-      cmd << '--ds-password="d1r3ct0ry=P@ssw0r"'
-      cmd << "--admin-password='#{admin_password}'"
+      cmd << "--ds-password='#{ipa_directory_service_password}'"
+      cmd << "--admin-password='#{ipa_admin_password}'"
 
       puts "\e[1;34m>>>>> The next step takes a very long time ... Please be patient! \e[0m"
       on(ipa_server, cmd.join(' '))

--- a/spec/acceptance/suites/ipa/nodesets/el6_server.yml
+++ b/spec/acceptance/suites/ipa/nodesets/el6_server.yml
@@ -49,6 +49,7 @@ HOSTS:
   agent-el6:
     roles:
       - agent
+      - syslog_server
       - ipa_client
     platform:   el-6-x86_64
     box:        <%= box_6 %>

--- a/spec/acceptance/suites/ipa/nodesets/el7_server.yml
+++ b/spec/acceptance/suites/ipa/nodesets/el7_server.yml
@@ -41,6 +41,7 @@ HOSTS:
   agent-el7:
     roles:
       - agent
+      - syslog_server
       - ipa_client
     platform:   el-7-x86_64
     box:        <%= box_7 %>

--- a/spec/spec_helper_integration.rb
+++ b/spec/spec_helper_integration.rb
@@ -7,6 +7,7 @@ require_relative 'acceptance/shared_examples'
 
 include Simp::BeakerHelpers
 include Acceptance::Helpers::ExpectScriptHelper
+include Acceptance::Helpers::IpaHelper
 include Acceptance::Helpers::PasswordHelper
 include Acceptance::Helpers::PuppetHelper
 include Acceptance::Helpers::RepoHelper


### PR DESCRIPTION
- Finished work to use default suite SIMP server/client initial
  set up actions
- Tidied up the ipa test code and added clarifying comments
- Removed unnecessary install of 'simp-adapter' in other suites
- Added ability to run 'ipa' acceptance tests in GitLab without
  the full matrix of 'default' tests.  (Still runs 2 'default'
  test permutations...just not all of them).

**KNOWN PROBLEMS**
Any of the simp-core tests can fail at any time because of an unexpected
IO close error.  See SIMP-6863

SIMP-6712 #close