### PR TITLE
(SIMP-7834) Update Gemfile deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,18 +3,7 @@
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
-
 gem_sources.each { |gem_source| source gem_source }
-
-# In offline CI environments, the only copy of simp-rake-helpers will be in the
-# local source tree.  Unless the SIMP_NO_LOCAL_RAKE_HELPERS environment variable
-# is set, that path will be loaded if persent
-simp_rake_helpers_opts = {}
-path = './src/rubygems/simp-rake-helpers'
-if File.directory?( path ) && ENV.fetch( 'SIMP_NO_LOCAL_RAKE_HELPERS', false )
-  simp_rake_helpers_opts = { :path => path }
-end
-
 
 # mandatory gems
 gem 'coderay'
@@ -29,12 +18,12 @@ gem 'net-telnet'
 gem 'rake'
 gem 'ruby-progressbar'
 gem 'simp-build-helpers', ENV.fetch('SIMP_BUILD_HELPERS_VERSION', '>= 0.1.0')
-gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.9.1', '< 6.0'])
+gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.11.1', '< 6.0'])
 
 group :system_tests do
   gem 'nokogiri'
   gem 'beaker', (ENV['SIMP_BEAKER_VERSION']||nil)
-  gem 'beaker-rspec'
+  gem 'beaker-rspec', (ENV['SIMP_BEAKER_RSPEC_VERSION']||nil)
   gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.15.1', '< 2.0'])
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ansi (1.5.0)
     ast (2.4.1)
-    beaker (4.25.0)
+    beaker (4.26.0)
       beaker-hostgenerator
       hocon (~> 1.0)
       in-parallel (~> 0.1)
@@ -28,7 +28,7 @@ GEM
     beaker-docker (0.7.0)
       docker-api
       stringify-hash (~> 0.0.0)
-    beaker-hostgenerator (1.2.5)
+    beaker-hostgenerator (1.2.6)
       deep_merge (~> 1.0)
       stringify-hash (~> 0.0.0)
     beaker-pe (2.11.4)
@@ -60,7 +60,7 @@ GEM
     colored2 (3.1.2)
     cri (2.15.10)
     deep_merge (1.2.1)
-    diff-lcs (1.3)
+    diff-lcs (1.4.2)
     docker-api (1.34.2)
       excon (>= 0.47.0)
       multi_json
@@ -147,7 +147,7 @@ GEM
     puppet-strings (2.4.0)
       rgen
       yard (~> 0.9.5)
-    puppet-syntax (3.0.1)
+    puppet-syntax (3.1.0)
       puppet (>= 5)
       rake
     puppet_forge (2.3.4)
@@ -214,7 +214,7 @@ GEM
       rspec-its
       specinfra (~> 2.72)
     sfl (2.3)
-    simp-beaker-helpers (1.18.4)
+    simp-beaker-helpers (1.18.6)
       beaker (>= 4.17.0, < 5.0.0)
       beaker-docker (~> 0.3)
       beaker-puppet (>= 1.18.14, < 2.0.0)
@@ -280,7 +280,7 @@ DEPENDENCIES
   ruby-progressbar
   simp-beaker-helpers (>= 1.15.1, < 2.0)
   simp-build-helpers (>= 0.1.0)
-  simp-rake-helpers (>= 5.9.1, < 6.0)
+  simp-rake-helpers (>= 5.11.1, < 6.0)
 
 BUNDLED WITH
-   1.17.3
+   1.16.6


### PR DESCRIPTION
This patch:

* Updates simp-rake-helpers to >= 5.11.1 to prevent RPM build failures
  during development for modules with the prerelease suffix `-rc0`
* Removes the obsolete offline CI logic
* Updates Gemfile.lock to reflect the recent changes

[SIMP-7834] [SIMP-7839] #close

[SIMP-7834]: https://simp-project.atlassian.net/browse/SIMP-7834
[SIMP-7839]: https://simp-project.atlassian.net/browse/SIMP-7839