### PR TITLE
Remove `augeasproviders_core` as an ssh dep

### DIFF
--- a/build/rpm/dependencies.yaml
+++ b/build/rpm/dependencies.yaml
@@ -150,7 +150,6 @@
 'ssh':
   :requires:
     # exclude pupmod-puppet-selinux
-    - pupmod-herculesteam-augeasproviders_core
     - pupmod-herculesteam-augeasproviders_ssh
     - pupmod-puppetlabs-stdlib
     - pupmod-simp-simplib


### PR DESCRIPTION
* This was removed from the core module and now needs to be removed from
  the build overrides

Closes: #853
Refs: simp/pupmod-simp-ssh#149
