### PR TITLE
Remove upstart from bolt configs

### DIFF
--- a/build/distributions/CentOS/7/x86_64/bolt_pulp3_config.yaml
+++ b/build/distributions/CentOS/7/x86_64/bolt_pulp3_config.yaml
@@ -150,7 +150,6 @@ SIMP:
   - name: pupmod-simp-tpm
   - name: pupmod-simp-tpm2
   - name: pupmod-simp-tuned
-  - name: pupmod-simp-upstart
   - name: pupmod-simp-useradd
   - name: pupmod-simp-vnc
   - name: pupmod-simp-vox_selinux

--- a/build/distributions/CentOS/8/x86_64/bolt_pulp3_config.yaml
+++ b/build/distributions/CentOS/8/x86_64/bolt_pulp3_config.yaml
@@ -448,11 +448,11 @@ postgresql:
   - name: postgresql96-server
 
 SIMP:
-  # FIXME: using /experimental/ during 6.6.0 EL8 development; change to latest when ready to release:
+  # FIXME: using /github/ during 6.6.0 EL7 development; change to /latest/ when ready to release:
   #
-  #   url: https://download.simp-project.com/SIMP/yum/releases/latest/el/8Server/x86_64/simp/
+  #   url: https://download.simp-project.com/simp/yum/releases/latest/el/8server/x86_64/simp/
   #
-  url: https://download.simp-project.com/simp/yum/experimental/simp6/el/8Server/x86_64/simp/
+  url: https://download.simp-project.com/simp/yum/github/simp6/el/8Server/x86_64/simp/
   rpms:
    - name: pupmod-camptocamp-systemd
    - name: pupmod-herculesteam-augeasproviders_core
@@ -556,7 +556,6 @@ SIMP:
    - name: pupmod-simp-tpm
    - name: pupmod-simp-tpm2
    - name: pupmod-simp-tuned
-   - name: pupmod-simp-upstart
    - name: pupmod-simp-useradd
    - name: pupmod-simp-vnc
    - name: pupmod-simp-vox_selinux

--- a/build/distributions/CentOS/8Stream/x86_64/bolt_pulp3_config.yaml
+++ b/build/distributions/CentOS/8Stream/x86_64/bolt_pulp3_config.yaml
@@ -432,10 +432,11 @@ postgresql:
   - name: postgresql96-server
 
 SIMP:
-  # NOTE: Using /unstable/ during 6.6.0 EL8 development
-  #       Change to /latest/ for final release & ISO build!
-  url: https://download.simp-project.com/simp/yum/unstable/simp6/el/8Server/x86_64/simp/
-  # url: https://download.simp-project.com/SIMP/yum/releases/latest/el/8Server/x86_64/simp/
+  # FIXME: using /github/ during 6.6.0 EL8 development; change to latest when ready to release:
+  #
+  #   url: https://download.simp-project.com/simp/yum/releases/latest/el/8server/x86_64/simp/
+  #
+  url: https://download.simp-project.com/simp/yum/github/simp6/el/8Server/x86_64/simp/
   rpms:
    - name: pupmod-camptocamp-systemd
    - name: pupmod-herculesteam-augeasproviders_core
@@ -539,7 +540,6 @@ SIMP:
    - name: pupmod-simp-tpm
    - name: pupmod-simp-tpm2
    - name: pupmod-simp-tuned
-   - name: pupmod-simp-upstart
    - name: pupmod-simp-useradd
    - name: pupmod-simp-vnc
    - name: pupmod-simp-vox_selinux


### PR DESCRIPTION
Completes work started in #814, fixes mirroring errors in simp/bolt-pulp3