### PR TITLE
Drop simp-build-helpers; require simp-rake-helpers ~> 6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,9 +26,7 @@ group :test do
   gem 'rspec'
   gem 'rspec-puppet'
   # renovate: datasource=rubygems versioning=ruby
-  gem 'simp-build-helpers', ENV.fetch('SIMP_BUILD_HELPERS_VERSION', ['> 0.1', '< 2.0'])
-  # renovate: datasource=rubygems versioning=ruby
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 6.0')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 6.1')
   # renovate: datasource=rubygems versioning=ruby
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 4.0.0')
   gem 'terminal-table'

--- a/rakelib/deps.rake
+++ b/rakelib/deps.rake
@@ -1,7 +1,7 @@
 # simp-core additions to deps-namespaced targets
 #
 # This is a playground for tasks that may eventually be moved to
-# simp-rake-helpers or simp-build-helpers
+# simp-rake-helpers
 #
 require_relative 'simp_core_deps_helper'
 


### PR DESCRIPTION
Depends on simp/rubygem-simp-rake-helpers#274 — **do not merge until simp-rake-helpers 6.1.0 is published.**

## Why this declaration existed

`simp-build-helpers` was only listed here as a workaround: simp-rake-helpers hard-requires `Simp::Build::ReleaseMapper` in `simp/rake/build/auto.rb` but never declared it as a runtime dependency, so this project had to supply it. `Rakefile:12-16` catches the resulting `LoadError` and only warns, so without it every simp-core build task silently vanished.

It also pinned a **broken** gem. The last release on RubyGems is 0.1.1 (2016-09-28), which calls `File.exists?` — removed from current Rubies — so `rake build:auto` raised `NoMethodError` on its first ISO path check. Verified against this repo's own `build/distributions/CentOS/8Stream/x86_64/release_mappings.yaml`:

```
published 0.1.1 => NoMethodError: undefined method 'exists?' for class File
```

`Simp::Build::ReleaseMapper` has now been absorbed into simp-rake-helpers 6.1.0 under the same namespace, so this project doesn't need to declare it at all.

## Changes

- Remove the `simp-build-helpers` `Gemfile` entry
- Raise `simp-rake-helpers` from `~> 6.0` to `~> 6.1`
- Drop a stale mention of the gem from a comment in `rakelib/deps.rake`

## Why `~> 6.1` and not `~> 6.0`

Deliberate. Left at `~> 6.0`, bundler would silently resolve to the published 6.0.1 — which no longer has the Gemfile workaround and does not yet contain `release_mapper.rb` — turning this into a `LoadError` at build time. `~> 6.1` fails loudly at `bundle install` instead, until 6.1.0 ships.

Note that `Gemfile.lock` is gitignored here, so there's no lockfile to update.