### PR TITLE
(SIMP-10618) simp-core EL8 client ks config file fixes

### DIFF
--- a/build/distributions/CentOS/8/x86_64/DVD/ks/pupclient_x86_64.cfg
+++ b/build/distributions/CentOS/8/x86_64/DVD/ks/pupclient_x86_64.cfg
@@ -50,6 +50,11 @@ keyboard us
 lang en_US
 url --noverifyssl --url=https://#YUMSERVER#/yum/#LINUXDIST#/8/x86_64
 
+module --name=python36 --stream=3.6
+module --name=perl --stream=5.26
+module --name=perl-IO-Socket-SSL --stream=2.066
+module --name=perl-libwww-perl --stream=6.34
+
 network --bootproto=dhcp
 reboot
 
@@ -70,7 +75,6 @@ git
 grub2-efi-x64
 iptables
 irqbalance
-krb5-workstation
 libaio
 libutempter
 logrotate
@@ -93,7 +97,6 @@ shim-x64
 smartmontools
 sssd
 stunnel
-subversion
 sudo
 sysstat
 tmpwatch


### PR DESCRIPTION
EL8 client kickstart config fixes:
- Removed krb5-workstation and subversion from the list of required packages
- Added the following lines to enable modular repos required by the kickstart

  module --name=python36 --stream-3.6
  module --name=perl --stream=5.26
  module --name=perl-IO-Socket-SSL --stream=2.066
  module --name=perl-libwww-perl --stream=6.34

(SIMP-10618) #comment simp-core fixed