### PR TITLE
Revert addition of build container USER

### DIFF
--- a/build/Dockerfiles/SIMP_EL7_Build.dockerfile
+++ b/build/Dockerfiles/SIMP_EL7_Build.dockerfile
@@ -50,9 +50,5 @@ RUN ./prime_ruby.sh
 RUN ./package_cleanup.sh
 RUN rm -rf /root/build_scripts
 
-ENV HOME=/home/build_user
-WORKDIR $HOME
-USER build_user
-
 # Drop into a shell for building
-CMD /bin/bash -l
+CMD /bin/bash -c "su -l build_user"

--- a/build/Dockerfiles/SIMP_EL8_Build.dockerfile
+++ b/build/Dockerfiles/SIMP_EL8_Build.dockerfile
@@ -28,9 +28,5 @@ RUN ./prime_ruby.sh
 RUN ./package_cleanup.sh
 RUN rm -rf /root/build_scripts
 
-ENV HOME=/home/build_user
-WORKDIR $HOME
-USER build_user
-
 # Drop into a shell for building
-CMD /bin/bash -l
+CMD /bin/bash -c "su -l build_user"


### PR DESCRIPTION
* No longer set the default user in the build containers to `build_user`
  since this caused dependent processes to break.

Closes #824
