### PR TITLE
(SIMP-6740) Add tests for service toggles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,37 +1,51 @@
-# Variables:
-#
-# SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
-# PUPPET_VERSION   | specifies the version of the puppet gem to load
-gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
+gem_sources = ENV.fetch('GEM_SERVERS','https://rubygems.org').split(/[, ]+/)
+
+ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
+
 gem_sources.each { |gem_source| source gem_source }
 
-# mandatory gems
-gem 'coderay'
-gem 'dotenv'
-gem 'metadata-json-lint'
-gem 'parallel'
-gem 'puppet', ENV.fetch('PUPPET_VERSION', '~> 5.5')
-gem 'puppet-lint'
-gem 'puppet-strings'
-gem 'puppetlabs_spec_helper'
-gem 'net-telnet'
-gem 'rake'
-gem 'ruby-progressbar'
-gem 'simp-build-helpers', ENV.fetch('SIMP_BUILD_HELPERS_VERSION', '>= 0.1.0')
-gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.11.1', '< 6.0'])
-
-group :system_tests do
-  gem 'nokogiri'
-  gem 'beaker', (ENV['SIMP_BEAKER_VERSION']||nil)
-  gem 'beaker-rspec', (ENV['SIMP_BEAKER_RSPEC_VERSION']||nil)
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.15.1', '< 2.0'])
+group :test do
+  puppet_version = ENV['PUPPET_VERSION'] || '~> 5.5'
+  major_puppet_version = puppet_version.scan(/(\d+)(?:\.|\Z)/).flatten.first.to_i
+  gem 'rake'
+  gem 'puppet', puppet_version
+  gem 'rspec'
+  gem 'rspec-puppet'
+  gem 'hiera-puppet-helper'
+  gem 'puppetlabs_spec_helper'
+  gem 'metadata-json-lint'
+  gem 'puppet-strings'
+  gem 'puppet-lint-empty_string-check',   :require => false
+  gem 'puppet-lint-trailing_comma-check', :require => false
+  gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
+  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['> 5.11', '< 6']
+  gem( 'pdk', ENV['PDK_VERSION'] || '~> 1.0', :require => false) if major_puppet_version > 5
 end
 
-# nice-to-have gems (for debugging)
-group :debug do
+group :development do
   gem 'pry'
   gem 'pry-byebug'
   gem 'pry-doc'
 end
 
-#vim: set syntax=ruby:
+group :system_tests do
+  #gem 'beaker'
+  # This is needed until beaker can get it merged and released upstream,
+  # otherwise the acceptance tests will probably fail
+  gem 'beaker', :git => 'https://github.com/trevor-vaughan/beaker', :branch => 'fix_reboot_check_fix'
+  gem 'beaker-rspec'
+  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.18.7', '< 2']
+end
+
+# Evaluate extra gemfiles if they exist
+extra_gemfiles = [
+  ENV['EXTRA_GEMFILE'] || '',
+  "#{__FILE__}.project",
+  "#{__FILE__}.local",
+  File.join(Dir.home, '.gemfile'),
+]
+extra_gemfiles.each do |gemfile|
+  if File.file?(gemfile) && File.readable?(gemfile)
+    eval(File.read(gemfile), binding)
+  end
+end

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,8 @@ group :test do
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
-  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['> 5.11', '< 6']
+  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['> 5.11', '< 6.0']
+  gem 'simp-build-helpers', ENV['SIMP_BUILD_HELPERS_VERSION'] || ['> 0.1', '< 2.0']
   gem( 'pdk', ENV['PDK_VERSION'] || '~> 1.0', :require => false) if major_puppet_version > 5
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
     mime-types (2.99.3)
     mini_portile2 (2.4.0)
     minitar (0.9)
-    minitest (5.14.1)
+    minitest (5.14.2)
     mocha (1.11.2)
     multi_json (1.15.0)
     multipart-post (2.1.1)
