### PR TITLE
(SIMP-10621) Fix minor bolt_pulp3_config + CVE

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
     beaker-docker (1.0.1)
       docker-api (~> 2.1)
       stringify-hash (~> 0.0.0)
-    beaker-hostgenerator (1.8.0)
+    beaker-hostgenerator (1.10.0)
       deep_merge (~> 1.0)
     beaker-pe (2.11.16)
       beaker (~> 4.0)
@@ -39,7 +39,7 @@ GEM
       beaker-puppet (~> 1.0)
       beaker-vmpooler (~> 1.0)
       stringify-hash (~> 0.0.0)
-    beaker-puppet (1.22.1)
+    beaker-puppet (1.22.2)
       beaker (~> 4.1)
       in-parallel (~> 0.1)
       oga
@@ -63,17 +63,17 @@ GEM
     commander (4.5.2)
       highline (~> 2.0.0)
     concurrent-ruby (1.1.9)
-    cri (2.15.10)
-    deep_merge (1.2.1)
+    cri (2.15.11)
+    deep_merge (1.2.2)
     diff-lcs (1.4.4)
     docker-api (2.2.0)
       excon (>= 0.47.0)
       multi_json
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    excon (0.88.0)
+    excon (0.89.0)
     facter (2.5.7)
-    facterdb (1.12.0)
+    facterdb (1.12.2)
       facter (< 5.0.0)
       jgrep
     faraday (0.17.4)
@@ -81,7 +81,7 @@ GEM
     faraday_middleware (0.14.0)
       faraday (>= 0.7.4, < 1.0)
     fast_gettext (1.1.2)
-    ffi (1.15.4)
+    ffi (1.15.5)
     gettext (3.2.9)
       locale (>= 2.0.5)
       text (>= 1.3.0)
@@ -89,7 +89,7 @@ GEM
       fast_gettext (~> 1.1.0)
       gettext (>= 3.0.2, < 3.3.0)
       locale
-    hiera (3.7.0)
+    hiera (3.8.0)
     hiera-puppet-helper (1.0.1)
     highline (2.0.3)
     hitimes (2.0.0)
@@ -104,7 +104,6 @@ GEM
     json-schema (2.8.0)
       addressable (>= 2.4)
     json_pure (2.1.0)
-    jwt (2.2.3)
     locale (2.1.3)
     log4r (1.1.10)
     metadata-json-lint (3.0.1)
@@ -112,9 +111,8 @@ GEM
       spdx-licenses (~> 1.0)
     method_source (1.0.0)
     mime-types (2.99.3)
-    mini_portile2 (2.6.1)
     minitar (0.9)
-    minitest (5.14.4)
+    minitest (5.15.0)
     mocha (1.13.0)
     multi_json (1.15.0)
     multipart-post (2.1.1)
@@ -124,8 +122,7 @@ GEM
     net-ssh (6.1.0)
     net-telnet (0.1.1)
     netrc (0.11.0)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.0-x86_64-linux)
       racc (~> 1.4)
     oga (3.3)
       ast
@@ -188,7 +185,7 @@ GEM
       puppet-lint (>= 1.0, < 3.0)
     puppet-resource_api (1.8.14)
       hocon (>= 1.0)
-    puppet-strings (2.8.0)
+    puppet-strings (2.9.0)
       rgen
       yard (~> 0.9.5)
     puppet-syntax (3.1.0)
@@ -206,13 +203,12 @@ GEM
       puppet-lint (~> 2.0)
       puppet-syntax (>= 2.0, < 4)
       rspec-puppet (~> 2.0)
-    r10k (3.13.0)
+    r10k (3.8.0)
       colored2 (= 3.1.2)
-      cri (= 2.15.10)
+      cri (>= 2.15.10, < 3.0.0)
       fast_gettext (~> 1.1.0)
       gettext (>= 3.0.2, < 3.3.0)
       gettext-setup (~> 0.24)
-      jwt (~> 2.2.3)
       log4r (= 1.1.10)
       multi_json (~> 1.10)
       puppet_forge (~> 2.3.0)
@@ -240,7 +236,7 @@ GEM
     rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-puppet (2.11.0)
+    rspec-puppet (2.11.1)
       rspec
     rspec-puppet-facts (2.0.3)
       facter
@@ -259,7 +255,7 @@ GEM
       rspec-its
       specinfra (~> 2.72)
     sfl (2.3)
