### PR TITLE
(SIMP-9421) Update simp-core acceptance tests for priv local user

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@
 # Release       Puppet   Ruby    EOL
 # SIMP 6.4      5.5      2.4.10  TBD
 # PE 2018.1     5.5      2.4.10  2021-01 (LTS overlap)
-# PE 2019.8     6.18     2.5.7   2022-12 (LTS)
+# PE 2019.8     6.21     2.5.8   2022-12 (LTS)
 ---
 
 stages:
@@ -111,7 +111,7 @@ variables:
 .pup_6_pe: &pup_6_pe
   image: 'ruby:2.5'
   variables:
-    PUPPET_VERSION: '6.18.0'
+    PUPPET_VERSION: '6.21.1'
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 

--- a/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/CentOS/7/x86_64/yum_data/packages.yaml
@@ -232,8 +232,8 @@ protobuf:
   :rpm_name: protobuf-2.5.0-8.el7.x86_64.rpm
   :source: http://mirror.centos.org/centos/7/os/x86_64/Packages/protobuf-2.5.0-8.el7.x86_64.rpm
 puppet-agent:
-  :rpm_name: puppet-agent-6.18.0-1.el7.x86_64.rpm
-  :source: https://yum.puppet.com/puppet/el/7/x86_64/puppet-agent-6.18.0-1.el7.x86_64.rpm
+  :rpm_name: puppet-agent-6.21.1-1.el7.x86_64.rpm
+  :source: https://yum.puppet.com/puppet6/el/7/x86_64/puppet-agent-6.21.1-1.el7.x86_64.rpm
 puppet-bolt:
   :rpm_name: puppet-bolt-2.29.0-1.el7.x86_64.rpm
   :source: https://yum.puppet.com/puppet/el/7/x86_64/puppet-bolt-2.29.0-1.el7.x86_64.rpm

--- a/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
+++ b/build/distributions/RedHat/7/x86_64/yum_data/packages.yaml
@@ -225,8 +225,8 @@ protobuf:
   :rpm_name: protobuf-2.5.0-8.el7.x86_64.rpm
   :source: http://mirror.centos.org/centos/7/os/x86_64/Packages/protobuf-2.5.0-8.el7.x86_64.rpm
 puppet-agent:
-  :rpm_name: puppet-agent-6.18.0-1.el7.x86_64.rpm
-  :source: https://yum.puppet.com/puppet/el/7/x86_64/puppet-agent-6.18.0-1.el7.x86_64.rpm
+  :rpm_name: puppet-agent-6.21.1-1.el7.x86_64.rpm
+  :source: https://yum.puppet.com/puppet6/el/7/x86_64/puppet-agent-6.21.1-1.el7.x86_64.rpm
 puppet-bolt:
   :rpm_name: puppet-bolt-2.29.0-1.el7.x86_64.rpm
   :source: https://yum.puppet.com/puppet/el/7/x86_64/puppet-bolt-2.29.0-1.el7.x86_64.rpm

--- a/spec/acceptance/common_files/beaker_hiera.yaml
+++ b/spec/acceptance/common_files/beaker_hiera.yaml
@@ -1,5 +1,11 @@
 ---
-# Settings to make beaker happy
+# Settings for test access
+# * vagrant ssh access to nodes using the public key in /home/vagrant/.ssh/authorized_keys
+#   - This allows you to `vagrant ssh` into the node
+#
+# * root ssh access to nodes using the public key in /root/.ssh/authorized_keys
+#   - This allows beaker to access nodes during test steps (e.g., on(host,...)
+#
 sudo::user_specifications:
   vagrant_all:
     user_list:

--- a/spec/acceptance/common_files/simp_conf.yaml.erb
+++ b/spec/acceptance/common_files/simp_conf.yaml.erb
@@ -13,11 +13,37 @@
 # NOTE:
 # - All YAML keys that begin with 'cli::' are used by
 #   simp config, internally, and are not Puppet hieradata.
+# - Some entries have been automatically determined by
+#   `simp config` based on the values of other entries
+#   and/or gathered server status.
 #========================================================================
 ---
 # === cli::version ===
 # The version of simp-cli used to generate this file.
