### PR TITLE
Fix the puppetfile:check rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ group :test do
   puppet_version = ENV['PUPPET_VERSION'] || '~> 6.22'
   major_puppet_version = puppet_version.scan(/(\d+)(?:\.|\Z)/).flatten.first.to_i
   gem 'rake'
+  gem 'terminal-table'
+  gem 'naturally'
   gem 'puppet', puppet_version
   gem 'rspec'
   gem 'rspec-puppet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
     commander (4.5.2)
       highline (~> 2.0.0)
     concurrent-ruby (1.1.9)
-    cri (2.15.11)
+    cri (2.15.10)
     deep_merge (1.2.1)
     diff-lcs (1.4.4)
     docker-api (2.2.0)
@@ -71,9 +71,9 @@ GEM
       multi_json
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    excon (0.87.0)
+    excon (0.88.0)
     facter (2.5.7)
-    facterdb (1.10.1)
+    facterdb (1.12.0)
       facter (< 5.0.0)
       jgrep
     faraday (0.17.4)
@@ -104,6 +104,7 @@ GEM
     json-schema (2.8.0)
       addressable (>= 2.4)
     json_pure (2.1.0)
+    jwt (2.2.3)
     locale (2.1.3)
     log4r (1.1.10)
     metadata-json-lint (3.0.1)
@@ -111,17 +112,20 @@ GEM
       spdx-licenses (~> 1.0)
     method_source (1.0.0)
     mime-types (2.99.3)
+    mini_portile2 (2.6.1)
     minitar (0.9)
     minitest (5.14.4)
     mocha (1.13.0)
     multi_json (1.15.0)
     multipart-post (2.1.1)
+    naturally (2.2.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (6.1.0)
     net-telnet (0.1.1)
     netrc (0.11.0)
-    nokogiri (1.12.5-x86_64-linux)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     oga (3.3)
       ast
@@ -163,7 +167,7 @@ GEM
       pry (~> 0.11)
       yard (~> 0.9.11)
     public_suffix (4.0.6)
-    puppet (6.25.0)
+    puppet (6.25.1)
       concurrent-ruby (~> 1.0)
       deep_merge (~> 1.0)
       facter (> 2.0.1, < 5)
@@ -178,7 +182,7 @@ GEM
       puppet (>= 2.7.16)
       rest-client (~> 1.8.0)
     puppet-lint (2.5.2)
-    puppet-lint-empty_string-check (0.2.2)
+    puppet-lint-empty_string-check (1.0.0)
       puppet-lint (>= 1.0, < 3.0)
     puppet-lint-trailing_comma-check (0.4.2)
       puppet-lint (>= 1.0, < 3.0)
@@ -202,12 +206,13 @@ GEM
       puppet-lint (~> 2.0)
       puppet-syntax (>= 2.0, < 4)
       rspec-puppet (~> 2.0)
-    r10k (3.8.0)
+    r10k (3.13.0)
       colored2 (= 3.1.2)
-      cri (>= 2.15.10, < 3.0.0)
+      cri (= 2.15.10)
       fast_gettext (~> 1.1.0)
       gettext (>= 3.0.2, < 3.3.0)
       gettext-setup (~> 0.24)
+      jwt (~> 2.2.3)
       log4r (= 1.1.10)
       multi_json (~> 1.10)
       puppet_forge (~> 2.3.0)
@@ -235,13 +240,13 @@ GEM
     rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-puppet (2.10.0)
+    rspec-puppet (2.11.0)
       rspec
     rspec-puppet-facts (2.0.3)
       facter
       facterdb (>= 0.5.0)
       puppet
-    rspec-support (3.10.2)
+    rspec-support (3.10.3)
     rsync (1.0.9)
     ruby-ll (2.1.2)
       ansi
@@ -285,12 +290,14 @@ GEM
       json (>= 1.0)
       rspec-puppet-facts
     spdx-licenses (1.3.0)
-    specinfra (2.83.0)
+    specinfra (2.83.1)
       net-scp
       net-ssh (>= 2.7)
       net-telnet (= 0.1.1)
       sfl
     stringify-hash (0.0.2)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
     text (1.3.1)
     thor (1.1.0)
     tty-color (0.6.0)
@@ -309,6 +316,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8)
+    unicode-display_width (2.1.0)
     vmfloaty (1.3.0)
       colorize (~> 0.8.1)
       commander (>= 4.4.3, < 4.6.0)
@@ -317,14 +325,14 @@ GEM
     yard (0.9.26)
 
 PLATFORMS
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   beaker
   beaker-rspec
   hiera-puppet-helper
   metadata-json-lint
-  pathspec (~> 0.2)
+  naturally
   pdk (~> 2.0)
   pry
   pry-byebug
@@ -341,6 +349,7 @@ DEPENDENCIES
   simp-build-helpers (> 0.1, < 2.0)
   simp-rake-helpers (>= 5.12.7, < 6)
   simp-rspec-puppet-facts (~> 3.1)
+  terminal-table
 
 BUNDLED WITH
-   2.2.29
+   1.17.3

--- a/rakelib/puppetfile.rake
+++ b/rakelib/puppetfile.rake
@@ -58,8 +58,6 @@ namespace :puppetfile do
     # Return past the status line
     puts ''
 
-    modules.each do |id, mod|
-      print_module_status(mod)
-    end
+    print_module_status(modules)
   end
 end


### PR DESCRIPTION
Changes in the release pages on GitHub caused the `puppetfile:check`
rake task to no longer function properly.

This update:
  * Fixes the issue
  * Provides better output formatting
  * Shows the next release if the pinned one is out of date

Closes #781
