### PR TITLE
Add YAML syntax, GHA PR checks

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -1,0 +1,52 @@
+# Validate simple & quick things, like syntax & lint
+name: PR Validation
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+env:
+  # Required to prevent all rake tasks from exploding
+  SIMP_RPM_dist: .el7
+
+jobs:
+  validate-yaml:
+    name: YAML syntax
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - run: 'command -v rpm || if command -v apt-get; then apt-get update; apt-get install -y rpm; fi ||:'
+      - run: bundle exec rake check:syntax:yaml
+
+  rpm_checks:
+    name: RPM checks
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - run: 'command -v rpm || if command -v apt-get; then apt-get update; apt-get install -y rpm; fi ||:'
+      - run: |
+         command -v rpm || if command -v apt-get; then apt-get update; apt-get install -y rpm; fi ||:
+         bundle exec rake check:dot_underscore
+         bundle exec rake check:test_file
+
+  module_checks:
+    name: Puppet module checks
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - run: 'command -v rpm || if command -v apt-get; then apt-get update; apt-get install -y rpm; fi ||:'
+      - run: |
+          bundle exec rake metadata_lint
+          bundle exec pdk build --force --target-dir=dist

--- a/rakelib/yamllint.rake
+++ b/rakelib/yamllint.rake
@@ -1,0 +1,30 @@
+require 'find'
+
+namespace :check do
+  namespace :syntax do
+    desc <<~DESC
+      Check syntax of yaml files
+
+      Checks .yaml/.yml files in the top directory, and under build/ & .github/
+    DESC
+    task :yaml do
+      bad = []
+      seen = []
+      Rake::FileList.new(['{build/**/,.github/**/}*.{yaml,yml}']).each do |f|
+        begin
+          seen << f
+          YAML.safe_load(File.read(f), permitted_classes: [Symbol])
+        rescue Exception => e
+          STDERR.puts "\n", "-- #{f}", "#{e.class}: #{e.message}"
+          bad << f
+        end
+      end
+
+      puts "\nScanned #{seen.size} files, found #{bad.size} errors\n"
+      unless bad.empty?
+        STDERR.puts("ERROR: #{bad.size} YAML files failed loading during syntax check")
+        exit 1
+      end
+    end
+  end
+end

--- a/src/assets/simp/build/simp.spec
+++ b/src/assets/simp/build/simp.spec
@@ -242,7 +242,7 @@ fi
 # Post uninstall stuff
 
 %changelog
-* May 11 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.6.0-1
+* Wed May 11 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.6.0-1
 - Removed:
   - pupmod-puppetlabs-mysql
 


### PR DESCRIPTION
simp-core is the only critical path repo that doesn't have any GitHub actions.

This patch adds:
* A GHA pipeline that runs simple checks (based on `.gitlab-ci.yml`)
* A rake task for YAML syntax checks
* An RPM CHANGELOG fix for an error that was identified while testing the pipeline.