### PR TITLE
(SIMP-MAINT) Update puppetdb repo URL

### DIFF
--- a/Puppetfile.branches
+++ b/Puppetfile.branches
@@ -120,7 +120,7 @@ mod 'puppetlabs-postgresql',
   :tag => 'v6.6.0'
 
 mod 'puppetlabs-puppetdb',
-  :git => 'https://github.com/simp/puppetlabs-puppetdb',
+  :git => 'https://github.com/simp/pupmod-puppetlabs-puppetdb',
   :tag => '7.5.0'
 
 mod 'puppetlabs-puppet_authorization',

--- a/Puppetfile.pinned
+++ b/Puppetfile.pinned
@@ -123,7 +123,7 @@ mod 'puppetlabs-postgresql',
   :tag => 'v6.6.0'
 
 mod 'puppetlabs-puppetdb',
-  :git => 'https://github.com/simp/puppetlabs-puppetdb',
+  :git => 'https://github.com/simp/pupmod-puppetlabs-puppetdb',
   :tag => '7.5.0'
 
 mod 'puppetlabs-puppet_authorization',


### PR DESCRIPTION
The URL to the puppetlabs-puppetdb repo changed.
This patch avoids the need to rely on GitHub's redirect.