### PR TITLE
(SIMP-7840) Match ruby version in build containers

### DIFF
--- a/build/Dockerfiles/SIMP_EL6_Build.dockerfile
+++ b/build/Dockerfiles/SIMP_EL6_Build.dockerfile
@@ -92,8 +92,8 @@ RUN runuser build_user -l -c "for i in {1..5}; do { gpg2 --keyserver  hkp://pool
 RUN runuser build_user -l -c "for i in {1..5}; do { gpg2 --keyserver  hkp://pool.sks-keyservers.net --recv-keys 7D2BAF1CF37B13E2069D6956105BD0E739499BDB || gpg2 --keyserver hkp://pgp.mit.edu --recv-keys 7D2BAF1CF37B13E2069D6956105BD0E739499BDB || gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 7D2BAF1CF37B13E2069D6956105BD0E739499BDB; } && break || sleep 1; done"
 #RUN runuser build_user -l -c "gpg2 --refresh-keys"
 RUN runuser build_user -l -c "curl -sSL https://raw.githubusercontent.com/rvm/rvm/stable/binscripts/rvm-installer -o rvm-installer && curl -sSL https://raw.githubusercontent.com/rvm/rvm/stable/binscripts/rvm-installer.asc -o rvm-installer.asc && gpg2 --verify rvm-installer.asc rvm-installer && bash rvm-installer"
-RUN runuser build_user -l -c "rvm install 2.4.5 --disable-binary"
-RUN runuser build_user -l -c "rvm use --default 2.4.5"
+RUN runuser build_user -l -c "rvm install 2.4.10 --disable-binary"
+RUN runuser build_user -l -c "rvm use --default 2.4.10"
 RUN runuser build_user -l -c "rvm all do gem install bundler -v '~> 1.16'"
 RUN runuser build_user -l -c "rvm all do gem install bundler -v '~> 2.0'"
 

--- a/build/Dockerfiles/SIMP_EL7_Build.dockerfile
+++ b/build/Dockerfiles/SIMP_EL7_Build.dockerfile
@@ -1,12 +1,34 @@
-# This version of CentOS is needed for the SELinux context builds
+# This Dockerfile begins from an ancient version of CentOS and upgrades itself
+# in order to acquire all the accumulated SELinux contexts starting from EL7.0
+# until the present.
+#
+# To build using docker, run:
+#
+# ```sh
+# docker build \
+#   --tag "simp-core-iso-builder:el7.$(git rev-parse --short HEAD)" \
+#   --file build/Dockerfiles/SIMP_EL7_Build.dockerfile
+# ```
+#
+# To build using podman, run:
+# ```sh
+# podman build \
+#   --tag "simp-core-iso-builder:el7.$(git rev-parse --short HEAD)" \
+#   --file build/Dockerfiles/SIMP_EL7_Build.dockerfile
+# ```
+#
 # After building, you will probably want to mount your ISO directory using
 # something like the following:
-#   * docker run -v $PWD/ISO:/ISO:Z -it <container ID>
+#
+# ```sh
+# docker run -v $PWD/ISO:/ISO:Z -it <container ID>
+# ```
 #
 # If you want to save your container for future use, you use use the `docker
 # commit` command
 #   * docker commit <running container ID> el7_build
 #   * docker run -it el7_build
+
 FROM centos:7.0.1406
 ENV container docker
 
@@ -92,8 +114,8 @@ RUN runuser build_user -l -c "for i in {1..5}; do { gpg2 --keyserver  hkp://pool
 RUN runuser build_user -l -c "for i in {1..5}; do { gpg2 --keyserver  hkp://pool.sks-keyservers.net --recv-keys 7D2BAF1CF37B13E2069D6956105BD0E739499BDB || gpg2 --keyserver hkp://pgp.mit.edu --recv-keys 7D2BAF1CF37B13E2069D6956105BD0E739499BDB || gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 7D2BAF1CF37B13E2069D6956105BD0E739499BDB; } && break || sleep 1; done"
 #RUN runuser build_user -l -c "gpg2 --refresh-keys"
 RUN runuser build_user -l -c "curl -sSL https://raw.githubusercontent.com/rvm/rvm/stable/binscripts/rvm-installer -o rvm-installer && curl -sSL https://raw.githubusercontent.com/rvm/rvm/stable/binscripts/rvm-installer.asc -o rvm-installer.asc && gpg2 --verify rvm-installer.asc rvm-installer && bash rvm-installer"
-RUN runuser build_user -l -c "rvm install 2.4.5 --disable-binary"
-RUN runuser build_user -l -c "rvm use --default 2.4.5"
+RUN runuser build_user -l -c "rvm install 2.4.10 --disable-binary"
+RUN runuser build_user -l -c "rvm use --default 2.4.10"
 RUN runuser build_user -l -c "rvm all do gem install bundler -v '~> 1.16'"
 RUN runuser build_user -l -c "rvm all do gem install bundler -v '~> 2.0'"
 

