### PR TITLE
Ignore SIMP_RPM_dist in rpm_build acceptance test

### DIFF
--- a/spec/acceptance/suites/rpm_docker/00_rpm_build_spec.rb
+++ b/spec/acceptance/suites/rpm_docker/00_rpm_build_spec.rb
@@ -53,6 +53,8 @@ def get_test_env
   test_env_variables = ENV.select { |env| env.match('^SIMP_') }
   env_string = ''
   test_env_variables.each do |key,value|
+    next if key == 'SIMP_RPM_dist'
+
     env_string += "#{key}=#{value} "
   end
 


### PR DESCRIPTION
Prevent the incorrect SIMP_RPM_dist environment variable from leaking
into the test.

Closes #785
