### PR TITLE
Remove simp-ntpd from super-release

### DIFF
--- a/Puppetfile.branches
+++ b/Puppetfile.branches
@@ -258,10 +258,6 @@ mod 'simp-nfs',
   :git => 'https://github.com/simp/pupmod-simp-nfs',
   :branch => 'master'
 
-mod 'simp-ntpd',
-  :git => 'https://github.com/simp/pupmod-simp-ntpd',
-  :branch => 'master'
-
 mod 'simp-oath',
   :git => 'https://github.com/simp/pupmod-simp-oath',
   :branch => 'master'

--- a/Puppetfile.pinned
+++ b/Puppetfile.pinned
@@ -261,10 +261,6 @@ mod 'simp-nfs',
   :git => 'https://github.com/simp/pupmod-simp-nfs',
   :tag => '7.2.0'
 
-mod 'simp-ntpd',
-  :git => 'https://github.com/simp/pupmod-simp-ntpd',
-  :tag => '6.7.0'
-
 mod 'simp-oath',
   :git => 'https://github.com/simp/pupmod-simp-oath',
   :tag => '0.3.0'

--- a/build/distributions/RedHat/8/x86_64/bolt_pulp3_config.yaml
+++ b/build/distributions/RedHat/8/x86_64/bolt_pulp3_config.yaml
@@ -485,7 +485,6 @@ SIMP:
    - name: pupmod-simp-mozilla
    - name: pupmod-simp-named
    - name: pupmod-simp-nfs
-   - name: pupmod-simp-ntpd
    - name: pupmod-simp-oath
    - name: pupmod-simp-oddjob
    - name: pupmod-simp-openscap


### PR DESCRIPTION
The last OS where `ntpd` was available and supported was EL7.  As such, the pupmod-simp-ntpd repo has been archived.  As no supported OSes can use the simp-ntpd module, this patch removes it from the SIMP super-release

Fixes #932