### PR TITLE
(SIMP-8114) PXE boot EL8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,56 +36,62 @@ rvm: 2.5.8
 
 jobs:
   include:
-    - stage: check
-      # Need to set the version for dist because Ubuntu may not have the macro set.
-      # If it is blank the job will fail.
-      name: 'Validation and metadata checks'
-      script:
-        - SIMP_RPM_dist=.el7 bundle exec rake check:dot_underscore
-        - SIMP_RPM_dist=.el7 bundle exec rake check:test_file
-        - SIMP_RPM_dist=.el7 bundle exec rake metadata_lint
-        - bundle exec rake check:pkglist_lint
-
-    - stage: check
-      name: 'Check Puppetfile.*'
-      script:
-        - bundle exec rake spec
-
-    - stage: package
-      name: 'Build EL6 SIMP Packages'
-      if: 'NOT env(TRAVIS_IS_SLOW_TODAY) = yes'
-      sudo: required
-      services:
-        - docker
-      script:
-        - bundle exec rake beaker:suites[rpm_docker,el6]
-
-    - stage: package
-      name: 'Build EL6 SIMP Packages (using travis_wait)'
-      if: 'env(TRAVIS_IS_SLOW_TODAY) = yes'
-      sudo: required
-      services:
-        - docker
-      script:
-        - travis_wait 45 unbuffer bundle exec rake beaker:suites[rpm_docker,el6]
-
-    - stage: package
-      name: 'Build EL7 SIMP Packages'
-      if: 'NOT env(TRAVIS_IS_SLOW_TODAY) = yes'
-      sudo: required
-      services:
-        - docker
-      script:
-        - bundle exec rake beaker:suites[rpm_docker,el7]
-
-    - stage: package
-      name: 'Build EL7 SIMP Packages (using travis_wait)'
-      if: 'env(TRAVIS_IS_SLOW_TODAY) = yes'
-      sudo: required
-      services:
-        - docker
-      script:
-        - travis_wait 45 unbuffer bundle exec rake beaker:suites[rpm_docker,el7]
+    ###  Testing on Travis CI is indefinitely disabled
+    ###
+    ###  See:
+    ###    * https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
+    ###    * https://simp-project.atlassian.net/browse/SIMP-8703
+    ###
+    ###    - stage: check
+    ###      # Need to set the version for dist because Ubuntu may not have the macro set.
+    ###      # If it is blank the job will fail.
+    ###      name: 'Validation and metadata checks'
+    ###      script:
+    ###        - SIMP_RPM_dist=.el7 bundle exec rake check:dot_underscore
+    ###        - SIMP_RPM_dist=.el7 bundle exec rake check:test_file
+    ###        - SIMP_RPM_dist=.el7 bundle exec rake metadata_lint
+    ###        - bundle exec rake check:pkglist_lint
+    ###
+    ###    - stage: check
+    ###      name: 'Check Puppetfile.*'
+    ###      script:
+    ###        - bundle exec rake spec
+    ###
+    ###    - stage: package
+    ###      name: 'Build EL6 SIMP Packages'
+    ###      if: 'NOT env(TRAVIS_IS_SLOW_TODAY) = yes'
+    ###      sudo: required
+    ###      services:
+    ###        - docker
+    ###      script:
+    ###        - bundle exec rake beaker:suites[rpm_docker,el6]
+    ###
+    ###    - stage: package
+    ###      name: 'Build EL6 SIMP Packages (using travis_wait)'
+    ###      if: 'env(TRAVIS_IS_SLOW_TODAY) = yes'
+    ###      sudo: required
+    ###      services:
+    ###        - docker
+    ###      script:
+    ###        - travis_wait 45 unbuffer bundle exec rake beaker:suites[rpm_docker,el6]
+    ###
+    ###    - stage: package
+    ###      name: 'Build EL7 SIMP Packages'
+    ###      if: 'NOT env(TRAVIS_IS_SLOW_TODAY) = yes'
+    ###      sudo: required
+    ###      services:
+    ###        - docker
+    ###      script:
+    ###        - bundle exec rake beaker:suites[rpm_docker,el7]
+    ###
+    ###    - stage: package
+    ###      name: 'Build EL7 SIMP Packages (using travis_wait)'
+    ###      if: 'env(TRAVIS_IS_SLOW_TODAY) = yes'
+    ###      sudo: required
+    ###      services:
+    ###        - docker
+    ###      script:
+    ###        - travis_wait 45 unbuffer bundle exec rake beaker:suites[rpm_docker,el7]
 
     - stage: deploy
       script:

