### PR TITLE
(SIMP-8469) Disable CentOS-* repos in EL8 ks cfg

### DIFF
--- a/build/distributions/CentOS/8/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/8/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -30,8 +30,8 @@ authconfig --enableshadow --passalgo=sha512
 # If this affects your OS, remove the `fips=1 ` string from the bootloader
 # line's `--append` argument below (this will not affect the FIPS Mode of the
 # final system):
-bootloader --location=mbr --append="fips=1 console=ttyS1,57600 console=tty1" --iscrypted --password=grub.pbkdf2.sha512.10000.94454C752918769A415DB7949779653CA87DC7D4B21C4E531F5E53CF16DE397CA8BA8BF758019D5F299717D59E4598040FBA0B3039FA757E033A9ED0E37A7FEF.BA03CF7EAEF494D86C79BBEDDF308C23FD359FC31F63851CE28CDEC0D8B3A278B392136BE8E4F1D9028EC8B90C13908B2438385AA8890E0DF2D1E35CFC6B2788
-rootpw --iscrypted $6$58rp5hrn$Rv/tzwlVBS5oHsKXPwcMzohyFzehtOC9HB502E9j8fjPeujf3cd9THmKODO39Y0Fhnimj5AZ.OXu3GByImjDH.
+bootloader --location=mbr --append="fips=1 console=ttyS1,57600 console=tty1" --iscrypted --password=#BOOTPASS#
+rootpw --iscrypted #ROOTPASS#
 firewall --enabled --ssh
 firstboot --disable
 logging --level=info

--- a/build/distributions/CentOS/8/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/8/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -5,19 +5,33 @@
 # Use the following command to generate your grub password hash:
 #   grub2-mkpasswd-pbkdf2
 #
-# Replace the following strings in this file
-# #BOOTPASS# - Your hashed bootloader password
-# #ROOTPASS# - Your hashed root password
-# #KSSERVER# - The IP address of your Kickstart server
-# #YUMSERVER# - The IP address of your YUM server
-# #LINUXDIST# - The LINUX Distribution you are kickstarting
-#        - Current CASE SENSITIVE options: RedHat CentOS
+# Replace the following strings in this file:
+#
+#     #BOOTPASS#  - Your hashed bootloader password
+#     #ROOTPASS#  - Your hashed root password
+#     #KSSERVER#  - The IP address of your Kickstart server
+#     #YUMSERVER# - The IP address of your YUM server
+#     #LINUXDIST# - The LINUX Distribution you are kickstarting
+#                 - Current CASE SENSITIVE options: RedHat CentOS
 
-# anaconda has known issues when fips is turned on during boot, so it (fips=1)  was remove from bootloader line.
-# see url: https://groups.google.com/forum/?fromgroups#!topic/simp-announce/3pBQDZl1OVc
 authconfig --enableshadow --passalgo=sha512
-bootloader --location=mbr --append="console=ttyS1,57600 console=tty1" --iscrypted --password=#BOOTPASS#
-rootpw --iscrypted #ROOTPASS#
+
+# On some EL versions (notably 7.0-7.4), anaconda had a known issue, where
+# installation images did not support FIPS mode (fips=1) when the kickstart file
+# (this file) is loaded from an HTTPS source.
+#
+# Details:
+#
+#   - https://access.redhat.com/errata/RHBA-2018:0947
+#   - https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/7.5_release_notes
+#   - https://bugzilla.redhat.com/show_bug.cgi?id=1341280
+#   - https://groups.google.com/forum/?fromgroups#!topic/simp-announce/3pBQDZl1OVc
+#
+# If this affects your OS, remove the `fips=1 ` string from the bootloader
+# line's `--append` argument below (this will not affect the FIPS Mode of the
+# final system):
+bootloader --location=mbr --append="fips=1 console=ttyS1,57600 console=tty1" --iscrypted --password=grub.pbkdf2.sha512.10000.94454C752918769A415DB7949779653CA87DC7D4B21C4E531F5E53CF16DE397CA8BA8BF758019D5F299717D59E4598040FBA0B3039FA757E033A9ED0E37A7FEF.BA03CF7EAEF494D86C79BBEDDF308C23FD359FC31F63851CE28CDEC0D8B3A278B392136BE8E4F1D9028EC8B90C13908B2438385AA8890E0DF2D1E35CFC6B2788
+rootpw --iscrypted $6$58rp5hrn$Rv/tzwlVBS5oHsKXPwcMzohyFzehtOC9HB502E9j8fjPeujf3cd9THmKODO39Y0Fhnimj5AZ.OXu3GByImjDH.
 firewall --enabled --ssh
 firstboot --disable
 logging --level=info
@@ -106,15 +120,14 @@ sysfsutils
 
 %pre
 ksserver="#KSSERVER#"
-#pull down disk and repo scripts from kickstart server and run them
-# to create the included files.
-wget --no-check-certificate -O /tmp/diskdetect.sh https://$ksserver/ks/diskdetect.sh;
-chmod 750 /tmp/diskdetect.sh;
-/tmp/diskdetect.sh;
 
