### PR TITLE
Fix Hiera data logic in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -224,7 +224,7 @@ Vagrant.configure('2') do |c|
     #
     #  Enable the kickstart class
     v.vm.provision 'shell',
-      inline: %{echo "  - 'simp::server::kickstart'" >> /etc/puppetlabs/code/environments/production/data/hosts/puppet.test.simp.yaml}
+      inline: %{echo "- 'simp::server::kickstart'" >> /etc/puppetlabs/code/environments/production/data/hosts/puppet.test.simp.yaml}
 
     #  Add a newline
     v.vm.provision 'shell',


### PR DESCRIPTION
When `vagrant up` runs `simp bootstrap`, the command times out waiting
for the Puppet Server to switch from port 8150 to 8140.  This is because
the bootstrap's `puppet agent` are failing to compile because of
malformed YAML syntax in the `classes` array at the end of the
`data/hosts/puppet.test.simp.yaml`.

This patch fixes the `Vagrantfile` logic that introduces the malformed
YAML by matching the whitespace in the previous array element.

Closes #805