### PR TITLE
(SIMP-9282) 2nd set of external module deps updates

### DIFF
--- a/Puppetfile.branches
+++ b/Puppetfile.branches
@@ -77,7 +77,7 @@ mod 'herculesteam-augeasproviders_grub',
 
 mod 'herculesteam-augeasproviders_ssh',
   :git => 'https://github.com/simp/augeasproviders_ssh',
-  :tag => '3.3.0'
+  :tag => '4.0.0'
 
 mod 'herculesteam-augeasproviders_sysctl',
   :git => 'https://github.com/simp/augeasproviders_sysctl',
@@ -89,7 +89,7 @@ mod 'onyxpoint-gpasswd',
 
 mod 'puppetlabs-apache',
   :git => 'https://github.com/simp/puppetlabs-apache',
-  :tag => 'v5.5.0'
+  :tag => 'v6.2.0'
 
 mod 'puppetlabs-concat',
   :git => 'https://github.com/simp/puppetlabs-concat',
@@ -105,11 +105,11 @@ mod 'puppetlabs-inifile',
 
 mod 'puppetlabs-java',
   :git => 'https://github.com/simp/puppetlabs-java',
-  :tag => 'v6.2.0'
+  :tag => 'v7.0.2'
 
 mod 'puppetlabs-motd',
   :git => 'https://github.com/simp/puppetlabs-motd',
-  :tag => 'v4.1.0'
+  :tag => 'v6.0.0'
 
 mod 'puppetlabs-mysql',
   :git => 'https://github.com/simp/puppetlabs-mysql',
@@ -145,7 +145,7 @@ mod 'saz-locales',
 
 mod 'saz-timezone',
   :git => 'https://github.com/simp/pupmod-simp-timezone',
-  :tag => 'v5.2.0'
+  :tag => 'v6.1.0'
 
 mod 'simp-acpid',
   :git => 'https://github.com/simp/pupmod-simp-acpid',
@@ -508,7 +508,7 @@ mod 'voxpupuli-posix_acl',
 
 mod 'voxpupuli-gitlab',
   :git => 'https://github.com/simp/puppet-gitlab.git',
-  :tag => 'v6.0.1'
+  :tag => 'v7.1.0'
 
 mod 'voxpupuli-snmp',
   :git => 'https://github.com/simp/puppet-snmp',

--- a/Puppetfile.pinned
+++ b/Puppetfile.pinned
@@ -80,7 +80,7 @@ mod 'herculesteam-augeasproviders_grub',
 
 mod 'herculesteam-augeasproviders_ssh',
   :git => 'https://github.com/simp/augeasproviders_ssh',
-  :tag => '3.3.0'
+  :tag => '4.0.0'
 
 mod 'herculesteam-augeasproviders_sysctl',
   :git => 'https://github.com/simp/augeasproviders_sysctl',
@@ -92,7 +92,7 @@ mod 'onyxpoint-gpasswd',
 
 mod 'puppetlabs-apache',
   :git => 'https://github.com/simp/puppetlabs-apache',
-  :tag => 'v5.5.0'
+  :tag => 'v6.2.0'
 
 mod 'puppetlabs-concat',
   :git => 'https://github.com/simp/puppetlabs-concat',
@@ -108,11 +108,11 @@ mod 'puppetlabs-inifile',
 
 mod 'puppetlabs-java',
   :git => 'https://github.com/simp/puppetlabs-java',
-  :tag => 'v6.2.0'
+  :tag => 'v7.0.2'
 
 mod 'puppetlabs-motd',
   :git => 'https://github.com/simp/puppetlabs-motd',
-  :tag => 'v4.1.0'
+  :tag => 'v6.0.0'
 
 mod 'puppetlabs-mysql',
   :git => 'https://github.com/simp/puppetlabs-mysql',
@@ -148,7 +148,7 @@ mod 'saz-locales',
 
 mod 'saz-timezone',
   :git => 'https://github.com/simp/pupmod-simp-timezone',
-  :tag => 'v5.2.0'
+  :tag => 'v6.1.0'
 
 mod 'simp-acpid',
   :git => 'https://github.com/simp/pupmod-simp-acpid',
@@ -512,7 +512,7 @@ mod 'voxpupuli-posix_acl',
 
 mod 'voxpupuli-gitlab',
   :git => 'https://github.com/simp/puppet-gitlab.git',