--- a/build/distributions/CentOS/8/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/8/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -58,10 +58,11 @@ aide
 bzip2
 chrony
 crontabs
-dracut
+#dracut
 ## Uncomment the previous line and comment out the line below to disable
 ## checking FIPS compliance at boot.
-#dracut-fips
+## Also in the %post section change FIPS=true to FIPS=false
+dracut-fips
 fipscheck
 git
 grub2-efi-x64
@@ -191,27 +192,37 @@ if [ -f /etc/centos-release ]; then
     /etc/yum.repos.d/CentOS-*.repo
 fi
 
+## Change this to false if you do not want FIPS mode.
+## Also in the %packages sections make sure dracut is uncommented
+## dracut-fips is comments out.
+##
+FIPS=true
 
-## Comment out/delete the following block of commands if you want to disable FIPS compliance. ##
-### START FIPS ###
+# In EL8 the bios kickstart was failing because the boot=UUID  kernel parameter
+# is not being set.  In FIPs mod it will create a new Boot menu item
+# with fips=1, in non fips mode it will update the existing default entry.
 
 # In case you need a working fallback
 BOOTDEV=`df /boot | tail -1 | cut -f1 -d' '`
 DEFAULT_KERNEL_INFO=`/sbin/grubby --default-kernel`
 DEFAULT_INITRD=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep initrd | cut -f2 -d'='`
 DEFAULT_KERNEL_TITLE=`/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep -m1 title | cut -f2 -d'='`
-/sbin/grubby --copy-default --make-default \
-  --add-kernel=`/sbin/grubby --default-kernel` \
-  --initrd=${DEFAULT_INITRD} \
-  --title="FIPS ${DEFAULT_KERNEL_TITLE}"
 
-# Remove ALL fips= duplicates and force fips=1.
+if $FIPS; then
+  FIPS_SETTING=1
+  /sbin/grubby --copy-default --make-default \
+    --add-kernel=`/sbin/grubby --default-kernel` \
+    --initrd=${DEFAULT_INITRD} \
+    --title="FIPS ${DEFAULT_KERNEL_TITLE}"
+else
+   FIPS_SETTING=0
+fi
+# Remove ALL fips= duplicates.
 until [ "$(/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep args | grep -o fips | wc -l)" -eq 0 ]; do
   /sbin/grubby --remove-args="fips" --update-kernel ${DEFAULT_KERNEL_INFO}
 done
-/sbin/grubby --args="boot=${BOOTDEV} fips=1" --update-kernel ${DEFAULT_KERNEL_INFO}
 
-### END FIPS ####
+/sbin/grubby --args="boot=${BOOTDEV} fips=${FIPS_SETTING}" --update-kernel ${DEFAULT_KERNEL_INFO}
 
 # For the disk crypto
 if [ -f "/etc/.cryptcreds" ]; then
@@ -222,7 +233,6 @@ for x in `ls -d /lib/modules/*`; do
   installed_kernel=`basename $x`
   dracut -f "/boot/initramfs-${installed_kernel}.img" $installed_kernel
 done
-
 
 ksserver="#KSSERVER#"
 


### PR DESCRIPTION
- updated diskdetect.sh for encryption.  The partitioning of
  an encrypted physical volume would fail if size=1 was set.  It was
  increased to size=20480 (which is the combined size of all the
  logical volumes on it, and the --grow option was eleft there.
  This allowed the part pv.01 --encrypt to work.
- It appears that the python command is not available during kickstart
  so the creation of the password for encryption was changed from
  a python command to use /dev/random.
- Bios kickstarting without FIPS was failing because the boot=UUID=????
  arguement was not set on the command line.  It worked in FIPS because
  a new menu item was created with fips=1 and a boot device. The
existing code for FIPS was modified to update the default entry to
  put in the boot=UUID=??? argument. (Note:  UEFI worked fine without it
 and EL7 never needed this.)