-cli::version: "5.0.0"
+cli::version: "6.2.0"
+
+# === chrony::servers ===
+# NTP time servers used by cronyd
+chrony::servers: "%{alias('simp_options::ntp::servers')}"
+
+# === cli::ensure_priv_local_user ===
+# Whether to configure a privileged local user to prevent server lockout
+# after bootstrap.
+#
+# SIMP by default disables remote logins for all users and disables `root`
+# logins at the console. So, after bootstrap, you are very likely to lose
+# access to this system, **unless** you configure a local user to have
+# `sudo` and `ssh` access.
+#
+# Enter 'yes' if want to configure a local user to have `sudo` and `ssh`
+# access after bootstrap.
+#
+# * You will select the local user to configure.
+# * The local user will be created for you if it does not already exist.
+# * If the user already exists and has ssh authorized keys, those keys
+#   will be copied to /etc/ssh/local_keys/, the default directory for
+#   local user SSH authorized keys files in SIMP.
+cli::ensure_priv_local_user: false
 
 # === cli::is_simp_ldap_server ===
 # Whether the SIMP server will also be a SIMP-provided LDAP server.
@@ -73,7 +99,6 @@ cli::network::netmask: <%= netmask %>
 # You should enter 'yes' if the interface has not yet been configured.
 # You may want to enter 'yes', if you want to reconfigure it and are **NOT**
 # logged into the server via this interface.
-#
 cli::network::set_up_nic: false
 
 # === cli::set_grub_password ===
@@ -127,6 +152,14 @@ puppetdb::master::config::puppetdb_server: "%{hiera('simp_options::puppet::serve
 # The default system runlevel (1-5).
 simp::runlevel: 3
 
+# === simp::server::allow_simp_user ===
+# Whether to allow local 'simp' user su and ssh privileges.
+#
+# When SIMP is installed from ISO, a local user 'simp' is created to
+# prevent server lockout. This capability should only be enabled
+# when this user has been created.
+simp::server::allow_simp_user: false
+
 # === simp_openldap::server::conf::rootpw ===
 # The salted LDAP Root password hash.
 #
@@ -147,14 +180,14 @@ simp_options::dns::search: [ <%= domain %> ]
 # all clients will configure themselves as caching DNS servers
 # pointing to the other entries in the list.
 #
-# If you have a system that's including the 'named' class and
-# is *not* in this list, then you'll need to set a variable at
-# the top of that node entry called $named_server to 'true'.
-# This will get around the convenience logic that was put in
-# place to handle the caching entries and will not attempt to
-# convert your system to a caching DNS server. You'll know
-# that you have this situation if you end up with a duplicate
-# definition for File['/etc/named.conf'].
+# If you are using the SIMP ``resolv`` module, and the system is a DNS server
+# using the SIMP ``named`` module but you wish to have your node point to a
+# different DNS server for primary DNS resolution, then you MUST set
+# ``resolv::named_server`` to ``true`` via Hiera.
+#
+# This will get around the convenience logic that was put in place to handle
+# the caching entries and will not attempt to convert your system to a
+# caching DNS server.
 simp_options::dns::servers: [ <%= nameserver %> ]
 
 # === simp_options::ldap ===
@@ -229,8 +262,11 @@ simp_options::trusted_nets: <%= (trusted_nets.nil? or trusted_nets.empty?) ? '[]
 #
 # * When you are using SIMP-provided LDAP, this field should include `LDAP`,
 #   the name of the SSSD domain SIMP creates.
-# * Otherwise, this field must be a valid domain ('Local' and/or a custom
-#   domain) or the sssd service will fail to start.
+# * This field may include 'LOCAL', to use the domain SIMP creates with
+#   the 'files' provider.
+#
+# IMPORTANT: For EL < 8, this field *MUST* have a valid domain or the sssd
+# service will fail to start.
 #
 sssd::domains:
 - LDAP

--- a/spec/acceptance/common_files/simp_conf.yaml_no_ldap.erb
+++ b/spec/acceptance/common_files/simp_conf.yaml_no_ldap.erb
@@ -1,7 +1,7 @@
 #========================================================================
 # simp config answers
 #
-# Generated for 'simp' scenario on 2019-05-23 20:42:35
+# Generated for <%= scenario %> scenario for simp-core tests:
 #------------------------------------------------------------------------
 # You can use these answers to quickly configure subsequent
 # simp installations by running the command:
@@ -17,7 +17,30 @@
 ---
 # === cli::version ===
 # The version of simp-cli used to generate this file.