@@ -223,7 +223,7 @@ GEM
       rspec-its
       specinfra (~> 2.72)
     sfl (2.3)
-    simp-beaker-helpers (1.18.8)
+    simp-beaker-helpers (1.18.9)
       beaker (>= 4.17.0, < 5.0.0)
       beaker-docker (~> 0.3)
       beaker-puppet (>= 1.18.14, < 2.0.0)
@@ -233,6 +233,7 @@ GEM
       highline (~> 2.0)
       net-telnet (~> 0.1.1)
       nokogiri (~> 1.8)
+    simp-build-helpers (0.1.1)
     simp-rake-helpers (5.11.4)
       bundler (>= 1.14, < 3.0)
       pager (~> 1.0)
@@ -285,7 +286,8 @@ DEPENDENCIES
   rspec
   rspec-puppet
   simp-beaker-helpers (>= 1.18.7, < 2)
-  simp-rake-helpers (> 5.11, < 6)
+  simp-build-helpers (> 0.1, < 2.0)
+  simp-rake-helpers (> 5.11, < 6.0)
   simp-rspec-puppet-facts (~> 3.1)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,24 @@
+GIT
+  remote: https://github.com/trevor-vaughan/beaker
+  revision: 18c8d444526fdfa6044512165c929a9d01027168
+  branch: fix_reboot_check_fix
+  specs:
+    beaker (4.27.0)
+      beaker-hostgenerator
+      hocon (~> 1.0)
+      in-parallel (~> 0.1)
+      inifile (~> 3.0)
+      minitar (~> 0.6)
+      minitest (~> 5.4)
+      net-scp (>= 1.2, < 4.0)
+      net-ssh (>= 5.0)
+      open_uri_redirections (~> 0.2.1)
+      pry-byebug (~> 3.9)
+      rb-readline (~> 0.5.3)
+      rsync (~> 1.0.9)
+      stringify-hash (~> 0.0)
+      thor (>= 1.0.1, < 2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -5,21 +26,6 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ansi (1.5.0)
     ast (2.4.1)
-    beaker (4.26.0)
-      beaker-hostgenerator
-      hocon (~> 1.0)
-      in-parallel (~> 0.1)
-      inifile (~> 3.0)
-      minitar (~> 0.6)
-      minitest (~> 5.4)
-      net-scp (~> 1.2)
-      net-ssh (>= 5.0)
-      open_uri_redirections (~> 0.2.1)
-      pry-byebug (~> 3.6)
-      rb-readline (~> 0.5.3)
-      rsync (~> 1.0.9)
-      stringify-hash (~> 0.0)
-      thor (>= 1.0.1, < 2.0)
     beaker-abs (0.5.0)
     beaker-answers (0.27.0)
       hocon (~> 1.0)
@@ -31,7 +37,7 @@ GEM
     beaker-hostgenerator (1.2.6)
       deep_merge (~> 1.0)
       stringify-hash (~> 0.0.0)
-    beaker-pe (2.11.4)
+    beaker-pe (2.11.7)
       beaker (~> 4.0)
       beaker-abs
       beaker-answers (~> 0.0)
@@ -60,14 +66,13 @@ GEM
     colored2 (3.1.2)
     cri (2.15.10)
     deep_merge (1.2.1)
-    diff-lcs (1.4.2)
+    diff-lcs (1.4.4)
     docker-api (1.34.2)
       excon (>= 0.47.0)
       multi_json
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.7.5)
-    excon (0.75.0)
+    excon (0.76.0)
     facter (2.5.7)
     facterdb (1.4.0)
       facter (< 4.0.0)
@@ -85,14 +90,15 @@ GEM
       gettext (>= 3.0.2, < 3.3.0)
       locale
     hiera (3.6.0)
+    hiera-puppet-helper (1.0.1)
     highline (2.0.3)
     hocon (1.3.1)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     in-parallel (0.1.17)
     inifile (3.0.0)
