### PR TITLE
(SIMP-10593) EL8 kickstart files

### DIFF
--- a/build/distributions/CentOS/8/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/8/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -53,9 +53,6 @@ url --noverifyssl --url=https://#YUMSERVER#/yum/#LINUXDIST#/8/x86_64
 network --bootproto=dhcp
 reboot
 
-module --name=javapackages-runtime --stream=common
-module --name=httpd --stream=common
-
 %packages
 -sendmail
 acl
@@ -225,10 +222,8 @@ if $FIPS; then
 else
    FIPS_SETTING=0
 fi
-# Remove ALL fips= duplicates.
-until [ "$(/sbin/grubby --info=${DEFAULT_KERNEL_INFO} | grep args | grep -o fips | wc -l)" -eq 0 ]; do
-  /sbin/grubby --remove-args="fips" --update-kernel=DEFAULT
-done
+# Replace fips= in boot command line.
+/sbin/grubby --remove-args="fips" --update-kernel=DEFAULT
 /sbin/grubby --args="boot=${BOOTUUID} fips=${FIPS_SETTING}" --update-kernel=DEFAULT
 
 # For the disk crypto


### PR DESCRIPTION
- remove loop cmdline arg. It gets stuck in a loop.  A single removal
  and then adding it back in correctly works.
- remove module enables.  They were wrong and not needed.

SIMP-10593 #close