### PR TITLE
(SIMP-10621) Remove deprecated sssd-libwbclient 

### DIFF
--- a/build/distributions/CentOS/8/x86_64/bolt_pulp3_config.yaml
+++ b/build/distributions/CentOS/8/x86_64/bolt_pulp3_config.yaml
@@ -204,7 +204,6 @@ BaseOS:
   - name: sssd-krb5
   - name: sssd-krb5-common
   - name: sssd-ldap
-  - name: sssd-libwbclient
   - name: sssd-nfs-idmap
   - name: sssd-polkit-rules
   - name: sssd-proxy


### PR DESCRIPTION
Starting with RHEL 8.5 / CentOS 8 (2111), the sssd package obsoletes sssd-libwbclient (Nov 2021).

Closes #792
[SIMP-10621] #comment removed from pulp3 config in simp-core


[SIMP-10621]: https://simp-project.atlassian.net/browse/SIMP-10621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