-    jgrep (1.5.2)
-    json (2.3.0)
+    jgrep (1.5.3)
+    json (2.3.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
     locale (2.1.3)
@@ -106,16 +112,16 @@ GEM
     minitar (0.9)
     minitest (5.14.1)
     mocha (1.11.2)
-    multi_json (1.14.1)
+    multi_json (1.15.0)
     multipart-post (2.1.1)
-    net-scp (1.2.1)
-      net-ssh (>= 2.6.5)
+    net-scp (3.0.0)
+      net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)
     net-telnet (0.1.1)
     netrc (0.11.0)
-    nokogiri (1.10.9)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
-    oga (3.2)
+    oga (3.3)
       ast
       ruby-ll (~> 2.1)
     open_uri_redirections (0.2.1)
@@ -134,7 +140,7 @@ GEM
       pry (~> 0.11)
       yard (~> 0.9.11)
     public_suffix (4.0.5)
-    puppet (5.5.20)
+    puppet (5.5.21)
       facter (> 2.0.1, < 4)
       fast_gettext (~> 1.1.2)
       hiera (>= 3.2.1, < 4)
@@ -144,7 +150,11 @@ GEM
       puppet (>= 2.7.16)
       rest-client (~> 1.8.0)
     puppet-lint (2.4.2)
-    puppet-strings (2.4.0)
+    puppet-lint-empty_string-check (0.2.2)
+      puppet-lint (>= 1.0, < 3.0)
+    puppet-lint-trailing_comma-check (0.4.2)
+      puppet-lint (>= 1.0, < 3.0)
+    puppet-strings (2.5.0)
       rgen
       yard (~> 0.9.5)
     puppet-syntax (3.1.0)
@@ -162,7 +172,7 @@ GEM
       puppet-lint (~> 2.0)
       puppet-syntax (>= 2.0, < 4)
       rspec-puppet (~> 2.0)
-    r10k (3.5.1)
+    r10k (3.5.2)
       colored2 (= 3.1.2)
       cri (>= 2.15.10, < 3.0.0)
       fast_gettext (~> 1.1.0)
@@ -194,12 +204,11 @@ GEM
     rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-puppet (2.7.8)
+    rspec-puppet (2.7.10)
       rspec
-    rspec-puppet-facts (1.10.0)
+    rspec-puppet-facts (2.0.0)
       facter
       facterdb (>= 0.5.0)
-      json
       puppet
     rspec-support (3.9.3)
     rsync (1.0.9)
@@ -214,7 +223,7 @@ GEM
       rspec-its
       specinfra (~> 2.72)
     sfl (2.3)
-    simp-beaker-helpers (1.18.6)
+    simp-beaker-helpers (1.18.8)
       beaker (>= 4.17.0, < 5.0.0)
       beaker-docker (~> 0.3)
       beaker-puppet (>= 1.18.14, < 2.0.0)
@@ -224,8 +233,7 @@ GEM
       highline (~> 2.0)
       net-telnet (~> 0.1.1)
       nokogiri (~> 1.8)
-    simp-build-helpers (0.1.1)
-    simp-rake-helpers (5.11.3)
+    simp-rake-helpers (5.11.4)
       bundler (>= 1.14, < 3.0)
       pager (~> 1.0)
       parallel (~> 1.0)
@@ -244,7 +252,7 @@ GEM
       json (>= 1.0)
       rspec-puppet-facts
     spdx-licenses (1.2.0)
-    specinfra (2.82.17)
+    specinfra (2.82.19)
       net-scp
       net-ssh (>= 2.7)
       net-telnet (= 0.1.1)
@@ -261,26 +269,24 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  beaker
+  beaker!
   beaker-rspec
-  coderay
-  dotenv
+  hiera-puppet-helper
   metadata-json-lint
