### PR TITLE
Add Beaker-runnable EL8/9/10 build images + fix libyaml-devel

### DIFF
--- a/build/Dockerfiles/SIMP_EL10_BeakerBuild.dockerfile
+++ b/build/Dockerfiles/SIMP_EL10_BeakerBuild.dockerfile
@@ -1,0 +1,47 @@
+# Beaker-runnable AlmaLinux 9 image WITH the SIMP RPM build environment.
+#
+# Unions the beaker base image (SIMP_EL10_Beaker.dockerfile) with the build
+# toolchain, build_user, and RVM from SIMP_EL10_Build.dockerfile, MINUS the
+# ISO-builder-only steps:
+#
+#   * 00_setup_vault.sh  - pins every repo to the 9.0 vault. Undesirable for a
+#                          test image: the SUT should track current packages
+#                          (e.g. it installs the current OpenVox release).
+#   * 05_selinux.sh      - downgrades packages back toward the vault pin and is
+#                          coupled to 00_setup_vault.sh.
+#
+# Build/publish via simp-core's .github/workflows/build_containers.yml:
+#   dockerfile = SIMP_EL10_BeakerBuild.dockerfile
+#   image_name = simp-el10-beaker-build
+#   ruby_version = 3.3
+
+FROM almalinux:10
+ENV container docker
+ARG ruby_version=3.3
+
+RUN mkdir /root/build_scripts
+ADD scripts/common/* /root/build_scripts/
+ADD scripts/el10/*    /root/build_scripts/
+WORKDIR /root/build_scripts
+RUN chmod +x *
+
+# --- beaker base (mirrors SIMP_EL10_Beaker.dockerfile) ---
+RUN ./00_system_prep.sh
+RUN ./minimize_package_installs.sh
+RUN ./beaker_packages.sh
+RUN ./container_safe_services.sh
+
+# --- build environment (from SIMP_EL10_Build.dockerfile) ---
+RUN ./10_dev_packages.sh
+RUN ./user.sh build_user
+RUN ./rvm.sh build_user "$ruby_version"
+# Silence RVM's PATH-mismatch warning so it cannot pollute captured stdout
+RUN echo 'rvm_silence_path_mismatch_check_flag=1' > /etc/profile.d/00_rvm_silence.sh
+
+# --- finalize ---
+RUN yum -y update
+RUN ./package_cleanup.sh
+RUN rm -rf /root/build_scripts
+
+WORKDIR /home/build_user
+CMD [ "/sbin/init" ]

--- a/build/Dockerfiles/SIMP_EL8_BeakerBuild.dockerfile
+++ b/build/Dockerfiles/SIMP_EL8_BeakerBuild.dockerfile
@@ -1,0 +1,47 @@
+# Beaker-runnable AlmaLinux 9 image WITH the SIMP RPM build environment.
+#
+# Unions the beaker base image (SIMP_EL8_Beaker.dockerfile) with the build
+# toolchain, build_user, and RVM from SIMP_EL8_Build.dockerfile, MINUS the
+# ISO-builder-only steps:
+#
+#   * 00_setup_vault.sh  - pins every repo to the 9.0 vault. Undesirable for a
+#                          test image: the SUT should track current packages
+#                          (e.g. it installs the current OpenVox release).
+#   * 05_selinux.sh      - downgrades packages back toward the vault pin and is
+#                          coupled to 00_setup_vault.sh.
+#
+# Build/publish via simp-core's .github/workflows/build_containers.yml:
+#   dockerfile = SIMP_EL8_BeakerBuild.dockerfile
+#   image_name = simp-el8-beaker-build
+#   ruby_version = 3.3
+
+FROM almalinux:8
+ENV container docker
+ARG ruby_version=3.3
+
+RUN mkdir /root/build_scripts
+ADD scripts/common/* /root/build_scripts/
+ADD scripts/el8/*    /root/build_scripts/
+WORKDIR /root/build_scripts
+RUN chmod +x *
+
+# --- beaker base (mirrors SIMP_EL8_Beaker.dockerfile) ---
+RUN ./00_system_prep.sh
+RUN ./minimize_package_installs.sh
+RUN ./beaker_packages.sh
+RUN ./container_safe_services.sh
+
+# --- build environment (from SIMP_EL8_Build.dockerfile) ---
+RUN ./10_dev_packages.sh
+RUN ./user.sh build_user
+RUN ./rvm.sh build_user "$ruby_version"
+# Silence RVM's PATH-mismatch warning so it cannot pollute captured stdout
+RUN echo 'rvm_silence_path_mismatch_check_flag=1' > /etc/profile.d/00_rvm_silence.sh
+
+# --- finalize ---
+RUN yum -y update
+RUN ./package_cleanup.sh
+RUN rm -rf /root/build_scripts
+
+WORKDIR /home/build_user
+CMD [ "/sbin/init" ]

--- a/build/Dockerfiles/SIMP_EL9_BeakerBuild.dockerfile
+++ b/build/Dockerfiles/SIMP_EL9_BeakerBuild.dockerfile
@@ -1,0 +1,47 @@
+# Beaker-runnable AlmaLinux 9 image WITH the SIMP RPM build environment.
+#
+# Unions the beaker base image (SIMP_EL9_Beaker.dockerfile) with the build
+# toolchain, build_user, and RVM from SIMP_EL9_Build.dockerfile, MINUS the
+# ISO-builder-only steps:
+#
+#   * 00_setup_vault.sh  - pins every repo to the 9.0 vault. Undesirable for a
+#                          test image: the SUT should track current packages
+#                          (e.g. it installs the current OpenVox release).
+#   * 05_selinux.sh      - downgrades packages back toward the vault pin and is
+#                          coupled to 00_setup_vault.sh.
+#
+# Build/publish via simp-core's .github/workflows/build_containers.yml:
+#   dockerfile = SIMP_EL9_BeakerBuild.dockerfile
+#   image_name = simp-el9-beaker-build
+#   ruby_version = 3.3
+
+FROM almalinux:9
+ENV container docker
+ARG ruby_version=3.3
+
+RUN mkdir /root/build_scripts
+ADD scripts/common/* /root/build_scripts/
+ADD scripts/el9/*    /root/build_scripts/
+WORKDIR /root/build_scripts
+RUN chmod +x *
+
+# --- beaker base (mirrors SIMP_EL9_Beaker.dockerfile) ---
+RUN ./00_system_prep.sh
+RUN ./minimize_package_installs.sh
+RUN ./beaker_packages.sh
+RUN ./container_safe_services.sh
+
+# --- build environment (from SIMP_EL9_Build.dockerfile) ---
+RUN ./10_dev_packages.sh
+RUN ./user.sh build_user
+RUN ./rvm.sh build_user "$ruby_version"
+# Silence RVM's PATH-mismatch warning so it cannot pollute captured stdout
+RUN echo 'rvm_silence_path_mismatch_check_flag=1' > /etc/profile.d/00_rvm_silence.sh
+
+# --- finalize ---
+RUN yum -y update
+RUN ./package_cleanup.sh
+RUN rm -rf /root/build_scripts
+
+WORKDIR /home/build_user
+CMD [ "/sbin/init" ]

--- a/build/Dockerfiles/scripts/el8/10_dev_packages.sh
+++ b/build/Dockerfiles/scripts/el8/10_dev_packages.sh
@@ -6,7 +6,7 @@ dnf install -y rpm-build rpmdevtools rpm-devel rpm-sign yum-utils
 dnf install -y ruby-devel
 dnf install -y util-linux openssl augeas-libs createrepo genisoimage isomd5sum git gnupg2 libicu-devel libxml2 libxml2-devel libxslt libxslt-devel which
 dnf install -y python3-virtualenv fontconfig dejavu-sans-fonts dejavu-sans-mono-fonts dejavu-serif-fonts dejavu-fonts-common libjpeg-devel zlib-devel openssl-devel
-dnf install -y libyaml glibc-headers autoconf gcc gcc-c++ glibc-devel readline-devel libffi-devel automake libtool bison sqlite-devel pinentry
+dnf install -y libyaml libyaml-devel glibc-headers autoconf gcc gcc-c++ glibc-devel readline-devel libffi-devel automake libtool bison sqlite-devel pinentry
 
 # Helper packages
 dnf install -y rubygems vim-enhanced jq

--- a/build/Dockerfiles/scripts/el9/10_dev_packages.sh
+++ b/build/Dockerfiles/scripts/el9/10_dev_packages.sh
@@ -9,7 +9,7 @@ dnf install -y util-linux openssl augeas-libs createrepo_c git gnupg2 libicu-dev
 dnf install -y genisoimage isomd5sum ||:
 dnf install -y xorriso ||:
 dnf install -y python3 fontconfig dejavu-sans-fonts dejavu-sans-mono-fonts dejavu-serif-fonts libjpeg-devel zlib-devel openssl-devel
-dnf install -y libyaml autoconf gcc gcc-c++ glibc-devel readline-devel libffi-devel automake libtool bison sqlite-devel pinentry
+dnf install -y libyaml libyaml-devel autoconf gcc gcc-c++ glibc-devel readline-devel libffi-devel automake libtool bison sqlite-devel pinentry
 
 # Helper packages
 dnf install -y rubygems vim-enhanced jq


### PR DESCRIPTION
## What

Adds three new Dockerfiles under `build/Dockerfiles/`:

- `SIMP_EL8_BeakerBuild.dockerfile`
- `SIMP_EL9_BeakerBuild.dockerfile`
- `SIMP_EL10_BeakerBuild.dockerfile`

These produce **beaker-runnable** AlmaLinux images that *also* contain the full RPM **build environment**. Today the published `ghcr.io/simp/simp-el*-beaker` images (from `SIMP_EL*_Beaker.dockerfile`) are bare — no `build_user`, Ruby/RVM, or RPM toolchain — while the build env only exists in `SIMP_EL*_Build.dockerfile`, which isn't beaker-runnable (`CMD su -l build_user`, no systemd/container-safe services).

Each new Dockerfile **unions** the two:

- **beaker base** (`00_system_prep` → `beaker_packages` → `container_safe_services`, `CMD ["/sbin/init"]`)
- **build env** (`10_dev_packages` → `user.sh` → `rvm.sh build_user $ruby_version`)
- a `rvm_silence_path_mismatch_check_flag` profile drop-in so RVM can't pollute captured stdout

They intentionally **omit** the ISO-builder-only `00_setup_vault.sh` / `05_selinux.sh`, which pin every repo to the `x.0` vault — undesirable for a test image that should track current packages (e.g. installs the current OpenVox release).

## Also: libyaml-devel fix

`scripts/el8/10_dev_packages.sh` and `scripts/el9/10_dev_packages.sh` installed `libyaml` but **not** `libyaml-devel`, so when RVM builds Ruby from source it can't build the `psych` (YAML) extension and later gem steps fail with `cannot load such file -- psych`. `scripts/el10/10_dev_packages.sh` already had `libyaml-devel`; this brings el8/el9 in line.

## Why

Lets downstream projects (e.g. `rubygem-simp-rake-helpers`) run RPM-build acceptance tests against a single pre-baked image, instead of provisioning `build_user` + RVM + toolchain via `docker_image_commands` on every CI run.

## Validation

All three images built and verified locally with podman (`ruby_version=3.3`):

| Image | build_user | RVM ruby | toolchain | psych | systemd |
|---|---|---|---|---|---|
| EL8 (AlmaLinux 8.10) | ✅ | 3.3.11 + bundler 2.5.22 | rpmbuild/rpmsign/createrepo/gpg2 | ✅ | ✅ |
| EL9 (AlmaLinux 9) | ✅ | 3.3.11 + bundler 2.5.22 | rpmbuild/rpmsign/createrepo_c/gpg2 | ✅ | ✅ |
| EL10 (AlmaLinux 10.2) | ✅ | 3.3.11 + bundler 2.5.22 | rpmbuild/rpmsign/createrepo_c/gpg2 | ✅ | ✅ |

Captured `runuser build_user -l -c` stdout was confirmed free of RVM warnings.

## Publishing

Via the existing `.github/workflows/build_containers.yml` (workflow_dispatch), e.g. `dockerfile=SIMP_EL9_BeakerBuild.dockerfile`, `image_name=simp-el9-beaker-build`, `ruby_version=3.3` → `ghcr.io/simp/simp-el9-beaker-build:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)