### PR TITLE
Use the `ignores` capability from simp-rake-helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :test do
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
-  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.15.0', '< 6']
+  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.17.0', '< 6']
   gem( 'pdk', ENV['PDK_VERSION'] || '~> 2.0', :require => false) if major_puppet_version > 5
   gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem 'simp-build-helpers', ENV['SIMP_BUILD_HELPERS_VERSION'] || ['> 0.1', '< 2.0']

--- a/build/rpm/dependencies.yaml
+++ b/build/rpm/dependencies.yaml
@@ -148,20 +148,8 @@
 # each optional dependency is translated to a Requires in a SIMP-generated
 # puppet module RPM, we need to exclude this optional dependency.
 'ssh':
-  :requires:
-    # exclude pupmod-puppet-selinux
-    - pupmod-herculesteam-augeasproviders_core
-    - pupmod-herculesteam-augeasproviders_ssh
-    - pupmod-puppetlabs-stdlib
-    - pupmod-simp-simplib
-    - pupmod-simp-haveged
-    - pupmod-simp-iptables
-    - pupmod-simp-oath
-    - pupmod-simp-pki
-    - pupmod-simp-tcpwrappers
-    - pupmod-simp-pam
-    - pupmod-simp-selinux
-    - pupmod-simp-vox_selinux
+  :ignores:
+    - pupmod-puppet-selinux
 
 # Vox Pupuli has assumed ownership of the this project
 'snmp':


### PR DESCRIPTION
* Bump the version of `simp-rake-helpers`
* Update the RPM deps file to use `ignores` instead of overriding everything

Closes: #855
Needs: simp/rubygem-simp-rake-helpers#196