-  net-telnet
-  nokogiri
-  parallel
   pry
   pry-byebug
   pry-doc
   puppet (~> 5.5)
-  puppet-lint
+  puppet-lint-empty_string-check
+  puppet-lint-trailing_comma-check
   puppet-strings
   puppetlabs_spec_helper
   rake
-  ruby-progressbar
-  simp-beaker-helpers (>= 1.15.1, < 2.0)
-  simp-build-helpers (>= 0.1.0)
-  simp-rake-helpers (>= 5.11.1, < 6.0)
+  rspec
+  rspec-puppet
+  simp-beaker-helpers (>= 1.18.7, < 2)
+  simp-rake-helpers (> 5.11, < 6)
+  simp-rspec-puppet-facts (~> 3.1)
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/Puppetfile.pinned
+++ b/Puppetfile.pinned
@@ -168,7 +168,7 @@ mod 'simp-at',
 
 mod 'simp-auditd',
   :git => 'https://github.com/simp/pupmod-simp-auditd',
-  :tag => '8.5.0'
+  :branch => 'master'
 
 mod 'simp-autofs',
   :git => 'https://github.com/simp/pupmod-simp-autofs',
@@ -300,7 +300,7 @@ mod 'simp-openscap',
 
 mod 'simp-pam',
   :git => 'https://github.com/simp/pupmod-simp-pam',
-  :tag => '6.7.1'
+  :branch => 'master'
 
 mod 'simp-pki',
   :git => 'https://github.com/simp/pupmod-simp-pki',
@@ -348,7 +348,7 @@ mod 'simp-simpkv',
 
 mod 'simp-simplib',
   :git => 'https://github.com/simp/pupmod-simp-simplib',
-  :tag => '4.2.0'
+  :branch => 'master'
 
 mod 'simp-simp_apache',
   :git => 'https://github.com/simp/pupmod-simp-simp_apache',

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 #!/usr/bin/rake -T
 
 require 'simp/rake/pupmod/helpers'
+require 'simp/rake/build/deps'
 
 Simp::Rake::Beaker.new(File.dirname(__FILE__))
 

--- a/spec/acceptance/common_files/site/manifests/test_ldifs.pp
+++ b/spec/acceptance/common_files/site/manifests/test_ldifs.pp
@@ -26,7 +26,7 @@
 #    user2   users
 #
 # @param $base_dn The LDAP Base DN
-# @param $user_password_hash The initial password hash used to set the 
+# @param $user_password_hash The initial password hash used to set the
 #   LDAP 'userPassword field for all users
 class site::test_ldifs(
   String      $base_dn               = $::simp_options::ldap::base_dn,

--- a/spec/acceptance/helpers/expect_script_helper.rb
+++ b/spec/acceptance/helpers/expect_script_helper.rb
@@ -29,7 +29,7 @@ module Acceptance
       #
       # +host+: Host (object) on which the expect script will be installed
       # +script+: Path to the expect script
-      # +dest_dir+: Destination directory into which the expect script 
+      # +dest_dir+: Destination directory into which the expect script
       #   will be installed
       #
       # @returns the location of the script on the host

--- a/spec/acceptance/shared_examples/simp_server_bootstrap.rb
+++ b/spec/acceptance/shared_examples/simp_server_bootstrap.rb
@@ -153,7 +153,7 @@ shared_examples 'SIMP server bootstrap' do |master, config|
       #   when the puppetserver RPM was installed
       # - Allow interruptions so we can kill the test easily during bootstrap
       on(master, 'rm -f /root/.simp/simp_bootstrap_start_lock')
-      on(master, 'simp bootstrap -u --remove_ssldir', :pty => true)
+      on(master, 'simp bootstrap -u -w 10 --remove_ssldir', :pty => true)
     end
 
     it 'should reboot the master to apply boot time config' do

--- a/spec/acceptance/shared_examples/simp_server_bootstrap.rb
+++ b/spec/acceptance/shared_examples/simp_server_bootstrap.rb
@@ -94,7 +94,7 @@ shared_examples 'SIMP server bootstrap' do |master, config|
       #
       # The following variables are require only by simp_conf.yaml.erb
       #   ldap_root_password_hash
-    
+
       trusted_nets =  host_networks(master)
       expect(trusted_nets).to_not be_empty
 
@@ -173,5 +173,4 @@ shared_examples 'SIMP server bootstrap' do |master, config|
       )
     end
   end