-cli::version: "5.0.0"
+cli::version: "6.2.0"
+
+# === chrony::servers ===
+# NTP time servers used by cronyd
+chrony::servers: "%{alias('simp_options::ntp::servers')}"
+
+# === cli::ensure_priv_local_user ===
+# Whether to configure a privileged local user to prevent server lockout
+# after bootstrap.
+#
+# SIMP by default disables remote logins for all users and disables `root`
+# logins at the console. So, after bootstrap, you are very likely to lose
+# access to this system, **unless** you configure a local user to have
+# `sudo` and `ssh` access.
+#
+# Enter 'yes' if want to configure a local user to have `sudo` and `ssh`
+# access after bootstrap.
+#
+# * You will select the local user to configure.
+# * The local user will be created for you if it does not already exist.
+# * If the user already exists and has ssh authorized keys, those keys
+#   will be copied to /etc/ssh/local_keys/, the default directory for
+#   local user SSH authorized keys files in SIMP.
+cli::ensure_priv_local_user: false
 
 # === cli::is_simp_ldap_server ===
 # Whether the SIMP server will also be a SIMP-provided LDAP server.
@@ -73,7 +96,6 @@ cli::network::netmask: <%= netmask %>
 # You should enter 'yes' if the interface has not yet been configured.
 # You may want to enter 'yes', if you want to reconfigure it and are **NOT**
 # logged into the server via this interface.
-#
 cli::network::set_up_nic: false
 
 # === cli::set_grub_password ===
@@ -127,6 +149,14 @@ puppetdb::master::config::puppetdb_server: "%{hiera('simp_options::puppet::serve
 # The default system runlevel (1-5).
 simp::runlevel: 3
 
+# === simp::server::allow_simp_user ===
+# Whether to allow local 'simp' user su and ssh privileges.
+#
+# When SIMP is installed from ISO, a local user 'simp' is created to
+# prevent server lockout. This capability should only be enabled
+# when this user has been created.
+simp::server::allow_simp_user: false
+
 
 # === simp_options::dns::search ===
 # The DNS domain search string.
@@ -141,16 +171,15 @@ simp_options::dns::search: [ <%= domain %> ]
 # all clients will configure themselves as caching DNS servers
 # pointing to the other entries in the list.
 #
-# If you have a system that's including the 'named' class and
-# is *not* in this list, then you'll need to set a variable at
-# the top of that node entry called $named_server to 'true'.
-# This will get around the convenience logic that was put in
-# place to handle the caching entries and will not attempt to
-# convert your system to a caching DNS server. You'll know
-# that you have this situation if you end up with a duplicate
-# definition for File['/etc/named.conf'].
+# If you are using the SIMP ``resolv`` module, and the system is a DNS server
+# using the SIMP ``named`` module but you wish to have your node point to a
+# different DNS server for primary DNS resolution, then you MUST set
+# ``resolv::named_server`` to ``true`` via Hiera.
+#
+# This will get around the convenience logic that was put in place to handle
+# the caching entries and will not attempt to convert your system to a
+# caching DNS server.
 simp_options::dns::servers: [ <%= nameserver %> ]
-
 
 # === simp_options::ntp::servers ===
 # Your network's NTP time servers.
@@ -202,11 +231,13 @@ simp_options::trusted_nets: <%= (trusted_nets.nil? or trusted_nets.empty?) ? '[]
 #
 # * When you are using SIMP-provided LDAP, this field should include `LDAP`,
 #   the name of the SSSD domain SIMP creates.
-# * Otherwise, this field must be a valid domain ('Local' and/or a custom
-#   domain) or the sssd service will fail to start.
+# * This field may include 'LOCAL', to use the domain SIMP creates with
+#   the 'files' provider.
 #
-sssd::domains:
-- Local
+# IMPORTANT: For EL < 8, this field *MUST* have a valid domain or the sssd
+# service will fail to start.
+#
+sssd::domains: <%= (sssd_domains.nil? or sssd_domains.empty?) ? '[]': '[ ' + sssd_domains.join(', ') + ' ]' %>
 
 # === svckill::mode ===
 # Strategy svckill should use when it encounters undeclared services.

--- a/spec/acceptance/helpers/puppet_helper.rb
+++ b/spec/acceptance/helpers/puppet_helper.rb
@@ -36,15 +36,18 @@ module Acceptance
         on(master, "grep #{domain} #{autosign_file}")
       end
 
+      # @return the puppetserver status command to be executed on the
+      #   puppetserver
+      #
+      # When the command succeeds on the puppetserver node, the
+      # puppetserver is up and accepting connections.
       def puppetserver_status_command(master_fqdn)
         [
-          'curl -sk',
+          'curl -sSk',
           "--cert /etc/puppetlabs/puppet/ssl/certs/#{master_fqdn}.pem",
           "--key /etc/puppetlabs/puppet/ssl/private_keys/#{master_fqdn}.pem",
-          "https://#{master_fqdn}:8140/status/v1/services",
-          '| python -m json.tool',
-          '| grep state',
-          '| grep running'
+          "https://localhost:8140/production/certificate_revocation_list/ca",
+          '| grep CRL'
         ].join(' ')
       end
 

