### PR TITLE
Switch centos7 container repos to use vault

### DIFF
--- a/build/Dockerfiles/SIMP_EL7_Build.dockerfile
+++ b/build/Dockerfiles/SIMP_EL7_Build.dockerfile
@@ -46,7 +46,7 @@ RUN ./01_disable_systemctl.sh
 RUN ./05_selinux.sh
 RUN ./10_dev_packages.sh
 RUN ./user.sh
-RUN ./rvm.sh "$ruby_version"
+RUN ./rvm.sh build_user "$ruby_version"
 RUN ./prime_ruby.sh
 RUN ./package_cleanup.sh
 RUN rm -rf /root/build_scripts

--- a/build/Dockerfiles/scripts/common/rvm.sh
+++ b/build/Dockerfiles/scripts/common/rvm.sh
@@ -27,4 +27,6 @@ runuser $user_id -l -c "curl -sSL https://raw.githubusercontent.com/rvm/rvm/stab
 runuser $user_id -l -c "rvm install ${ruby_version}"
 runuser $user_id -l -c "rvm use --default ${ruby_version}"
 runuser $user_id -l -c "rvm all do gem install bundler -v '~> 1.16'"
-runuser $user_id -l -c "rvm all do gem install bundler -v '~> 2.0'"
+runuser $user_id -l -c "rvm ls"
+#runuser $user_id -l -c "rvm all do gem install bundler -v '~> 2.0'"
+runuser $user_id -l -c "rvm all do gem install bundler -v 2.4.22"

--- a/build/Dockerfiles/scripts/el7/00_system_prep.sh
+++ b/build/Dockerfiles/scripts/el7/00_system_prep.sh
@@ -7,6 +7,17 @@ yum clean all
 rm -f /var/lib/rpm/__db*
 yum clean all && yum history sync
 
+# Deal with vault-ized CentOS7 repos, post-EOL
+sed -i \
+  -e 's@^mirrorlist.*=os$@baseurl=http://archive.kernel.org/centos-vault/centos/$releasever/os/$basearch/@' \
+  -e 's@^mirrorlist.*=updates$@baseurl=http://archive.kernel.org/centos-vault/centos/$releasever/updates/$basearch/@' \
+  -e 's@^mirrorlist.*=extras$@baseurl=http://archive.kernel.org/centos-vault/centos/$releasever/extras/$basearch/@' \
+  -e 's@^mirrorlist.*=centosplus$@baseurl=http://archive.kernel.org/centos-vault/centos/$releasever/centosplus/$basearch/@' \
+  -e 's@^mirrorlist.*=os$@baseurl=http://archive.kernel.org/centos-vault/centos/$releasever/os/$basearch/@' \
+  /etc/yum.repos.d/CentOS-Base.repo
+
+sed -i -e '/^#mirrorlist/d' -e '/^#baseurl=/d' /etc/yum.repos.d/{CentOS-Base.repo,CentOS-SCLo-scl-*.repo} ||:
+
 # The `yum-plugin-ovl` package is needed to avoid "copy-up" mistmatch
 # issues problems when using overlayFS.  However, in early releases of
 # EL7, the package was not included—so the `touch /var/lib/rpm/*;`

--- a/build/Dockerfiles/scripts/el7/10_dev_packages.sh
+++ b/build/Dockerfiles/scripts/el7/10_dev_packages.sh
@@ -11,6 +11,17 @@ yum install -y rpm-build rpmdevtools rpm-devel rpm-sign yum-utils createrepo
 
 yum install -y centos-release-scl python-pip python-virtualenv fontconfig dejavu-sans-fonts dejavu-sans-mono-fonts dejavu-serif-fonts dejavu-fonts-common libjpeg-devel zlib-devel openssl-devel
 
+# Deal with vault-ized CentOS7 repos, post-EOL
+# (at this point, SSL is updated enough use modern https)
+yum-config-manager --setopt=base.baseurl='https://vault.centos.org/centos/$releasever/os/$basearch/' --save
+yum-config-manager --setopt=updates.baseurl='https://vault.centos.org/centos/$releasever/updates/$basearch/' --save
+yum-config-manager --setopt=extras.baseurl='https://vault.centos.org/centos/$releasever/extras/$basearch/' --save
+yum-config-manager --setopt=centosplus.baseurl='https://vault.centos.org/centos/$releasever/centosplus/$basearch/' --save
+yum-config-manager --setopt=centos-sclo-rh.baseurl='https://vault.centos.org/centos/$releasever/sclo/$basearch/rh/' --save
+yum-config-manager --setopt=centos-sclo-sclo.baseurl='https://vault.centos.org/centos/$releasever/sclo/$basearch/sclo/' --save
+
+sed -i -e 's/^mirrorlist/#\0/g' -e '/^#baseurl=/d' /etc/yum.repos.d/{CentOS-Base.repo,CentOS-SCLo-scl-rh.repo,CentOS-SCLo-scl.repo}
+
 yum install -y libyaml-devel glibc-headers autoconf gcc gcc-c++ glibc-devel readline-devel libffi-devel automake libtool bison sqlite-devel
 
 yum-config-manager --enable rhel-server-rhscl-7-rpms


### PR DESCRIPTION
el7 acceptance tests using the `simpproject/simp_build_centos7` have been failing because when CentOS 7 EOLed, most of the repos baked into that container were retired.

This patch fixes the el7 Dockerfiles to build containers using the new archived repo URLs at vault.centos.org

Fixes #896