-
 end

--- a/spec/acceptance/suites/default/87_disable_fips_spec.rb
+++ b/spec/acceptance/suites/default/87_disable_fips_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper_integration'
+
+test_name 'disabling FIPS after fully configured with FIPS enabled'
+
+master      = only_host_with_role(hosts, 'master')
+master_fqdn = fact_on(master, 'fqdn')
+agents      = hosts_with_role(hosts, 'agent')
+
+describe 'disabling FIPS after fully configured with FIPS enabled' do
+
+  context 'set up hiera to disable FIPS' do
+    let(:prod_env_dir) { '/etc/puppetlabs/code/environments/production' }
+    let(:prod_env_default_yaml) { File.join(prod_env_dir, 'data', 'default.yaml') }
+
+    it 'should disable compliance enforcement and disable FIPS' do
+      hiera = YAML.load(on(master, "cat #{prod_env_default_yaml}").stdout)
+
+      # Set profile list to empty string in the existing hiera, because
+      # when no profiles are specified, there is nothing to enforce!
+      hiera['compliance_markup::enforcement'] = []
+
+      # disable FIPS
+      hiera['simp_options::fips'] = false
+
+      create_remote_file(master, "#{prod_env_default_yaml}", hiera.to_yaml)
+      on(master, "cat #{prod_env_default_yaml}")
+    end
+  end
+
+  context 'apply FIPS-disabling changes' do
+    let(:puppetserver_status_cmd) { puppetserver_status_command(master_fqdn) }
+
+    # can't apply most FIPS-related changes until after reboot, but can undo
+    # all the compliance-enforcement settings
+    it 'should undo compliance-enforced settings on agents' do
+      block_on(agents, :run_in_parallel => false) do |agent|
+        # FIXME: By the time we get to the last node, the ssh connection may have been
+        # aggressively terminated by beaker for that node instead of being handled with
+        # reconnect-after-timeout logic.
+        ensure_ssh_connection(agent)
+
+        retry_on(agent, 'puppet agent -t',
+          :desired_exit_codes => [0,2],
+          :retry_interval     => 15,
+          :max_retries        => 5,
+          :verbose            => true.to_s  # work around beaker bug
+        )
+      end
+    end
+
+    it 'should reboot the agents to apply boot time config' do
+      block_on(agents, :run_in_parallel => false) do |agent|
+        agent.reboot
+      end
+    end
+
+    it 'FIPS should be disabled on each agent' do
+      block_on(agents, :run_in_parallel => false) do |agent|
+        expect( fips_enabled(agent) ).to be false
+      end
+    end
+
+    it 'should apply non-FIPS-mode settings on agents' do
+      # Wait for the puppetserver to be ready to receive requests
+      retry_on(master, puppetserver_status_cmd, :retry_interval => 10)
+
+      block_on(agents, :run_in_parallel => false) do |agent|
+        # Wait for the machine to come back up
+        retry_on(agent, 'uptime', :retry_interval => 15 )
+
+        retry_on(agent, 'puppet agent -t',
+          :desired_exit_codes => [0,2],
+          :retry_interval     => 15,
+          :max_retries        => 5,
+          :verbose            => true.to_s  # work around beaker bug
+        )
+      end
+    end
+  end
+end