-  :tag => 'v6.0.1'
+  :tag => 'v7.1.0'
 
 mod 'voxpupuli-snmp',
   :git => 'https://github.com/simp/puppet-snmp',

--- a/build/rpm/dependencies.yaml
+++ b/build/rpm/dependencies.yaml
@@ -80,14 +80,10 @@
 # (4) This file is only used for simp-rake-helpers >= 5.3.0
 ---
 
-'docker':
-  :requires:
-    # exclude pupmod-puppetlabs-apt
-    # exclude the following modules required for operation on Windows:
-    #   pupmod-puppetlabs-powershell
-    #   pupmod-puppetlabs-reboot
-    - 'pupmod-puppetlabs-stdlib'
-    - 'pupmod-puppetlabs-translate'
+# Vox Pupuli has assumed ownership of the chrony project
+'chrony':
+  :obsoletes:
+    'pupmod-aboe-chrony': '0.3.1-0'
 
 'ds389':
   :requires:
@@ -98,7 +94,7 @@
     - 'pupmod-simp-simplib'
     - 'pupmod-simp-vox_selinux'
 
-# Vox Pupuli has assumed ownership of the this project
+# Vox Pupuli has assumed ownership of the gitlab project
 'gitlab':
   :obsoletes:
     'pupmod-vshn-gitlab': '1.13.3-2016.1'
@@ -129,7 +125,6 @@
   :requires:
     # exclude pupmod-puppetlabs-registry
     - 'pupmod-puppetlabs-stdlib'
-    - 'pupmod-puppetlabs-translate'
 
 # pupmod-puppetlabs-mount_providers-1.0.0-0 has a packaging bug in which
 # simp_rpm_helper is called in %post instead of %posttrans.  Need to
@@ -179,7 +174,7 @@
   :obsoletes:
     'pupmod-razorsedge-snmp': '3.9.0-0'
 
-# Camptocamp has assumed ownership of the this project
+# Camptocamp has assumed ownership of the systemd project
 'systemd':
   :obsoletes:
     'pupmod-simp-systemd': '2.1.0-0'

