### PR TITLE
(SIMP-8618) Bad instructions client ks non-FIPS + encryption

### DIFF
--- a/build/distributions/CentOS/6/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/6/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -239,13 +239,14 @@ DEFAULT_INITRD=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep initrd | cut -
 DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 title | cut -f2 -d'='`
 /sbin/grubby --copy-default --make-default --args="boot=${BOOTDEV} fips=1" --add-kernel=`/sbin/grubby --default-kernel` --initrd=${DEFAULT_INITRD} --title="FIPS ${DEFAULT_KERNEL_TITLE}"
 
+### END FIPS ###
+
 # For the disk crypto
 if [ -f "/etc/.cryptcreds" ]; then
   echo 'install_items+="/etc/.cryptcreds"' >> /etc/dracut.conf
 fi
 
 dracut -f
-### END FIPS ###
 
 # Notify users that bootstrap will run on firstboot
 echo "Welcome to SIMP!  If this is firstboot, SIMP bootstrap is scheduled to run.

--- a/build/distributions/CentOS/7/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/7/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -246,6 +246,8 @@ until [ "$(/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep args | grep -o fips
 done
 /sbin/grubby --args="boot=${BOOTDEV} fips=1" --update-kernel ${DEFAULT_KERNEL_INFO}
 
+## END FIPS ##
+
 # For the disk crypto
 if [ -f "/etc/.cryptcreds" ]; then
   echo 'install_items+="/etc/.cryptcreds"' >> /etc/dracut.conf
@@ -255,7 +257,6 @@ for x in `ls -d /lib/modules/*`; do
   installed_kernel=`basename $x`
   dracut -f "/boot/initramfs-${installed_kernel}.img" $installed_kernel
 done
-## END FIPS ##
 
 # Notify users that bootstrap will run on firstboot
 echo "Welcome to SIMP!  If this is firstboot, SIMP bootstrap is scheduled to run.

--- a/build/distributions/CentOS/8/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/8/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -211,6 +211,7 @@ until [ "$(/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep args | grep -o fips
 done
 /sbin/grubby --args="boot=${BOOTDEV} fips=1" --update-kernel ${DEFAULT_KERNEL_INFO}
 
+### END FIPS ####
 
 # For the disk crypto
 if [ -f "/etc/.cryptcreds" ]; then
@@ -221,8 +222,6 @@ for x in `ls -d /lib/modules/*`; do
   installed_kernel=`basename $x`
   dracut -f "/boot/initramfs-${installed_kernel}.img" $installed_kernel
 done
-
-### END FIPS ####
 
 
 ksserver="#KSSERVER#"


### PR DESCRIPTION
Without the encrypted disk credentials being added to the dracut
configuration, automatic decrypt does not happed at client boot.

SIMP-8618 #close