--- a/spec/acceptance/shared_examples/simp_client_bootstrap_manual.rb
+++ b/spec/acceptance/shared_examples/simp_client_bootstrap_manual.rb
@@ -11,7 +11,7 @@ include Acceptance::Helpers::Utils
 #   :master      - puppetserver Host
 #   :master_fqdn - FQDN of the puppetmaster
 #
-shared_examples 'SIMP client manual bootstrap' do |agent, options|
+shared_examples 'SIMP client manual bootstrap' do |agents, options|
 
   let(:domain) { options[:domain] }
   let(:master) { options[:master] }

--- a/spec/acceptance/shared_examples/simp_server_bootstrap.rb
+++ b/spec/acceptance/shared_examples/simp_server_bootstrap.rb
@@ -76,6 +76,9 @@ shared_examples 'SIMP server bootstrap' do |master, config|
       #
       # The following variables are require only by simp_conf.yaml.erb
       #   ldap_root_password_hash
+      #
+      # The following variables are require only by simp_conf.yaml_no_ldap.erb
+      #   sssd_domains
 
       trusted_nets =  host_networks(master)
       expect(trusted_nets).to_not be_empty
@@ -93,6 +96,9 @@ shared_examples 'SIMP server bootstrap' do |master, config|
 
       if config.fetch(:simp_ldap_server, true)
         ldap_root_password_hash = encrypt_openldap_password(test_password)
+      else
+        el7_master = (fact_on(master, 'operatingsystemmajrelease') == '7')
+        sssd_domains = el7_master ? ['local'] : []
       end
 
       if config.has_key?(:simp_scenario)
@@ -141,7 +147,7 @@ shared_examples 'SIMP server bootstrap' do |master, config|
       #   when the puppetserver RPM was installed
       # - Allow interruptions so we can kill the test easily during bootstrap
       on(master, 'rm -f /root/.simp/simp_bootstrap_start_lock')
-      on(master, 'simp bootstrap -u -w 10 --remove_ssldir', :pty => true)
+      on(master, 'simp bootstrap -u -w 10 --remove_ssldir -v', :pty => true)
     end
 
     it 'should reboot the master to apply boot time config' do

--- a/spec/acceptance/suites/simp_lite/20_local_users_wheel_spec.rb
+++ b/spec/acceptance/suites/simp_lite/20_local_users_wheel_spec.rb
@@ -24,7 +24,7 @@ describe 'Wheel configuration test' do
     hosts.each do |host|
       it 'should su on clients but not on puppetserver' do
         # Looks like some of the vagrant boxes (el8 mostly) have added
-        # restritions to pam.d/su to not allow anyone to su to root
+        # restrictions to pam.d/su to not allow anyone to su to root
         # using pam_succeed_if user notin root:vagrant
         # This will remove that line from /etc/pam.d/su if it exists.
         on(host,'sed -i  \'/^account\s*required\s*pam_succeed_if.so user notin .*$/d\' /etc/pam.d/su')


### PR DESCRIPTION
* Bumped version of puppet-agent to 6.22.1
  - PE has been updated to 6.22.1
  - In the acceptance tests, `simp bootstrap` fails with 6.18.0

* Test updates:
  - Updated simp-core acceptance tests to work with simp cli version
    that prompts for configuration of a privileged local user.
    - Updated answers files to disable configuration of the privileged
      local user instead of specifying vagrant as that user, because
      this is a multi-node test in which all nodes need vagrant ssh
      access, not just the puppetserver.

  - Updated the (mock) simp cli installation to `gem install` the simp-cli
    and highline gems in the same gem directory.
    - This avoids inadvertently using the old highline gem version that
      comes with puppet-agent. The old version does not have the same
      API as the new version and can cause odd simp cli runtime failures.

  - Updated other parts of the `simp config` answers files for consistency.

  - EL8 puppetserver prep:
    - Added logic to determine the correct sssd::domains value in the
      non-LDAP `simp config` answers file.
    - Eliminated the unversioned `python` command from the test command used
      to determine if the puppetserver is up. The `python` command is not
      available on EL8.

SIMP-9421 #close