-    simp-beaker-helpers (1.24.0)
+    simp-beaker-helpers (1.24.1)
       beaker (>= 4.17.0, < 5.0.0)
       beaker-docker (>= 0.8.3, < 2.0.0)
       beaker-puppet (>= 1.18.14, < 2.0.0)
@@ -271,7 +267,7 @@ GEM
       net-telnet (~> 0.1.1)
       nokogiri (~> 1.8)
     simp-build-helpers (0.1.1)
-    simp-rake-helpers (5.12.7)
+    simp-rake-helpers (5.13.0)
       bundler (>= 1.14, < 3.0)
       pager (~> 1.0)
       parallel (~> 1.0)
@@ -299,7 +295,7 @@ GEM
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     text (1.3.1)
-    thor (1.1.0)
+    thor (1.2.1)
     tty-color (0.6.0)
     tty-cursor (0.7.1)
     tty-prompt (0.23.1)
@@ -321,11 +317,13 @@ GEM
       colorize (~> 0.8.1)
       commander (>= 4.4.3, < 4.6.0)
       faraday (~> 0.17.0)
+    webrick (1.7.0)
     wisper (2.0.1)
-    yard (0.9.26)
+    yard (0.9.27)
+      webrick (~> 1.7.0)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   beaker
@@ -352,4 +350,4 @@ DEPENDENCIES
   terminal-table
 
 BUNDLED WITH
-   1.17.3
+   2.3.4

--- a/build/distributions/CentOS/7/x86_64/bolt_pulp3_config.yaml
+++ b/build/distributions/CentOS/7/x86_64/bolt_pulp3_config.yaml
@@ -1,7 +1,7 @@
 # ------------------------------------------------------------------------------
 # FYI to future maintainers: This file was created to recreate the 6.5.0-1
 # release, but was not used to acquire the EL7 packages for 6.6.0-1 (EL7
-# packaes were acquited using the old rake helpers methods, including 
+# packages were acquired using the old rake helpers methods, including
 # `rake deps:checkout`, reading from `packages.yaml`)
 #
 # TODO: Before using this file to stage a new EL7 release, validate its
@@ -33,6 +33,14 @@
 #                   direct_urls (and no Remote mirror)  to the best available
 #                   versions or obey `version:` constraints.  Make sure any
 #                   direct_url URLs are kept up to date with new releases!
+#
+#  packagegroups: an (optional) list of RPM package groups
+#
+#     Mandatory keys for each packagegroup:
+#
+#     - id: [String] Packagegroup 'id' (view with `dnf grouplist --ids`)
+#
+#
 ---
 
 #
@@ -57,6 +65,9 @@ puppet:
 
 os:
   url: http://mirror.centos.org/centos/7/os/x86_64/
+  packagegroups:
+  - id: core
+  - id: base
   rpms:
   - name: apr-util-ldap
   - name: ima-evm-utils
@@ -1641,6 +1652,7 @@ extras:
   - name: createrepo_c
   - name: createrepo_c-libs
   - name: libssh
+  - name: libev
 epel:
   url: https://dl.fedoraproject.org/pub/epel/7/x86_64/
   rpms:
@@ -1666,7 +1678,6 @@ epel:
   - name: libXcomp
   - name: libXcompshad
   - name: libconfuse
-  - name: libev
   - name: libmatekbd
   - name: libmatemixer
   - name: libmateweather
@@ -1729,7 +1740,11 @@ postgresql:
   - name: postgresql96-server
 
 simp:
-  url: https://download.simp-project.com/SIMP/yum/releases/latest/el/7Server/x86_64/simp/
+  # FIXME: using /experimental/ during 6.6.0 EL8 development; change to latest when ready to release:
+  #
+  #   url: https://download.simp-project.com/SIMP/yum/releases/latest/el/8Server/x86_64/simp/
+  #
+  url: https://download.simp-project.com/SIMP/yum/releases/experimental/el/7Server/x86_64/simp/
   rpms:
   - name: HIRS_Provisioner_TPM_1_2
   - name: HIRS_Provisioner_TPM_2_0

--- a/build/distributions/CentOS/8/x86_64/bolt_pulp3_config.yaml
+++ b/build/distributions/CentOS/8/x86_64/bolt_pulp3_config.yaml
@@ -38,6 +38,36 @@
 #     - stream: [String] module stream in N:S format (ex: `httpd:2.4`)
 #
 ---
