### PR TITLE
(SIMP-8625) Add createrepo_c to EL6 and EL7

### DIFF
--- a/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/6/x86_64/yum_data/packages.yaml
@@ -23,6 +23,12 @@ clamd:
 clamsmtp:
   :rpm_name: clamsmtp-1.10-7.el6.x86_64.rpm
   :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/clamsmtp-1.10-7.el6.x86_64.rpm
+createrepo_c:
+  :rpm_name: createrepo_c-0.10.0-2.el6.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/createrepo_c-0.10.0-2.el6.x86_64.rpm
+createrepo_c-libs:
+  :rpm_name: createrepo_c-libs-0.10.0-2.el6.x86_64.rpm
+  :source: http://lug.mtu.edu/epel/6/x86_64/Packages/c/createrepo_c-libs-0.10.0-2.el6.x86_64.rpm
 fping:
   :rpm_name: fping-2.4b2-10.el6.x86_64.rpm
   :source: http://lug.mtu.edu/epel/6/x86_64/Packages/f/fping-2.4b2-10.el6.x86_64.rpm

--- a/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
@@ -47,6 +47,12 @@ clamav-update:
 clamd:
   :rpm_name: clamd-0.102.4-1.el7.x86_64.rpm
   :source: http://mirror.umd.edu/fedora/epel/7/x86_64/Packages/c/clamd-0.102.4-1.el7.x86_64.rpm
+createrepo_c:
+  :rpm_name: createrepo_c-0.10.0-20.el7.x86_64.rpm
+  :source: http://mirror.centos.org/centos/7/extras/x86_64/Packages/createrepo_c-0.10.0-20.el7.x86_64.rpm
+createrepo_c-libs:
+  :rpm_name: createrepo_c-libs-0.10.0-20.el7.x86_64.rpm
+  :source: http://mirror.centos.org/centos/7/extras/x86_64/Packages/createrepo_c-libs-0.10.0-20.el7.x86_64.rpm
 fortune-mod:
   :rpm_name: fortune-mod-1.99.1-17.el7.x86_64.rpm
   :source: http://lug.mtu.edu/epel/7/x86_64/Packages/f/fortune-mod-1.99.1-17.el7.x86_64.rpm


### PR DESCRIPTION
This patch adds createrepo_c packages to EL6 and EL7, so yum servers
hosted from those OSes can maintain modular repositories to support EL8+
clients.

[SIMP-8626] #close #comment Added createrepo_c to EL6
[SIMP-8627] #close #comment Added createrepo_c to EL7

[SIMP-8626]: https://simp-project.atlassian.net/browse/SIMP-8626
[SIMP-8627]: https://simp-project.atlassian.net/browse/SIMP-8627