--- a/build/Dockerfiles/SIMP_EL8_Build.dockerfile
+++ b/build/Dockerfiles/SIMP_EL8_Build.dockerfile
@@ -80,8 +80,8 @@ RUN runuser build_user -l -c "for i in {1..5}; do { gpg2 --keyserver  hkp://pool
 RUN runuser build_user -l -c "for i in {1..5}; do { gpg2 --keyserver  hkp://pool.sks-keyservers.net --recv-keys 7D2BAF1CF37B13E2069D6956105BD0E739499BDB || gpg2 --keyserver hkp://pgp.mit.edu --recv-keys 7D2BAF1CF37B13E2069D6956105BD0E739499BDB || gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 7D2BAF1CF37B13E2069D6956105BD0E739499BDB; } && break || sleep 1; done"
 #RUN runuser build_user -l -c "gpg2 --refresh-keys"
 RUN runuser build_user -l -c "curl -sSL https://raw.githubusercontent.com/rvm/rvm/stable/binscripts/rvm-installer -o rvm-installer && curl -sSL https://raw.githubusercontent.com/rvm/rvm/stable/binscripts/rvm-installer.asc -o rvm-installer.asc && gpg2 --verify rvm-installer.asc rvm-installer && bash rvm-installer"
-RUN runuser build_user -l -c "rvm install 2.4.5 --disable-binary"
-RUN runuser build_user -l -c "rvm use --default 2.4.5"
+RUN runuser build_user -l -c "rvm install 2.4.10 --disable-binary"
+RUN runuser build_user -l -c "rvm use --default 2.4.10"
 RUN runuser build_user -l -c "rvm all do gem install bundler -v '~> 1.16'"
 RUN runuser build_user -l -c "rvm all do gem install bundler -v '~> 2.0'"
 

--- a/spec/acceptance/suites/rpm_docker/00_rpm_build_spec.rb
+++ b/spec/acceptance/suites/rpm_docker/00_rpm_build_spec.rb
@@ -1,36 +1,41 @@
-# Uses Docker to do a full build of all SIMP packages for CentOS
+# Uses Beaker+Docker to package a full build of all SIMP packages for CentOS
 #
 # Also works in Travis CI
 #
+# ## Building SIMP ISOs
+#
 # If you have a local 'ISO' directory in 'simp-core' with the necessary ISO
-# images, will attempt to build a full SIMP ISO release.
+# images, this test will attempt to build a full SIMP ISO release.
 #
-# If you set the environment variable BEAKER_copyin=yes will copy in your
-# 'simp-core' repo instead of using the one on the filesystem. You probably
-# want to also set BEAKER_destroy=no if you do this so that you can retrieve
-# any relevant artifacts.
+# If you set the environment variable BEAKER_copyin=yes, it will copy in your
+# local copy of the 'simp-core' repo instead of using the one on the
+# filesystem. You probably want to also set BEAKER_destroy=no if you do this,
+# so that you can retrieve any relevant artifacts.
 #
-#   * This mode could be **MUCH** slower but will preserve the sanctity of your
-#     workspace
+#   * NOTE: This mode could be **MUCH** slower, but will preserve the state of
+#           your workspace (including any local changes you may have made)
+#
+# ## Building RHEL ISOs
 #
 # This will also do a full build for RedHat in a vagrant box if the 'rhel7'
 # nodeset is used.
-# To make this work copy only the redhat iso into the simp-core/ISO directory.
-# In order to get the Redhat Build to work you must set the following
+#
+# To make this work, copy only the redhat iso into the simp-core/ISO directory.
+# In order to get the Redhat Build to work, you must set the following
 # Environment variables:
 #
 #  BEAKER_RHSM_USER=(Your RedHat developer account name)
 #  BEAKER_RHSM_PASS=(Your RedHat developer account password)
 #  BEAKER_copyin=yes
 #
-# NOTE: if copyin is not set to yes, it will download simp-core from the
-# simp repository and build the rpms from that.  It will not create an ISO
-# even if you have an ISO directory
-#
-# This will create the RedHat ISO and copy it out to simp-core directory.
-# If you need any of the other artifacts set  BEAKER_destroy=no and retrieve them
+# This will create the RedHat ISO and copy it out to simp-core directory.  If
+# you need any of the other artifacts, set BEAKER_destroy=no and retrieve them
 # from the VM.
-# 
+#
+# NOTE: BEAKER_copyin *MUST* be set to 'yes',  otherwise it will download
+# simp-core from the simp repository and build the rpms from that, with the
+# result that it will not create an ISO (even if you have an ISO directory)!
+#
 require 'spec_helper_rpm'
 
 test_name 'RPM build'
@@ -155,8 +160,8 @@ describe 'RPM build' do
         end
 
         it 'should set up RVM' do
-          on(host, %(#{run_cmd} "rvm install 2.4.4 --disable-binary"))
-          on(host, %(#{run_cmd} "rvm use --default 2.4.4"))
+          on(host, %(#{run_cmd} "rvm install 2.4.10 --disable-binary"))
+          on(host, %(#{run_cmd} "rvm use --default 2.4.10"))
           on(host, %(#{run_cmd} "rvm all do gem install bundler -v \\"~> 1.16\\" --no-document"))
           on(host, %(#{run_cmd} "rvm all do gem install bundler -v \\"~> 2.0\\" --no-document"))
         end


### PR DESCRIPTION
Before this patch, the `SIMP_EL*_Build.dockerfile`s that create the SIMP
build containers and the `rpm_docker` Beaker suite that sourced them used
different versions of ruby with RVM.

The mismatch required each run of the `rpm_docker` suite to unnecessarily
download and build RVM over again, which took significant run time and
bandwidth when amortized over the CI runs during a release cycle.

This patch updates all files to use Ruby 2.4.10 from Puppet 5.5.20.

SIMP-7840 #close