### PR TITLE
(SIMP-10426) KMOD obsolete fix

### DIFF
--- a/build/rpm/dependencies.yaml
+++ b/build/rpm/dependencies.yaml
@@ -111,7 +111,7 @@
 # Voxpupuli has taken ownership of this project
 'kmod':
   :obsoletes:
-    'pupmod-camptocamp-kmod': '3.0.0'
+    'pupmod-camptocamp-kmod': '2.5.0-0'
 
 # pupmod-saz-locales-2.5.1-0 has a packaging bug in which the RPM state
 # directory used contains an unexpanded RPM macro (the string


### PR DESCRIPTION
-  Correct the version of camptocamp-kmod module in the
   dependencies.yaml file so it obsoletes the old kmod module correctly.

SIMP-10426 #close