### PR TITLE
Tell Renovate not to bump the AlmaLinux base image tags

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,14 @@
     "config:recommended",
     "github>simp/renovate-config",
     "github>simp/renovate-config:ruby.json"
+  ],
+  "packageRules": [
+    {
+      "description": "The AlmaLinux base image tags in build/Dockerfiles are pinned on purpose (one image per EL major, Build images pinned to a specific minor). Renovate must not bump them.",
+      "matchManagers": ["dockerfile"],
+      "matchDepNames": ["almalinux"],
+      "matchFileNames": ["build/Dockerfiles/**"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
## Problem

The `almalinux` tags in `build/Dockerfiles/` are pinned on purpose — one image per EL major, with the `*_Build` images pinned to a specific minor:

| File | Tag |
|---|---|
| `SIMP_EL8_Beaker.dockerfile` | `almalinux:8` |
| `SIMP_EL8_Build.dockerfile` | `almalinux:8.4` |
| `SIMP_EL9_Beaker.dockerfile` | `almalinux:9` |
| `SIMP_EL9_Build.dockerfile` | `almalinux:9.0` |
| `SIMP_EL10_Beaker.dockerfile` | `almalinux:10` |
| `SIMP_EL10_Build.dockerfile` | `almalinux:10.0` |

Renovate has no way to know that, so it treats each one as a stale tag and proposes cross-major bumps — #923 wanted to take EL8 to `10.2` and EL9 to `10.2`. That PR is marked *Immortal*, so closing it unmerged just gets it recreated.

## Fix

One `packageRule` disabling the `almalinux` Docker dep, scoped to `build/Dockerfiles/**`. Nothing else in the repo is excluded:

- bundler deps (`Gemfile`, `github>simp/renovate-config:ruby.json`) keep updating
- the `github-actions` manager keeps updating (that's what produced e5c0a37)
- any *other* `FROM` / `COPY --from` image added to those same Dockerfiles later is still tracked

Excluding the Dockerfiles wholesale was not necessary.

## Notes

- `matchDepNames: ["almalinux"]` is the right matcher here: for `FROM almalinux:8` the dockerfile manager sets both `depName` and `packageName` to `almalinux` (`lib/modules/manager/dockerfile/extract.ts`).
- There is no inline escape hatch — the dockerfile manager has no `# renovate: ignore` support, only `# renovate: datasource=…` *hint* comments for `ARG`/`ENV` lines. A config rule is the only mechanism available.
- Kept repo-local rather than pushing it into `simp/renovate-config`, which today only sets `extends` + `ignorePaths`. If other repos pin EL base images the same way, it could move up later.

## Verification

- `renovate-config-validator renovate.json` → `Config validated successfully`

Once this is on `master`, Renovate's next run should auto-close #923.

🤖 Generated with [Claude Code](https://claude.com/claude-code)