+
+epel:
+  url: https://download.fedoraproject.org/pub/epel/8/Everything/x86_64/
+  ###url: https://sjc.edge.kernel.org/fedora-buffet/epel/8/Everything/x86_64/
+  rpms:
+  - name: htop        # no deps
+  - name: vim-ansible # depends on appstream: vim-filesystem
+  - name: vim-airline
+  - name: vim-powerline
+  - name: vim-jellybeans
+  - name: liboath
+  - name: oathtool
+  - name: libnfs
+  - name: pam_oath
+  - name: redhat-display-fonts
+  - name: redhat-mono-fonts
+  - name: redhat-text-fonts
+  - name: rubygem-highline
+  - name: rubygem-net-ldap
+  - name: incron
+  - name: haveged
+  - name: dkms
+  - name: dnf-plugin-ovl
+  - name: clamav
+  - name: clamav-update
+  - name: clamd
+  - name: pwgen
+  - name: rkhunter
+  - name: openssh-ldap-authkeys # AuthorizedKeysCommand script for LDAP
+
 epel-modular:
   url: https://dl.fedoraproject.org/pub/epel/8/Modular/x86_64/
   modules:
@@ -204,6 +234,7 @@ BaseOS:
   - name: sssd-krb5
   - name: sssd-krb5-common
   - name: sssd-ldap
+  ### - name: sssd-libwbclient # SIMP-10621 - now missing from CentOS 8
   - name: sssd-nfs-idmap
   - name: sssd-polkit-rules
   - name: sssd-proxy
@@ -247,7 +278,8 @@ AppStream:
       #   - mysql-server
     - stream: perl:5.26
     - stream: perl-IO-Socket-SSL:2.066
-    - stream: perl-libwww-perl:6.34
+    # - stream: perl-libwww-perl:6.34 # NOTE: https://github.com/simp/bolt-pulp3/issues/19
+    - stream: perl-libwww-perl:6.34:8030020201223164340:b967a9a2:x86_64
       # rpms:
       #   - python3-distro
       #   - python3-lib389
@@ -391,35 +423,6 @@ PowerTools:
     - name: lua-filesystem
     - name: lua-posix
 
-epel:
-  url: https://download.fedoraproject.org/pub/epel/8/Everything/x86_64/
-  ###url: https://sjc.edge.kernel.org/fedora-buffet/epel/8/Everything/x86_64/
-  rpms:
-  - name: htop        # no deps
-  - name: vim-ansible # depends on appstream: vim-filesystem
-  - name: vim-airline
-  - name: vim-powerline
-  - name: vim-jellybeans
-  - name: liboath
-  - name: oathtool
-  - name: libnfs
-  - name: pam_oath
-  - name: redhat-display-fonts
-  - name: redhat-mono-fonts
-  - name: redhat-text-fonts
-  - name: rubygem-highline
-  - name: rubygem-net-ldap
-  - name: incron
-  - name: haveged
-  - name: dkms
-  - name: dnf-plugin-ovl
-  - name: clamav
-  - name: clamav-update
-  - name: clamd
-  - name: pwgen
-  - name: rkhunter
-  - name: openssh-ldap-authkeys # AuthorizedKeysCommand script for LDAP
-
 postgresql:
   url: https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-8-x86_64/
   rpms:
@@ -551,4 +554,3 @@ simp:
    - name: simp-vendored-r10k-gem-r10k
    - name: simp-vendored-r10k-gem-semantic_puppet
    - name: simp-vendored-r10k-gem-text
-


### PR DESCRIPTION
- Moved EL7 `libev` package from `epel` to `os` to reflect changes in
  upstream repos
- Pinned EL8 `perl-libwww-perl` to a specific NSVCA
  - Requires simp/bolt-pulp3#20
  - See [SIMP-10621] and simp/bolt-pulp3#19 for background
- `Added `packagegroups` `core` and `base` to the EL7 `os` repo to
  ensure they are included in slim repo copies' metadata.
- Bumped Puppet version in Gemfile.lock to mitigate CVE-2021-27023

[SIMP-10621] #close #comment Pinned sssd-libwbclient in EL8 pulp3 conf
[SIMP-10624] #close #comment EL7 libev package from epel to os

[SIMP-10621]: https://simp-project.atlassian.net/browse/SIMP-10621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SIMP-10621]: https://simp-project.atlassian.net/browse/SIMP-10621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SIMP-10624]: https://simp-project.atlassian.net/browse/SIMP-10624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