### PR TITLE
Pin simplib fix

### DIFF
--- a/Puppetfile.pinned
+++ b/Puppetfile.pinned
@@ -343,7 +343,7 @@ mod 'simp-simpkv',
 
 mod 'simp-simplib',
   :git => 'https://github.com/simp/pupmod-simp-simplib',
-  :tag => '4.10.3'
+  :tag => '4.10.4'
 
 mod 'simp-simp_apache',
   :git => 'https://github.com/simp/pupmod-simp-simp_apache',


### PR DESCRIPTION
Pins simplib to include fix from simp/pupmod-simp-simplib#275

Adds basic rate-limiting on 429 codes to `rake puppetfile:check`,
migrates to non-deprecated `URI.open` syntax (removes pages of warning spam)