--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,7 @@
     },
     {
       "name": "herculesteam/augeasproviders_ssh",
-      "version_requirement": ">= 3.3.0 < 4.0.0"
+      "version_requirement": ">= 4.0.0 < 5.0.0"
     },
     {
       "name": "herculesteam/augeasproviders_sysctl",
@@ -56,7 +56,7 @@
     },
     {
       "name": "puppetlabs/apache",
-      "version_requirement": ">= 5.5.0 < 6.0.0"
+      "version_requirement": ">= 6.2.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/concat",
@@ -72,7 +72,7 @@
     },
     {
       "name": "puppetlabs/motd",
-      "version_requirement": ">= 4.1.0 < 5.0.0"
+      "version_requirement": ">= 6.0.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/postgresql",
@@ -92,7 +92,7 @@
     },
     {
       "name": "saz/timezone",
-      "version_requirement": ">= 5.2.0 < 6.0.0"
+      "version_requirement": ">= 6.1.0 < 7.0.0"
     },
     {
       "name": "simp/acpid",

--- a/src/assets/simp/build/simp.spec
+++ b/src/assets/simp/build/simp.spec
@@ -24,30 +24,27 @@ Obsoletes: pupmod-simp-mcollective <= 3.0.0
 # Required for upgrades to SIMP 6.4+
 Obsoletes: pupmod-simp-simpcat <= 6.0.3
 
-# Required for upgrades to SIMP 6.6_
-Obsoletes: pupmod-aboe-chrony <= 0.3.1
-
 # Core SIMP Requirements
 Requires: pupmod-camptocamp-kmod >= 2.5.0, pupmod-camptocamp-kmod < 3.0.0
 Requires: pupmod-camptocamp-systemd >= 2.12.0, pupmod-camptocamp-systemd < 3.0.0
 Requires: pupmod-herculesteam-augeasproviders_core >= 2.7.0, pupmod-herculesteam-augeasproviders_core < 3.0.0
 Requires: pupmod-herculesteam-augeasproviders_grub >= 3.2.0, pupmod-herculesteam-augeasproviders_grub < 4.0.0
-Requires: pupmod-herculesteam-augeasproviders_ssh >= 3.3.0, pupmod-herculesteam-augeasproviders_ssh < 4.0.0
+Requires: pupmod-herculesteam-augeasproviders_ssh >= 4.0.0, pupmod-herculesteam-augeasproviders_ssh < 5.0.0
 Requires: pupmod-herculesteam-augeasproviders_sysctl >= 2.6.0 pupmod-herculesteam-augeasproviders_sysctl < 3.0.0
 Requires: pupmod-onyxpoint-gpasswd >= 1.1.2, pupmod-onyxpoint-gpasswd < 2.0.0
 Requires: pupmod-puppet-chrony >= 1.0.0, pupmod-puppet-chrony < 2.0.0
 Requires: pupmod-puppet-firewalld => 4.4.0, pupmod-puppet-firewalld < 5.0.0
 Requires: pupmod-puppet-yum >= 4.3.0, pupmod-puppet-yum < 5.0.0
-Requires: pupmod-puppetlabs-apache >= 3.0.0, pupmod-puppetlabs-apache < 6.0.0
+Requires: pupmod-puppetlabs-apache >= 6.2.0, pupmod-puppetlabs-apache < 7.0.0
 Requires: pupmod-puppetlabs-concat >= 6.2.0, pupmod-puppetlabs-concat < 7.0.0
 Requires: pupmod-puppetlabs-hocon >= 1.1.0, pupmod-puppetlabs-hocon < 2.0.0
 Requires: pupmod-puppetlabs-inifile >= 4.1.0, pupmod-puppetlabs-inifile < 5.0.0
-Requires: pupmod-puppetlabs-motd >= 4.1.0, pupmod-puppetlabs-motd < 5.0.0
+Requires: pupmod-puppetlabs-motd >= 6.0.0, pupmod-puppetlabs-motd < 7.0.0
 Requires: pupmod-puppetlabs-postgresql >= 6.6.0, pupmod-puppetlabs-postgresql < 7.0.0
 Requires: pupmod-puppetlabs-puppet_authorization >= 0.5.1, pupmod-puppetlabs-puppet_authorization < 1.0.0
 Requires: pupmod-puppetlabs-puppetdb >= 7.5.0, pupmod-puppetlabs-puppetdb < 8.0.0
 Requires: pupmod-puppetlabs-stdlib >= 6.6.0, pupmod-puppetlabs-stdlib < 7.0.0
-Requires: pupmod-saz-timezone >= 5.2.0, pupmod-saz-timezone < 6.0.0
+Requires: pupmod-saz-timezone >= 6.1.0, pupmod-saz-timezone < 7.0.0
 Requires: pupmod-simp-acpid >= 1.2.0, pupmod-simp-acpid < 2.0.0
 Requires: pupmod-simp-aide >= 6.4.2, pupmod-simp-aide < 7.0.0
 Requires: pupmod-simp-at >= 0.1.0, pupmod-simp-at < 1.0.0
@@ -137,10 +134,10 @@ Obsoletes:  pupmod-simp-simp_docker  <= 0.2.1
 Obsoletes:  pupmod-simp-journald   <= 1.1.0
 
 Requires: simp-adapter >= 2.0.0, simp-adapter < 3.0.0
-Requires: pupmod-puppet-gitlab >= 6.0.1
+Requires: pupmod-puppet-gitlab >= 7.1.0
 Requires: pupmod-puppet-posix_acl >= 1.0.1
 Requires: pupmod-puppet-snmp >= 5.1.1
-Requires: pupmod-puppetlabs-java >= 6.2.0
+Requires: pupmod-puppetlabs-java >= 7.0.2
 Requires: pupmod-puppetlabs-mysql >= 10.4.0
 Requires: pupmod-puppetlabs-ruby_task_helper >= 0.6.0
 Requires: pupmod-puppetlabs-translate >= 2.1.0


### PR DESCRIPTION
* Updated
  - herculesteam-augeasproviders_ssh major version bump to 4.0.0
    - Verified to work with simp-ssh and simp-simp_gitlab
  - puppetlabs-apache major version bump to v6.2.0
    - Not used by any SIMP-packaged modules
  - puppetlabs-java major version bump to v7.0.2
    - Verified to work with simp-hirs_provisioner
  - puppetlabs-motd two major version bumps to v6.0.0
    - Not used by any SIMP-packaged modules
  - saz-timezone major version bump to v6.1.0
    - Verified to work with simp-simp (which just includes the class)
  - voxpupuli-gitlab major version bump to v7.1.0
    - Verified to work with simp-simp_gitlab

* Fixed
  - Fixed the wrong mechanism I had used to obsolete aboe/chrony
    in the previous commit.
  - Removed OBE 'docker' entry in dependencies.yaml