--- a/spec/acceptance/suites/default/89_disable_audit_spec.rb
+++ b/spec/acceptance/suites/default/89_disable_audit_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper_integration'
+
+test_name 'disabling auditing to prep for compliance enforcement'
+
+master      = only_host_with_role(hosts, 'master')
+master_fqdn = fact_on(master, 'fqdn')
+agents      = hosts_with_role(hosts, 'agent')
+
+describe 'disabling auditd to ensure that compliance enforcement works' do
+
+  context 'set up hiera to disable auditing' do
+    let(:prod_env_dir) { '/etc/puppetlabs/code/environments/production' }
+    let(:prod_env_default_yaml) { File.join(prod_env_dir, 'data', 'default.yaml') }
+
+    it 'should disable compliance enforcement and disable auditd' do
+      hiera = YAML.load(on(master, "cat #{prod_env_default_yaml}").stdout)
+
+      # Set profile list to empty string in the existing hiera, because
+      # when no profiles are specified, there is nothing to enforce!
+      hiera['compliance_markup::enforcement'] = []
+
+      # disable auditd
+      hiera['simp_options::auditd'] = true
+      hiera['auditd::enable'] = false
+
+      create_remote_file(master, "#{prod_env_default_yaml}", hiera.to_yaml)
+      on(master, "cat #{prod_env_default_yaml}")
+    end
+  end
+
+  context 'apply auditd-disabling changes' do
+    let(:puppetserver_status_cmd) { puppetserver_status_command(master_fqdn) }
+
+    # can't apply most auditd-related changes until after reboot, but can undo
+    # all the compliance-enforcement settings
+    it 'should undo compliance-enforced settings on agents' do
+      block_on(agents, :run_in_parallel => false) do |agent|
+        # FIXME: By the time we get to the last node, the ssh connection may have been
+        # aggressively terminated by beaker for that node instead of being handled with
+        # reconnect-after-timeout logic.
+        ensure_ssh_connection(agent)
+
+        # We need to do this because the simplib__auditd fact will not be
+        # triggered until after the first puppet run which will cause PAM to
+        # deny access to the system due to the pam_tty_audit bug.
+        retry_on(agent, 'puppet agent -t; puppet agent -t',
+          :desired_exit_codes => [0,2],
+          :retry_interval     => 15,
+          :max_retries        => 5,
+          :verbose            => true.to_s  # work around beaker bug
+        )
+      end
+    end
+
+    it 'should reboot the agents to apply boot time config' do
+      block_on(agents, :run_in_parallel => false) do |agent|
+        agent.reboot
+      end
+    end
+
+    it 'auditd should be disabled on each agent' do
+      block_on(agents, :run_in_parallel => false) do |agent|
+        auditd_status = YAML.safe_load(on(agent, 'puppet resource service auditd --to_yaml').stdout)
+        expect(auditd_status['service']['auditd']['ensure']).not_to eq 'running'
+      end
+    end
+
+    it 'should apply non-auditd-mode settings on agents' do
+      # Wait for the puppetserver to be ready to receive requests
+      retry_on(master, puppetserver_status_cmd, :retry_interval => 10)
+
+      block_on(agents, :run_in_parallel => false) do |agent|
+        # Wait for the machine to come back up
+        retry_on(agent, 'uptime', :retry_interval => 15 )
+
+        retry_on(agent, 'puppet agent -t',
+          :desired_exit_codes => [0,2],
+          :retry_interval     => 15,
+          :max_retries        => 5,
+          :verbose            => true.to_s  # work around beaker bug
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added tests to flip:
  * FIPS mode
  * SELinux Mode
  * Auditd

Wait for 10 minutes when bootstrapping the server by default in case
we're running on an overloaded system.

Requires the following to work:
  * simp/pupmod-simp-simplib#228
  * simp/pupmod-simp-pam#94

Note: Currently pointing at trevor-vaughan/beaker until the patch in
fix_reboot_check_fix can be merged and released. The acceptance tests
will probably fail without this patch.

SIMP-6740 #close