-wget --no-check-certificate -O /tmp/repodetect.sh https://$ksserver/ks/repodetect.sh;
-chmod 750 /tmp/repodetect.sh;
-/tmp/repodetect.sh '8' $ksserver '#LINUXDIST#';
+# Fetch disk and repo detection scripts from kickstart server and run them
+# to create the files used by the'%include /tmp/*-include' above.
+wget --no-check-certificate -O /tmp/diskdetect.sh https://$ksserver/ks/diskdetect.sh
+/bin/sh /tmp/diskdetect.sh
+
+wget --no-check-certificate -O /tmp/repodetect.sh https://$ksserver/ks/repodetect.sh
+/bin/sh /tmp/repodetect.sh '8' "$ksserver" '#LINUXDIST#'
 
 %end
 
@@ -171,13 +184,11 @@ fi
 %end
 
 %post
+
+# Disable all the (internet-only) .repo files CentOS kickstarts install
 if [ -f /etc/centos-release ]; then
-  sed -i '/enabled=/d' /etc/yum.repos.d/CentOS-Base.repo;
-  sed -i '/\[.*\]/ a\
-enabled=0' /etc/yum.repos.d/CentOS-Base.repo;
-  sed -i '/enabled=/d' /etc/yum.repos.d/CentOS-AppStream.repo;
-  sed -i '/\[.*\]/ a\
-enabled=0' /etc/yum.repos.d/CentOS-AppStream.repo;
+  sed -i -e '/enabled=/d' -e 's/^\(\[.*\]\)/\1\nenabled=0/g' \
+    /etc/yum.repos.d/CentOS-*.repo
 fi
 
 
@@ -189,10 +200,14 @@ BOOTDEV=`df /boot | tail -1 | cut -f1 -d' '`
 DEFAULT_KERNEL_INFO=`/sbin/grubby --default-kernel`
 DEFAULT_INITRD=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep initrd | cut -f2 -d'='`
 DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 title | cut -f2 -d'='`
-/sbin/grubby --copy-default --make-default --add-kernel=`/sbin/grubby --default-kernel` --initrd=${DEFAULT_INITRD} --title="FIPS ${DEFAULT_KERNEL_TITLE}"
+/sbin/grubby --copy-default --make-default \
+  --add-kernel=`/sbin/grubby --default-kernel` \
+  --initrd=${DEFAULT_INITRD} \
+  --title="FIPS ${DEFAULT_KERNEL_TITLE}"
+
 # Remove ALL fips= duplicates and force fips=1.
 until [ "$(/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep args | grep -o fips | wc -l)" -eq 0 ]; do
-  $(/sbin/grubby --remove-args="fips" --update-kernel ${DEFAULT_KERNEL_INFO})
+  /sbin/grubby --remove-args="fips" --update-kernel ${DEFAULT_KERNEL_INFO}
 done
 /sbin/grubby --args="boot=${BOOTDEV} fips=1" --update-kernel ${DEFAULT_KERNEL_INFO}
 
@@ -225,10 +240,14 @@ source /root/.bashrc
 systemctl enable NetworkManager-wait-online
 
 # Enable the firstboot bootstrapping script.
-wget --no-check-certificate -O /etc/systemd/system/simp_client_bootstrap.service https://$ksserver/ks/simp_client_bootstrap.service;
-chmod 644 /etc/systemd/system/simp_client_bootstrap.service;
-wget --no-check-certificate -O /usr/local/sbin/bootstrap_simp_client https://$ksserver/ks/bootstrap_simp_client;
+wget --no-check-certificate \
+  -O /etc/systemd/system/simp_client_bootstrap.service \
+  https://$ksserver/ks/simp_client_bootstrap.service
+chmod 644 /etc/systemd/system/simp_client_bootstrap.service
+wget --no-check-certificate \
+  -O /usr/local/sbin/bootstrap_simp_client \
+  https://$ksserver/ks/bootstrap_simp_client
 chmod 700  /usr/local/sbin/bootstrap_simp_client
 
-systemctl enable simp_client_bootstrap.service;
+systemctl enable simp_client_bootstrap.service
 %end

--- a/src/assets/simp/build/simp.spec
+++ b/src/assets/simp/build/simp.spec
@@ -253,6 +253,11 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Wed Oct 14 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.5.0-ALPHA
+- Disable all internet-based CentOS repos in EL8 kickstart template
+- Re-enable `fips=1` in the EL8 kickstart template bootloader
+- Minor fixes & formatting updates to EL8 kickstart template
+
 * Tue Oct 06 2020 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.5.0-ALPHA
 - Add obsolete messages for pupmod rpms in simp-extras that were not
   updated for 6.5.0 and will cause depencancy issues when upgrading.


### PR DESCRIPTION
This patch fixes an issue where network-isolated CentOS 8 systems
kickstarted from the `pupclient_x86_64.cfg` template would fail because
internet-based repos (e.g., CentOS-Extras) would time out.

Additional fixes:
* Re-enable `fips=1` (fixed in EL7.5) in the EL8 `pupclient_x86_64.cfg`
* Minor fixes & formatting updates to EL8 kickstart template

[SIMP-8469] #close
[SIMP-8575] #close

[SIMP-8469]: https://simp-project.atlassian.net/browse/SIMP-8469
[SIMP-8575]: https://simp-project.atlassian.net/browse/SIMP-8575