### PR TITLE
Add isomd5sum to the Build images

### DIFF
--- a/build/Dockerfiles/SIMP_EL7_Build.dockerfile
+++ b/build/Dockerfiles/SIMP_EL7_Build.dockerfile
@@ -50,7 +50,9 @@ RUN ./prime_ruby.sh
 RUN ./package_cleanup.sh
 RUN rm -rf /root/build_scripts
 
-WORKDIR /root
+ENV HOME=/home/build_user
+WORKDIR $HOME
+USER build_user
 
 # Drop into a shell for building
-CMD /bin/bash -c "su -l build_user"
+CMD /bin/bash -l

--- a/build/Dockerfiles/SIMP_EL8_Build.dockerfile
+++ b/build/Dockerfiles/SIMP_EL8_Build.dockerfile
@@ -28,7 +28,9 @@ RUN ./prime_ruby.sh
 RUN ./package_cleanup.sh
 RUN rm -rf /root/build_scripts
 
-WORKDIR /root
+ENV HOME=/home/build_user
+WORKDIR $HOME
+USER build_user
 
 # Drop into a shell for building
-CMD /bin/bash -c "su -l build_user"
+CMD /bin/bash -l

--- a/build/Dockerfiles/scripts/el7/10_dev_packages.sh
+++ b/build/Dockerfiles/scripts/el7/10_dev_packages.sh
@@ -6,7 +6,7 @@ yum-config-manager --enable extras
 yum install -y acl ||:
 yum install -y epel-release
 
-yum install -y openssl util-linux augeas-devel genisoimage git gnupg2 libicu-devel libxml2 libxml2-devel libxslt libxslt-devel which ruby-devel
+yum install -y openssl util-linux augeas-devel genisoimage isomd5sum git gnupg2 libicu-devel libxml2 libxml2-devel libxslt libxslt-devel which ruby-devel
 yum install -y rpm-build rpmdevtools rpm-devel rpm-sign yum-utils createrepo
 
 yum install -y centos-release-scl python-pip python-virtualenv fontconfig dejavu-sans-fonts dejavu-sans-mono-fonts dejavu-serif-fonts dejavu-fonts-common libjpeg-devel zlib-devel openssl-devel

--- a/build/Dockerfiles/scripts/el8/00_system_prep.sh
+++ b/build/Dockerfiles/scripts/el8/00_system_prep.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-sed -i -e 's@^mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=\([^&/=$]*\).*@baseurl=http://vault.centos.org/centos/$releasever/\1/$basearch/os/@g' /etc/yum.repos.d/CentOS-Linux-*.repo
+sed -i -e 's@^mirrorlist=http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=\([^&/=$]*\).*@baseurl=http://vault.centos.org/centos/$releasever/\1/$basearch/os/@g' /etc/yum.repos.d/CentOS-*.repo
 dnf clean all
 dnf makecache
 

--- a/build/Dockerfiles/scripts/el8/10_dev_packages.sh
+++ b/build/Dockerfiles/scripts/el8/10_dev_packages.sh
@@ -5,7 +5,7 @@ yum install -y epel-release
 yum remove -y dnf-utils ||:
 yum install -y --enablerepo=BaseOS --enablerepo=AppStream rpm-build rpmdevtools rpm-devel rpm-sign yum-utils
 yum install -y ruby-devel
-yum install -y util-linux openssl augeas-libs createrepo genisoimage git gnupg2 libicu-devel libxml2 libxml2-devel libxslt libxslt-devel which ruby-devel
+yum install -y util-linux openssl augeas-libs createrepo genisoimage isomd5sum git gnupg2 libicu-devel libxml2 libxml2-devel libxslt libxslt-devel which ruby-devel
 yum -y install scl-utils python2-virtualenv python3-virtualenv fontconfig dejavu-sans-fonts dejavu-sans-mono-fonts dejavu-serif-fonts dejavu-fonts-common libjpeg-devel zlib-devel openssl-devel
 yum install -y libyaml glibc-headers autoconf gcc gcc-c++ glibc-devel readline-devel libffi-devel automake libtool bison sqlite-devel pinentry
 


### PR DESCRIPTION
Added the `isomd5sum` package to the Docker build images to support the
changes in https://github.com/simp/simp-rake-helpers#187 when building an ISO.

Closes #822
