### PR TITLE
(SIMP-MAINT) Fix repos for install_from_tar

### DIFF
--- a/spec/acceptance/helpers/repo_helper.rb
+++ b/spec/acceptance/helpers/repo_helper.rb
@@ -65,7 +65,7 @@ module Acceptance
       #
       # +host+: Host object on which SIMP repo(s) will be installed
       # +set_up_simp_main+:  Whether to set up the main SIMP repo
-      # +set_up_simp_deps+:  Whether to set up the SIMP dependencies repo
+      # +set_up_simp_deps+:  Whether to set up the SIMP dependencies repos
       #
       # @fails if the specified repos cannot be installed on host
       def set_up_simp_repos(host, set_up_simp_main = true, set_up_simp_deps = true )

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -68,7 +68,7 @@ CONFIG:
   synced_folder: disabled
   ssh:
     keepalive: true
-    keepalive_interval: 1
+    keepalive_interval: 10
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% else -%>

--- a/spec/acceptance/nodesets/el6_server.yml
+++ b/spec/acceptance/nodesets/el6_server.yml
@@ -67,7 +67,7 @@ CONFIG:
   synced_folder: disabled
   ssh:
     keepalive: true
-    keepalive_interval: 1
+    keepalive_interval: 10
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% else -%>

--- a/spec/acceptance/nodesets/el7_server.yml
+++ b/spec/acceptance/nodesets/el7_server.yml
@@ -68,7 +68,7 @@ CONFIG:
   synced_folder: disabled
   ssh:
     keepalive: true
-    keepalive_interval: 1
+    keepalive_interval: 10
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% else -%>

--- a/spec/acceptance/suites/README.md
+++ b/spec/acceptance/suites/README.md
@@ -120,8 +120,9 @@ clients, and then executes the following tests:
 
 #### yum repositories enabled
 
-This test enables EPEL, SIMP 6_X, SIMP 6_X_Dependencies, and Puppet
-repositories.
+This test enables EPEL, SIMP 6 (simp-community-simp), SIMP 6 dependencies
+(simp-community-epel, simp-community-puppet, simp-community-postgresql),
+and Puppet repositories.
 
 #### puppetserver installation
 
@@ -174,8 +175,9 @@ following:
 
 #### yum repositories enabled
 
-This test enables EPEL, SIMP 6_X, SIMP 6_X_Dependencies, and Puppet
-repositories.
+This test enables EPEL, SIMP 6 (simp-community-simp), SIMP 6 dependencies
+(simp-community-epel, simp-community-puppet, simp-community-postgresql),
+and Puppet repositories.
 
 #### puppetserver installation
 
@@ -217,10 +219,11 @@ clients.
 
 #### yum repositories enabled
 
-This test enables SIMP 6_X and SIMP 6_X_Dependencies repositories.  It
-explicitly does not enable the EPEL or Puppet repositories, as the test expects
-the EPEL and Puppet RPMs required for SIMP to be available in the
-SIMP 6_X_Dependencies repository.
+This test enables SIMP 6 (simp-community-simp) and SIMP 6 dependencies
+(simp-community-epel, simp-community-puppet, simp-community-postgresql)
+repositories.  It explicitly does not enable the EPEL or Puppet repositories,
+as the test expects the EPEL and Puppet RPMs required for SIMP to be available
+in the corresponding SIMP 6 dependencies repositories.
 
 #### puppetserver installation
 
@@ -253,9 +256,11 @@ clients.
 
 #### yum repositories enabled
 
-This test enables EPEL, SIMP 6_X_Dependencies, and Puppet repositories.  It
-also creates and enables a local repository containing the component RPMs
-packaged in the SIMP release tarball.
+This test enables EPEL, SIMP 6 (simp-community-simp for simp-vendored-r10k
+packages), SIMP 6 dependencies (simp-community-epel, simp-community-puppet,
+simp-community-postgresql), and Puppet repositories.  It also creates and
+enables a local repository containing the component RPMs packaged in the
+SIMP release tarball.
 
 #### puppetserver installation
 
@@ -294,8 +299,9 @@ clients.
 
 #### yum repositories enabled
 
-This test enables EPEL, SIMP 6_X, SIMP 6_X_Dependencies, and Puppet
-repositories.
+This test enables EPEL, SIMP 6 (simp-community-simp), SIMP 6 dependencies
+(simp-community-epel, simp-community-puppet, simp-community-postgresql),
+and Puppet repositories.
 
 #### puppetserver installation
 

--- a/spec/acceptance/suites/install_from_tar/00_simp_server_install_spec.rb
+++ b/spec/acceptance/suites/install_from_tar/00_simp_server_install_spec.rb
@@ -15,6 +15,7 @@ describe 'Install SIMP modules and assets via release tarball' do
       :root_password => test_password,
       :repos         => [
         :epel,
+        :simp,
         :simp_deps,
         :puppet
       ]


### PR DESCRIPTION
When the packagecloud SIMP repositories were used, the install_from_tar
test did not need the SIMP 6 main repository.  However, when we switched
to use the repositories at download.simp-project.com, the test now needs
the SIMP 6 main repository in order to find the simp-vendored-r10k RPMs.