### PR TITLE
(SIMP-MAINT) 2 more bug fixes

### DIFF
--- a/Puppetfile.pinned
+++ b/Puppetfile.pinned
@@ -192,7 +192,7 @@ mod 'simp-cron',
 
 mod 'simp-crypto_policy',
   :git => 'https://github.com/simp/pupmod-simp-crypto_policy',
-  :tag => '0.1.1'
+  :tag => '0.1.2'
 
 mod 'simp-dconf',
   :git => 'https://github.com/simp/pupmod-simp-dconf',
@@ -382,7 +382,7 @@ mod 'simp-simp_ipa',
 
 mod 'simp-simp_nfs',
   :git => 'https://github.com/simp/pupmod-simp-simp_nfs',
-  :tag => '1.0.0'
+  :tag => '1.0.1'
 
 mod 'simp-simp_openldap',
   :git => 'https://github.com/simp/pupmod-simp-simp_openldap',

--- a/metadata.json
+++ b/metadata.json
@@ -128,7 +128,7 @@
     },
     {
       "name": "simp/crypto_policy",
-      "version_requirement": ">= 0.1.1 < 1.0.0"
+      "version_requirement": ">= 0.1.2 < 1.0.0"
     },
     {
       "name": "simp/deferred_resources",

--- a/src/assets/simp/build/simp.spec
+++ b/src/assets/simp/build/simp.spec
@@ -53,7 +53,7 @@ Requires: pupmod-simp-chkrootkit >= 0.3.0, pupmod-simp-chkrootkit < 1.0.0
 Requires: pupmod-simp-clamav >= 6.4.0, pupmod-simp-clamav < 7.0.0
 Requires: pupmod-simp-compliance_markup >= 3.1.2, pupmod-simp-compliance_markup < 4.0.0
 Requires: pupmod-simp-cron >= 0.2.0, pupmod-simp-cron < 1.0.0
-Requires: pupmod-simp-crypto_policy >= 0.1.1, pupmod-simp-crypto_policy < 1.0.0
+Requires: pupmod-simp-crypto_policy >= 0.1.2, pupmod-simp-crypto_policy < 1.0.0
 Requires: pupmod-simp-deferred_resources >= 0.3.0, pupmod-simp-deferred_resources < 1.0.0
 Requires: pupmod-simp-dhcp >= 6.2.0, pupmod-simp-dhcp < 7.0.0
 Requires: pupmod-simp-fips >= 0.4.2, pupmod-simp-fips < 1.0.0
@@ -166,7 +166,7 @@ Requires: pupmod-simp-simp_bolt >= 0.3.0
 #Requires: pupmod-simp-simp_gitlab >= 0.5.1
 Requires: pupmod-simp-simp_grub >= 0.2.1
 Requires: pupmod-simp-simp_ipa >= 0.1.0
-Requires: pupmod-simp-simp_nfs >= 1.0.0
+Requires: pupmod-simp-simp_nfs >= 1.0.1
 Requires: pupmod-simp-simp_pki_service >= 0.3.1
 #Commented out for 6.5 because of dependency issues.
 #expect return in 6.6


### PR DESCRIPTION
Two extremely minor bug fixes:
* pupmod-simp-crypto_policy 0.1.2 (remove unused data/)
* pupmod-simp-simp_nfs 1.0.1 (update docs)